### PR TITLE
[NMA-1413] (Coinbase) Show different error dialog in case of unusable payment method

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/ui/payment_method_picker/PaymentMethod.kt
+++ b/common/src/main/java/org/dash/wallet/common/ui/payment_method_picker/PaymentMethod.kt
@@ -38,4 +38,5 @@ data class PaymentMethod(
     val account: String?,
     val accountType: String?,
     val paymentMethodType: PaymentMethodType,
+    val isValid: Boolean
 ):Parcelable

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/ui/CoinbaseServicesFragment.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/ui/CoinbaseServicesFragment.kt
@@ -73,10 +73,14 @@ class CoinbaseServicesFragment : Fragment(R.layout.fragment_coinbase_services) {
                 // New value received
                 when (uiState) {
                     is PaymentMethodsUiState.Success -> {
-                        val paymentMethodsArray = uiState.paymentMethodsList.toTypedArray()
+                        val paymentMethodsArray = uiState.paymentMethodsList.filter { it.isValid }.toTypedArray()
 
                         if (paymentMethodsArray.isEmpty()) {
-                            showNoPaymentMethodsError()
+                            if (uiState.paymentMethodsList.isEmpty()) {
+                                showNoPaymentMethodsError()
+                            } else {
+                                showBuyingNotAllowedError()
+                            }
                         } else {
                             viewModel.logEvent(AnalyticsConstants.Coinbase.BUY_DASH)
                             safeNavigate(CoinbaseServicesFragmentDirections.servicesToBuyDash(paymentMethodsArray))
@@ -209,7 +213,7 @@ class CoinbaseServicesFragment : Fragment(R.layout.fragment_coinbase_services) {
         viewModel.monitorNetworkStateChange()
     }
 
-    private fun setNetworkState(hasInternet: Boolean){
+    private fun setNetworkState(hasInternet: Boolean) {
         binding.lastKnownBalance.isVisible = !hasInternet
         binding.networkStatusStub.isVisible = !hasInternet
         binding.coinbaseServicesGroup.isVisible = hasInternet
@@ -222,13 +226,27 @@ class CoinbaseServicesFragment : Fragment(R.layout.fragment_coinbase_services) {
     private fun showNoPaymentMethodsError() {
         AdaptiveDialog.create(
             R.drawable.ic_info_red,
-            getString(R.string.coinbase_dash_wallet_no_payment_methods_error_title),
-            getString(R.string.coinbase_dash_wallet_no_payment_methods_error_message),
+            getString(R.string.coinbase_no_payment_methods_error_title),
+            getString(R.string.coinbase_no_payment_methods_error_message),
             getString(R.string.close),
             getString(R.string.add_payment_method),
         ).show(requireActivity()) { addMethod ->
             if (addMethod == true) {
                 viewModel.logEvent(AnalyticsConstants.Coinbase.BUY_ADD_PAYMENT_METHOD)
+                openCoinbaseWebsite()
+            }
+        }
+    }
+
+    private fun showBuyingNotAllowedError() {
+        AdaptiveDialog.create(
+            R.drawable.ic_info_red,
+            getString(R.string.coinbase_unusable_payment_method_error_title),
+            getString(R.string.coinbase_unusable_payment_method_error_message),
+            getString(R.string.close),
+            getString(R.string.coinbase_open_account),
+        ).show(requireActivity()) { addMethod ->
+            if (addMethod == true) {
                 openCoinbaseWebsite()
             }
         }

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/viewmodels/CoinbaseActivityViewModel.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/viewmodels/CoinbaseActivityViewModel.kt
@@ -78,25 +78,24 @@ class CoinbaseActivityViewModel @Inject constructor(
                 if (response.value.isEmpty()) {
                     _paymentMethodsUiState.value = PaymentMethodsUiState.Error(true)
                 } else {
-
-                        val result = response.value.filter { it.isBuyingAllowed == true }
-                            .map {
-                                val type = paymentMethodTypeFromCoinbaseType(it.type ?: "")
-                                val nameAccountPair = splitNameAndAccount(it.name, type)
-                                PaymentMethod(
-                                    it.id ?: "",
-                                    nameAccountPair.first,
-                                    nameAccountPair.second,
-                                    "", // set "Checking" to get "****1234 • Checking" in subtitle
-                                    paymentMethodType = type
-                                )
-                            }
+                    val result = response.value
+                        .map {
+                            val type = paymentMethodTypeFromCoinbaseType(it.type ?: "")
+                            val nameAccountPair = splitNameAndAccount(it.name, type)
+                            PaymentMethod(
+                                it.id ?: "",
+                                nameAccountPair.first,
+                                nameAccountPair.second,
+                                "", // set "Checking" to get "****1234 • Checking" in subtitle
+                                paymentMethodType = type,
+                                isValid = it.isBuyingAllowed ?: false
+                            )
+                        }
                     _paymentMethodsUiState.value = PaymentMethodsUiState.Success(result)
                 }
             }
             is ResponseResource.Failure -> {
                 _paymentMethodsUiState.value = PaymentMethodsUiState.Error(true)
-
             }
         }
     }

--- a/integrations/coinbase/src/main/res/values-ar/strings.xml
+++ b/integrations/coinbase/src/main/res/values-ar/strings.xml
@@ -41,8 +41,8 @@
     <string name="cancel">إلغاء</string>
     <string name="confirm_sec">تأكيد (%s)</string>
     <string name="confirm">تأكيد</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_title">لم نجد أي طرق دفع.</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_message">يرجى تحديث حساب كوين بيس الخاص بك للمتابعة.</string>
+    <string name="coinbase_no_payment_methods_error_title">لم نجد أي طرق دفع.</string>
+    <string name="coinbase_no_payment_methods_error_message">يرجى تحديث حساب كوين بيس الخاص بك للمتابعة.</string>
     <string name="add_payment_method">إضافة طريقة دفع</string>
     <string name="error">خطأ</string>
     <string name="cancel_transaction">إلغاء الصفقة؟</string>

--- a/integrations/coinbase/src/main/res/values-de/strings.xml
+++ b/integrations/coinbase/src/main/res/values-de/strings.xml
@@ -41,8 +41,8 @@
     <string name="cancel">Abbrechen</string>
     <string name="confirm_sec">Bestätigen (%ss)</string>
     <string name="confirm">Bestätigen</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_title">Wir haben keine Zahlungsmethoden gefunden.</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_message">Bitte aktualisiere dein Coinbase Konto um fortzufahren.</string>
+    <string name="coinbase_no_payment_methods_error_title">Wir haben keine Zahlungsmethoden gefunden.</string>
+    <string name="coinbase_no_payment_methods_error_message">Bitte aktualisiere dein Coinbase Konto um fortzufahren.</string>
     <string name="add_payment_method">Zahlungsmethode hinzufügen</string>
     <string name="error">Fehler</string>
     <string name="cancel_transaction">Transaktion abbrechen?</string>

--- a/integrations/coinbase/src/main/res/values-el/strings.xml
+++ b/integrations/coinbase/src/main/res/values-el/strings.xml
@@ -41,8 +41,8 @@
     <string name="cancel">Ακύρωση</string>
     <string name="confirm_sec">Επιβεβαίωση(%ss)</string>
     <string name="confirm">Επιβεβαίωση</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_title">Δεν βρήκαμε μεθόδους πληρωμής.</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_message"> Ενημερώστε τον Coinbase λογαριασμό σας για να προχωρήσετε.</string>
+    <string name="coinbase_no_payment_methods_error_title">Δεν βρήκαμε μεθόδους πληρωμής.</string>
+    <string name="coinbase_no_payment_methods_error_message"> Ενημερώστε τον Coinbase λογαριασμό σας για να προχωρήσετε.</string>
     <string name="add_payment_method">Προσθήκη μεθόδου πληρωμής</string>
     <string name="error">Σφάλμα</string>
     <string name="cancel_transaction">Ακύρωση συναλλαγής;</string>

--- a/integrations/coinbase/src/main/res/values-es/strings.xml
+++ b/integrations/coinbase/src/main/res/values-es/strings.xml
@@ -41,8 +41,8 @@
     <string name="cancel">Cancelar</string>
     <string name="confirm_sec">Confirmar (%ss)</string>
     <string name="confirm">Confirmar</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_title">No encontramos ningún método de pago.</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_message">Por favor actualiza tu cuenta de Coinbase para continuar.</string>
+    <string name="coinbase_no_payment_methods_error_title">No encontramos ningún método de pago.</string>
+    <string name="coinbase_no_payment_methods_error_message">Por favor actualiza tu cuenta de Coinbase para continuar.</string>
     <string name="add_payment_method">Añadir método de pago</string>
     <string name="error">Error</string>
     <string name="cancel_transaction">¿Cancelar transacción?</string>

--- a/integrations/coinbase/src/main/res/values-fa/strings.xml
+++ b/integrations/coinbase/src/main/res/values-fa/strings.xml
@@ -41,8 +41,8 @@
     <string name="cancel">لغو</string>
     <string name="confirm_sec">تائید (%sثانیه) </string>
     <string name="confirm">تائید</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_title">هیچ روش پرداختی پیدا نکردیم. </string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_message">برای ادامه لطفا حساب کوین‌بیس‌تان را به‌روزرسانی کنید. </string>
+    <string name="coinbase_no_payment_methods_error_title">هیچ روش پرداختی پیدا نکردیم. </string>
+    <string name="coinbase_no_payment_methods_error_message">برای ادامه لطفا حساب کوین‌بیس‌تان را به‌روزرسانی کنید. </string>
     <string name="add_payment_method">اضافه کردن روش پرداخت</string>
     <string name="error">خطا</string>
     <string name="cancel_transaction">تراکنش لغو شود؟ </string>

--- a/integrations/coinbase/src/main/res/values-fil/strings.xml
+++ b/integrations/coinbase/src/main/res/values-fil/strings.xml
@@ -41,8 +41,8 @@
     <string name="cancel">Kanselahin</string>
     <string name="confirm_sec">Kumpirmahin ang (%ss)</string>
     <string name="confirm">Kumpirmahin</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_title">Wala kaming nakitang anumang paraan ng pagbabayad.</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_message">Mangyaring i-update ang iyong Coinbase account upang magpatuloy.</string>
+    <string name="coinbase_no_payment_methods_error_title">Wala kaming nakitang anumang paraan ng pagbabayad.</string>
+    <string name="coinbase_no_payment_methods_error_message">Mangyaring i-update ang iyong Coinbase account upang magpatuloy.</string>
     <string name="add_payment_method">Magdagdag ng Paraan ng Pagbabayad</string>
     <string name="error">Mali</string>
     <string name="cancel_transaction">Kanselahin ang transaksyon?</string>

--- a/integrations/coinbase/src/main/res/values-fr/strings.xml
+++ b/integrations/coinbase/src/main/res/values-fr/strings.xml
@@ -41,8 +41,8 @@
     <string name="cancel">Annuler</string>
     <string name="confirm_sec">Confirmer (%ss)</string>
     <string name="confirm">Confirmer</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_title">Nous n\'avons pas trouvé de méthode de paiement.</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_message">Veuillez mettre à jour votre compte Coinbase pour continuer.</string>
+    <string name="coinbase_no_payment_methods_error_title">Nous n\'avons pas trouvé de méthode de paiement.</string>
+    <string name="coinbase_no_payment_methods_error_message">Veuillez mettre à jour votre compte Coinbase pour continuer.</string>
     <string name="add_payment_method">Ajouter une méthode de paiement</string>
     <string name="error">Erreur</string>
     <string name="cancel_transaction">Annuler la transaction ?</string>

--- a/integrations/coinbase/src/main/res/values-id/strings.xml
+++ b/integrations/coinbase/src/main/res/values-id/strings.xml
@@ -41,8 +41,8 @@
     <string name="cancel">Batal</string>
     <string name="confirm_sec">Konfirmasi (%ss)</string>
     <string name="confirm">Memastikan</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_title">Kami tidak menemukan metode pembayaran apa pun.</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_message">Harap perbarui akun Coinbase Anda untuk melanjutkan.</string>
+    <string name="coinbase_no_payment_methods_error_title">Kami tidak menemukan metode pembayaran apa pun.</string>
+    <string name="coinbase_no_payment_methods_error_message">Harap perbarui akun Coinbase Anda untuk melanjutkan.</string>
     <string name="add_payment_method">Tambahkan Metode Pembayaran</string>
     <string name="error">Kesalahan</string>
     <string name="cancel_transaction">Batalkan transaksi?</string>

--- a/integrations/coinbase/src/main/res/values-it/strings.xml
+++ b/integrations/coinbase/src/main/res/values-it/strings.xml
@@ -41,8 +41,8 @@
     <string name="cancel">Annulla</string>
     <string name="confirm_sec">Conferma (%ss)</string>
     <string name="confirm">Confermare</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_title">Non abbiamo trovato alcun metodo di pagamento.</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_message">Aggiorna il tuo account Coinbase per procedere.</string>
+    <string name="coinbase_no_payment_methods_error_title">Non abbiamo trovato alcun metodo di pagamento.</string>
+    <string name="coinbase_no_payment_methods_error_message">Aggiorna il tuo account Coinbase per procedere.</string>
     <string name="add_payment_method">Aggiungi metodo di pagamento</string>
     <string name="error">Errore</string>
     <string name="cancel_transaction">Annullare la transazione?</string>

--- a/integrations/coinbase/src/main/res/values-ja/strings.xml
+++ b/integrations/coinbase/src/main/res/values-ja/strings.xml
@@ -41,8 +41,8 @@
     <string name="cancel">キャンセル</string>
     <string name="confirm_sec">確認 (%s秒)</string>
     <string name="confirm">確認する</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_title">支払い方法は見つかりませんでした。</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_message">Coinbaseのアカウントを更新して手続きを進めてください。</string>
+    <string name="coinbase_no_payment_methods_error_title">支払い方法は見つかりませんでした。</string>
+    <string name="coinbase_no_payment_methods_error_message">Coinbaseのアカウントを更新して手続きを進めてください。</string>
     <string name="add_payment_method">支払い方法の追加</string>
     <string name="error">エラー</string>
     <string name="cancel_transaction">取引をキャンセルしますか。</string>

--- a/integrations/coinbase/src/main/res/values-ko/strings.xml
+++ b/integrations/coinbase/src/main/res/values-ko/strings.xml
@@ -41,8 +41,8 @@
     <string name="cancel">취소</string>
     <string name="confirm_sec">확인 (%ss)</string>
     <string name="confirm">승인</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_title">지불 방법을 찾지 못했습니다.</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_message">계속하시려면 코인베이스 계정을 업데이트 해주십시오.</string>
+    <string name="coinbase_no_payment_methods_error_title">지불 방법을 찾지 못했습니다.</string>
+    <string name="coinbase_no_payment_methods_error_message">계속하시려면 코인베이스 계정을 업데이트 해주십시오.</string>
     <string name="add_payment_method">지불 방법 추가하기</string>
     <string name="error">오류</string>
     <string name="cancel_transaction">거래를 취소하시겠습니까?</string>

--- a/integrations/coinbase/src/main/res/values-nl/strings.xml
+++ b/integrations/coinbase/src/main/res/values-nl/strings.xml
@@ -41,8 +41,8 @@
     <string name="cancel">Annuleer</string>
     <string name="confirm_sec">Bevestig (%ss)</string>
     <string name="confirm">Bevestig</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_title">We hebben geen betaalmethode gevonden.</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_message">Werk je Coinbase account bij om door te gaan.</string>
+    <string name="coinbase_no_payment_methods_error_title">We hebben geen betaalmethode gevonden.</string>
+    <string name="coinbase_no_payment_methods_error_message">Werk je Coinbase account bij om door te gaan.</string>
     <string name="add_payment_method">Betalingsmethode toevoegen</string>
     <string name="error">Fout</string>
     <string name="cancel_transaction">Transactie annuleren?</string>

--- a/integrations/coinbase/src/main/res/values-pl/strings.xml
+++ b/integrations/coinbase/src/main/res/values-pl/strings.xml
@@ -41,8 +41,8 @@
     <string name="cancel">Anuluj</string>
     <string name="confirm_sec">Potwierdź (%ss)</string>
     <string name="confirm">Potwierdź</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_title">Nie znaleźliśmy żadnej metody płatności.</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_message">Zaktualizuj swoje konto Coinbase aby móc kontynuować.</string>
+    <string name="coinbase_no_payment_methods_error_title">Nie znaleźliśmy żadnej metody płatności.</string>
+    <string name="coinbase_no_payment_methods_error_message">Zaktualizuj swoje konto Coinbase aby móc kontynuować.</string>
     <string name="add_payment_method">Dodaj Metodę Płatności</string>
     <string name="error">Błąd</string>
     <string name="cancel_transaction">Anuluj transakcję?</string>

--- a/integrations/coinbase/src/main/res/values-pt/strings.xml
+++ b/integrations/coinbase/src/main/res/values-pt/strings.xml
@@ -41,8 +41,8 @@
     <string name="cancel">Cancelar</string>
     <string name="confirm_sec">Confirmar (%ss)</string>
     <string name="confirm">Confirmar</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_title">Nós não encontramos nenhum método de pagamento.</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_message">Por favor, atualize sua conta Coinbase para continuar. </string>
+    <string name="coinbase_no_payment_methods_error_title">Nós não encontramos nenhum método de pagamento.</string>
+    <string name="coinbase_no_payment_methods_error_message">Por favor, atualize sua conta Coinbase para continuar. </string>
     <string name="add_payment_method">Adicionar método de pagamento</string>
     <string name="error">Erro</string>
     <string name="cancel_transaction">Cancelar transação?</string>

--- a/integrations/coinbase/src/main/res/values-ru/strings.xml
+++ b/integrations/coinbase/src/main/res/values-ru/strings.xml
@@ -41,8 +41,8 @@
     <string name="cancel">Отмена</string>
     <string name="confirm_sec">Подтвердить (%s)</string>
     <string name="confirm">Подтвердить</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_title">Способ оплаты не найден.</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_message">Для продолжения обновите свой аккаунт на Coinbase.</string>
+    <string name="coinbase_no_payment_methods_error_title">Способ оплаты не найден.</string>
+    <string name="coinbase_no_payment_methods_error_message">Для продолжения обновите свой аккаунт на Coinbase.</string>
     <string name="add_payment_method">Добавить способ оплаты</string>
     <string name="error">Ошибка</string>
     <string name="cancel_transaction">Отменить транзакцию?</string>

--- a/integrations/coinbase/src/main/res/values-sk/strings.xml
+++ b/integrations/coinbase/src/main/res/values-sk/strings.xml
@@ -41,8 +41,8 @@
     <string name="cancel">Zrušiť</string>
     <string name="confirm_sec">Potvrďte (%ss)</string>
     <string name="confirm">Potvrdiť</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_title">Nenašli sme žiadne spôsoby platby.</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_message">Ak chcete pokračovať, aktualizujte svoj účet Coinbase.</string>
+    <string name="coinbase_no_payment_methods_error_title">Nenašli sme žiadne spôsoby platby.</string>
+    <string name="coinbase_no_payment_methods_error_message">Ak chcete pokračovať, aktualizujte svoj účet Coinbase.</string>
     <string name="add_payment_method">Pridať spôsob platby</string>
     <string name="error">Chyba</string>
     <string name="cancel_transaction">Zrušiť transakciu?</string>

--- a/integrations/coinbase/src/main/res/values-th/strings.xml
+++ b/integrations/coinbase/src/main/res/values-th/strings.xml
@@ -41,8 +41,8 @@
     <string name="cancel">ยกเลิก</string>
     <string name="confirm_sec">ยืนยัน (%ss)</string>
     <string name="confirm">ยืนยัน</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_title">เราไม่พบการชำระเงินใด ๆ</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_message">โปรดอัพเดตบัญชี Coinbase ของคุณเพื่อดำเนินการต่อ</string>
+    <string name="coinbase_no_payment_methods_error_title">เราไม่พบการชำระเงินใด ๆ</string>
+    <string name="coinbase_no_payment_methods_error_message">โปรดอัพเดตบัญชี Coinbase ของคุณเพื่อดำเนินการต่อ</string>
     <string name="add_payment_method">เพิ่มวิธีการชำระเงิน</string>
     <string name="error">ผิดพลาด</string>
     <string name="cancel_transaction">ยกเลิกธุรกรรม?</string>

--- a/integrations/coinbase/src/main/res/values-tr/strings.xml
+++ b/integrations/coinbase/src/main/res/values-tr/strings.xml
@@ -41,8 +41,8 @@
     <string name="cancel">İptal et</string>
     <string name="confirm_sec">Onaylayın (%ss)</string>
     <string name="confirm">Onayla</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_title">Herhangi bir ödeme yöntemi bulamadık.</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_message">Devam etmek için lütfen Coinbase hesabınızı güncelleyin.</string>
+    <string name="coinbase_no_payment_methods_error_title">Herhangi bir ödeme yöntemi bulamadık.</string>
+    <string name="coinbase_no_payment_methods_error_message">Devam etmek için lütfen Coinbase hesabınızı güncelleyin.</string>
     <string name="add_payment_method">Ödeme yöntemi ekle</string>
     <string name="error">Hata</string>
     <string name="cancel_transaction">İşlemi iptal et?</string>

--- a/integrations/coinbase/src/main/res/values-uk/strings.xml
+++ b/integrations/coinbase/src/main/res/values-uk/strings.xml
@@ -41,8 +41,8 @@
     <string name="cancel">Відміна</string>
     <string name="confirm_sec">Підтвердження (%s сек.)</string>
     <string name="confirm">Підтвердити</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_title">Ми не знайшли способів оплати.</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_message">Щоб продовжити, оновіть свій обліковий запис Coinbase.</string>
+    <string name="coinbase_no_payment_methods_error_title">Ми не знайшли способів оплати.</string>
+    <string name="coinbase_no_payment_methods_error_message">Щоб продовжити, оновіть свій обліковий запис Coinbase.</string>
     <string name="add_payment_method">Додати спосіб оплати</string>
     <string name="error">Помилка</string>
     <string name="cancel_transaction">Відмінити транзакцію?</string>

--- a/integrations/coinbase/src/main/res/values-zh-rTW/strings.xml
+++ b/integrations/coinbase/src/main/res/values-zh-rTW/strings.xml
@@ -41,8 +41,8 @@
     <string name="cancel">取消</string>
     <string name="confirm_sec">確認 (%ss)</string>
     <string name="confirm">確認:</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_title">我們沒有找到任何付款方式。</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_message">請更新您的 Coinbase 帳戶以繼續。</string>
+    <string name="coinbase_no_payment_methods_error_title">我們沒有找到任何付款方式。</string>
+    <string name="coinbase_no_payment_methods_error_message">請更新您的 Coinbase 帳戶以繼續。</string>
     <string name="add_payment_method">添加付款方式</string>
     <string name="error">錯誤</string>
     <string name="cancel_transaction">取消交易?</string>

--- a/integrations/coinbase/src/main/res/values-zh/strings.xml
+++ b/integrations/coinbase/src/main/res/values-zh/strings.xml
@@ -41,8 +41,8 @@
     <string name="cancel">取消</string>
     <string name="confirm_sec">确认 (%ss)</string>
     <string name="confirm">确认</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_title">我们没有找到任何付款方式.</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_message">请更新您的 Coinbase账户以继续.</string>
+    <string name="coinbase_no_payment_methods_error_title">我们没有找到任何付款方式.</string>
+    <string name="coinbase_no_payment_methods_error_message">请更新您的 Coinbase账户以继续.</string>
     <string name="add_payment_method">添加付款方式</string>
     <string name="error">错误</string>
     <string name="cancel_transaction">取消交易?</string>

--- a/integrations/coinbase/src/main/res/values/strings.xml
+++ b/integrations/coinbase/src/main/res/values/strings.xml
@@ -44,8 +44,11 @@
     <string name="cancel">Cancel</string>
     <string name="confirm_sec">Confirm (%ss)</string>
     <string name="confirm">Confirm</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_title">We didn’t find any payment methods.</string>
-    <string name="coinbase_dash_wallet_no_payment_methods_error_message"> Please update your Coinbase account to proceed.</string>
+    <string name="coinbase_no_payment_methods_error_title">We didn’t find any payment methods.</string>
+    <string name="coinbase_no_payment_methods_error_message">Please update your Coinbase account to proceed.</string>
+    <string name="coinbase_unusable_payment_method_error_title">This payment method cannot be used.</string>
+    <string name="coinbase_unusable_payment_method_error_message">Please allow buying from this payment method in your Coinbase account.</string>
+    <string name="coinbase_open_account">Open Coinbase account</string>
     <string name="add_payment_method">Add Payment Method</string>
     <string name="error">Error</string>
     <string name="cancel_transaction">Cancel transaction?</string>
@@ -58,7 +61,7 @@
     <string name="conversion_failed">Conversion Failed</string>
     <string name="transfer_failed_msg"> The Dash was successfully deposited to your Coinbase account. But there was a problem transferring it to Dash Wallet on this device.</string>
     <string name="purchase_failed_msg"> Something went wrong</string>
-    <string name="it_could_take_up_to_2_3_minutes">It could take up to 2-3 minutes for the Dash to be transferred to your Dash Wallet on this device.</string>
+    <string name="it_could_take_up_to_2_3_minutes">It could take up to 2–3 minutes for the Dash to be transferred to your Dash Wallet on this device.</string>
     <string name="it_could_take_up_to_5_minutes">It could take up to 5 minutes to convert %s from Coinbase account to Dash in your Dash Wallet on this device..</string>
     <string name="it_could_take_up_to_5_minutes_to_coinbase">“It could take up to 5 minutes to convert Dash from Dash Wallet on this device to %s in your Coinbase account.</string>
     <string name="contact_coinbase_support">Contact Coinbase Support</string>


### PR DESCRIPTION
If there is a payment method but buying from it isn't allowed, we want to show a different error dialog. Currently, "No payment methods" error is shown.

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
