### PR TITLE
[NMA-1024] Warn user on last pin attempt 

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/ui/dialogs/AdaptiveDialog.kt
+++ b/common/src/main/java/org/dash/wallet/common/ui/dialogs/AdaptiveDialog.kt
@@ -62,8 +62,8 @@ class AdaptiveDialog(@LayoutRes private val layout: Int): DialogFragment() {
                 positiveButtonText
             )
         }
-        // not usable from Java
-        fun new(
+
+        fun create(
             @DrawableRes icon: Int,
             title: String,
             message: String,
@@ -228,7 +228,7 @@ class AdaptiveDialog(@LayoutRes private val layout: Int): DialogFragment() {
         val args = requireArguments()
         val text = args.getString(argKey)
 
-        if (text != null) {
+        if (!text.isNullOrEmpty()) {
             view.text = text
             view.isVisible = true
         } else {

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -33,6 +33,7 @@
     <string name="button_dismiss">Dismiss</string>
     <string name="network_unavailable_return">Return to Wallet</string>
     <string name="button_continue">Continue</string>
+    <string name="button_understand">I understand</string>
 
     <!-- Design system UI elements -->
     <string name="search_hint">Search</string>

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/extensions/LocationFragmentExt.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/extensions/LocationFragmentExt.kt
@@ -89,7 +89,7 @@ suspend fun Fragment.showPermissionExplainerDialog(exploreTopic: ExploreTopic): 
         R.string.explore_atm_location_explainer_message
     }
 
-    val dialog = AdaptiveDialog.new(
+    val dialog = AdaptiveDialog.create(
         R.drawable.ic_location,
         getString(title),
         getString(message),

--- a/wallet/res/values/strings-extra.xml
+++ b/wallet/res/values/strings-extra.xml
@@ -146,6 +146,8 @@
     <string name="wallet_lock_try_again">Try again in %1$d %2$s</string>
     <string name="wallet_lock_reset">Reset</string>
     <string name="wallet_lock_wrong_pin">Wrong PIN! %s</string>
+    <string name="wallet_last_attempt">Last PIN attempt</string>
+    <string name="wallet_last_attempt_message">Another failed attempt will require my passphrase to recover my wallet</string>
 
     <plurals name="wallet_lock_attempts_remaining">
         <item quantity="one">%d attempt remaining</item>

--- a/wallet/src/de/schildbach/wallet/ui/SetPinActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/SetPinActivity.kt
@@ -448,7 +448,7 @@ class SetPinActivity : InteractionAwareActivity() {
             title = R.string.set_pin_error_missing_wallet_title
             message = R.string.set_pin_error_missing_wallet_message
         }
-        val dialog = AdaptiveDialog.new(
+        val dialog = AdaptiveDialog.create(
             R.drawable.ic_error,
             getString(title),
             getString(message),

--- a/wallet/src/de/schildbach/wallet/ui/preference/PinRetryController.java
+++ b/wallet/src/de/schildbach/wallet/ui/preference/PinRetryController.java
@@ -124,6 +124,10 @@ public class PinRetryController {
         return prefs.getStringSet(PREFS_FAILED_PINS, new HashSet<String>()).size();
     }
 
+    public int getRemainingAttempts() {
+        return FAIL_LIMIT - failCount();
+    }
+
     public String getRemainingAttemptsMessage(Context context) {
         int attemptsRemaining = FAIL_LIMIT - failCount();
         return context.getResources().getQuantityString(R.plurals.wallet_lock_attempts_remaining,


### PR DESCRIPTION
If there is only 1 attempt left on the lock screen, we want to show a warning dialog.

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
https://www.figma.com/file/84tUBQA9DYU1svyQx8tnbk/Android-%7C-DashPay-Design?node-id=4436%3A16204

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
