### PR TITLE
fix: restore passphrase should not allow capital letters

### DIFF
--- a/wallet/src/de/schildbach/wallet/livedata/RecoverPinLiveData.kt
+++ b/wallet/src/de/schildbach/wallet/livedata/RecoverPinLiveData.kt
@@ -49,7 +49,7 @@ class RecoverPinLiveData(application: Application) : MutableLiveData<Resource<St
 
     private val securityGuard = SecurityGuard()
 
-    fun recover(words: MutableList<String>) {
+    fun recover(words: List<String>) {
         if (deriveKeyTask == null) {
             deriveKeyTask = object : DeriveKeyTask(backgroundHandler, walletApplication.scryptIterationsTarget()) {
 

--- a/wallet/src/de/schildbach/wallet/ui/RestoreWalletFromSeedActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/RestoreWalletFromSeedActivity.kt
@@ -22,11 +22,14 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.text.Editable
+import android.text.InputFilter
+import android.text.Spanned
 import android.text.TextUtils
 import android.text.TextWatcher
 import android.view.MenuItem
+import androidx.activity.viewModels
 import androidx.lifecycle.Observer
-import androidx.lifecycle.ViewModelProvider
+import dagger.hilt.android.AndroidEntryPoint
 import de.schildbach.wallet.WalletApplication
 import de.schildbach.wallet.livedata.Status
 import de.schildbach.wallet.ui.backup.RestoreFromFileActivity
@@ -34,10 +37,11 @@ import de.schildbach.wallet_test.R
 import kotlinx.android.synthetic.main.activity_forgot_pin.*
 import kotlinx.android.synthetic.main.activity_recover_wallet_from_seed.*
 import org.bitcoinj.crypto.MnemonicException
-import org.dash.wallet.common.ui.BaseAlertDialogBuilder
+import org.dash.wallet.common.ui.dialogs.AdaptiveDialog
 import java.util.*
+import javax.inject.Inject
 
-
+@AndroidEntryPoint
 class RestoreWalletFromSeedActivity : RestoreFromFileActivity() {
 
     companion object {
@@ -52,9 +56,10 @@ class RestoreWalletFromSeedActivity : RestoreFromFileActivity() {
         }
     }
 
-    private lateinit var viewModel: RestoreWalletFromSeedViewModel
+    private val viewModel: RestoreWalletFromSeedViewModel by viewModels()
 
-    private lateinit var walletApplication: WalletApplication
+    @Inject
+    lateinit var walletApplication: WalletApplication
 
     private val recoveryPinMode by lazy {
         intent?.extras?.getBoolean(EXTRA_RECOVERY_PIN_MODE) ?: false
@@ -74,16 +79,27 @@ class RestoreWalletFromSeedActivity : RestoreFromFileActivity() {
 
         setTitle(R.string.recover_wallet_title)
 
-        walletApplication = (application as WalletApplication)
-
-        viewModel = ViewModelProvider(this)[RestoreWalletFromSeedViewModel::class.java]
-
         initView()
         initViewModel()
     }
 
     private fun initView() {
         input.requestFocus()
+        input.filters = arrayOf<InputFilter>(
+            object : InputFilter.AllCaps() {
+                override fun filter(
+                    source: CharSequence,
+                    start: Int,
+                    end: Int,
+                    dest: Spanned?,
+                    dstart: Int,
+                    dend: Int
+                ): CharSequence {
+                    return source.toString().lowercase(Locale.getDefault())
+                }
+            }
+        )
+
         input.addTextChangedListener(object : TextWatcher {
             override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
                 submit.isEnabled = s.toString().trim().isNotEmpty()
@@ -150,11 +166,13 @@ class RestoreWalletFromSeedActivity : RestoreFromFileActivity() {
     }
 
     private fun showErrorDialog(errorMessage: String) {
-        BaseAlertDialogBuilder(this).apply {
-            title = getString(R.string.import_export_keys_dialog_failure_title)
-            message = errorMessage
-            positiveText = getString(R.string.button_ok)
-        }.buildAlertDialog().show()
+        AdaptiveDialog.create(
+            null,
+            title = getString(R.string.import_export_keys_dialog_failure_title),
+            message = errorMessage,
+            negativeButtonText = "",
+            positiveButtonText = getString(R.string.button_ok)
+        ).show(this)
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
We don't want capital letters to appear when typing a recover phrase.

Some android devices were capitalizing the first word.  This results in a new wallet.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
