### PR TITLE
fix: eliminate two crashes

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/EnterAmountFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/EnterAmountFragment.kt
@@ -75,18 +75,9 @@ class EnterAmountFragment : Fragment() {
     private var fiatAmountFormat: FiatAmountFormat ? = null
     var maxAmountSelected: Boolean = false
     private var shouldNotConvertFiatToDash: Boolean = false
-    private lateinit var abstractBindServiceActivity: AbstractBindServiceActivity
-    private lateinit var walletApplication: WalletApplication
     private lateinit var configuration: Configuration
     private var isInit: Boolean = true
 
-
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-        abstractBindServiceActivity = context as AbstractBindServiceActivity
-        walletApplication = abstractBindServiceActivity.application as WalletApplication
-        configuration = walletApplication.configuration
-    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.enter_amount_fragment, container, false)
@@ -94,6 +85,7 @@ class EnterAmountFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        configuration = WalletApplication.getInstance().configuration
         convert_direction.setOnClickListener {
             viewModel.setDashToFiatDirection(!viewModel.dashToFiatDirectionValue)
             if (viewModel.dashToFiatDirectionValue) {
@@ -235,9 +227,9 @@ class EnterAmountFragment : Fragment() {
         if (arguments != null) {
             val initialAmount = requireArguments().getSerializable(ARGUMENT_INITIAL_AMOUNT) as Monetary
             if (viewModel.dashToFiatDirectionValue) {
-                viewModel.setDashAmount(initialAmount as Coin)
+                viewModel.setDashAmount(Coin.valueOf(initialAmount.value))
             } else {
-                viewModel.setFiatAmount(initialAmount as Fiat)
+                viewModel.setFiatAmount(Fiat.valueOf(configuration.exchangeCurrencyCode, initialAmount.value))
             }
         } else {
             viewModel.setDashAmount(Coin.ZERO)


### PR DESCRIPTION
1. ReceiveActity is not derived from AbstractBindServiceActivity
2. Coin.ZERO is used to create EnterAmountFragment fragments in two other places
  This results in a casting exception (Coin -> Fiat) if Fiat is default

<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->
https://github.com/dashevo/dash-wallet/pull/774
## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
