### PR TITLE
feat(coinbase): cache base id values [NMA-1402]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,10 +9,13 @@ buildscript {
         workRuntimeVersion='2.7.1'
         firebaseVersion = '28.4.2'
         roomVersion = '2.4.3'
-        lifecycleVersion = '2.3.1'
-        navigationVersion = '2.5.2'
         jetpackVersion = '1.6.0'
         appCompatVersion = '1.4.2'
+
+        // Architecture
+        lifecycleVersion = '2.3.1'
+        navigationVersion = '2.5.2'
+        datastoreVersion = "1.0.0"
 
         // Utils
         slf4jVersion = '1.7.32'

--- a/common/src/main/java/org/dash/wallet/common/Configuration.java
+++ b/common/src/main/java/org/dash/wallet/common/Configuration.java
@@ -91,7 +91,6 @@ public class Configuration {
 
     public static final String PREFS_KEY_LAST_COINBASE_ACCESS_TOKEN = "last_coinbase_access_token";
     public static final String PREFS_KEY_LAST_COINBASE_REFRESH_TOKEN = "last_coinbase_refresh_token";
-    public static final String PREFS_KEY_LAST_COINBASE_BALANCE = "last_coinbase_balance";
     public static final String PREFS_KEY_COINBASE_USER_ACCOUNT_ID = "coinbase_account_id";
     public static final String PREFS_KEY_COINBASE_AUTH_INFO_SHOWN = "coinbase_auth_info_shown";
     public static final String PREFS_KEY_COINBASE_USER_WITHDRAWAL_LIMIT = "withdrawal_limit";
@@ -535,6 +534,7 @@ public class Configuration {
     }
 
     // Coinbase
+    // TODO: put new preferences in the CoinbaseConfig and migrate these.
 
     public void setLastCoinBaseAccessToken(String token) {
         prefs.edit().putString(PREFS_KEY_LAST_COINBASE_ACCESS_TOKEN, token).apply();
@@ -551,14 +551,6 @@ public class Configuration {
 
     public String getLastCoinbaseRefreshToken() {
         return prefs.getString(PREFS_KEY_LAST_COINBASE_REFRESH_TOKEN, null);
-    }
-
-    public void setLastCoinbaseBalance(String balance) {
-        prefs.edit().putString(PREFS_KEY_LAST_COINBASE_BALANCE, balance).apply();
-    }
-
-    public String getLastCoinbaseBalance() {
-        return prefs.getString(PREFS_KEY_LAST_COINBASE_BALANCE, null);
     }
 
     public Boolean getHasCoinbaseAuthInfoBeenShown() {

--- a/integrations/coinbase/build.gradle
+++ b/integrations/coinbase/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     implementation "androidx.navigation:navigation-fragment-ktx:$navigationVersion"
     implementation "androidx.navigation:navigation-ui-ktx:$navigationVersion"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
+    implementation "androidx.datastore:datastore-preferences:$datastoreVersion"
 
     // DI
     implementation "com.google.dagger:hilt-android:$hiltVersion"

--- a/integrations/coinbase/build.gradle
+++ b/integrations/coinbase/build.gradle
@@ -82,6 +82,9 @@ dependencies {
 
     implementation 'com.scottyab:secure-preferences-lib:0.1.7'
 
+    // Logging
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
+
     // Tests
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.mockito:mockito-core:4.0.0"

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/Constants.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/Constants.kt
@@ -16,7 +16,11 @@
  */
 package org.dash.wallet.integration.coinbase_integration
 
+import android.content.Context
+import java.io.File
+
 object CoinbaseConstants {
+    const val BASE_URL = "https://api.coinbase.com/"
     const val CB_VERSION_KEY = "CB-VERSION"
     const val CB_2FA_TOKEN_KEY = "CB-2FA-TOKEN"
     const val CB_VERSION_VALUE = "2021-09-07"
@@ -36,4 +40,9 @@ object CoinbaseConstants {
     const val VALUE_ZERO = "0"
     const val DEFAULT_CURRENCY_USD = "USD"
     const val MIN_USD_COINBASE_AMOUNT = "2"
+    const val BASE_IDS_REQUEST_URL = "v2/assets/prices?filter=holdable&resolution=latest"
+
+    fun getCacheDir(context: Context): File {
+        return File(context.cacheDir, "coinbase")
+    }
 }

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/di/CoinBaseModule.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/di/CoinBaseModule.kt
@@ -16,10 +16,12 @@
  */
 package org.dash.wallet.integration.coinbase_integration.di
 
+import android.content.Context
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import org.dash.wallet.common.Configuration
 import org.dash.wallet.integration.coinbase_integration.CoinbaseAddressMapper
@@ -32,6 +34,7 @@ import org.dash.wallet.integration.coinbase_integration.repository.CoinBaseRepos
 import org.dash.wallet.integration.coinbase_integration.service.CloseCoinbasePortalBroadcaster
 import org.dash.wallet.integration.coinbase_integration.service.CoinBaseAuthApi
 import org.dash.wallet.integration.coinbase_integration.service.CoinBaseServicesApi
+import org.dash.wallet.integration.coinbase_integration.utils.CoinbaseConfig
 import javax.inject.Singleton
 
 @Module
@@ -39,9 +42,13 @@ import javax.inject.Singleton
 object CoinBaseModule {
     @Singleton
     @Provides
-    fun provideRemoteDataSource(userPreferences: Configuration, broadcaster: CloseCoinbasePortalBroadcaster)
+    fun provideRemoteDataSource(
+        userPreferences: Configuration,
+        config: CoinbaseConfig,
+        broadcaster: CloseCoinbasePortalBroadcaster,
+        @ApplicationContext context: Context)
     : RemoteDataSource {
-        return RemoteDataSource(userPreferences, broadcaster)
+        return RemoteDataSource(context, userPreferences, config, broadcaster)
     }
 
     @Singleton

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/network/RemoteDataSource.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/network/RemoteDataSource.kt
@@ -16,7 +16,10 @@
  */
 package org.dash.wallet.integration.coinbase_integration.network
 
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
 import okhttp3.Authenticator
+import okhttp3.Cache
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import org.dash.wallet.common.BuildConfig
@@ -25,14 +28,18 @@ import org.dash.wallet.integration.coinbase_integration.repository.remote.Header
 import org.dash.wallet.integration.coinbase_integration.repository.remote.TokenAuthenticator
 import org.dash.wallet.integration.coinbase_integration.service.CloseCoinbasePortalBroadcaster
 import org.dash.wallet.integration.coinbase_integration.service.CoinBaseTokenRefreshApi
+import org.dash.wallet.integration.coinbase_integration.utils.CoinbaseConfig
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import java.io.File
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 
 class RemoteDataSource @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val userPreferences: Configuration,
+    private val config: CoinbaseConfig,
     private val broadcaster: CloseCoinbasePortalBroadcaster
 ) {
 
@@ -40,11 +47,11 @@ class RemoteDataSource @Inject constructor(
         private const val BASE_URL = "https://api.coinbase.com/"
     }
 
-    fun <Api> buildApi(api: Class<Api>, ): Api {
-        val authenticator = TokenAuthenticator(buildTokenApi(), userPreferences, broadcaster)
+    fun <Api> buildApi(api: Class<Api>): Api {
+        val authenticator = TokenAuthenticator(buildTokenApi(), userPreferences, config, broadcaster)
         return Retrofit.Builder()
             .baseUrl(BASE_URL)
-            .client(getRetrofitClient(authenticator))
+            .client(getOkHttpClient(authenticator))
             .addConverterFactory(GsonConverterFactory.create())
             .build()
             .create(api)
@@ -53,18 +60,22 @@ class RemoteDataSource @Inject constructor(
     private fun buildTokenApi(): CoinBaseTokenRefreshApi {
         return Retrofit.Builder()
             .baseUrl(BASE_URL)
-            .client(getRetrofitClient())
+            .client(getOkHttpClient())
             .addConverterFactory(GsonConverterFactory.create())
             .build()
             .create(CoinBaseTokenRefreshApi::class.java)
     }
 
-    private fun getRetrofitClient(authenticator: Authenticator? = null): OkHttpClient {
+    private fun getOkHttpClient(authenticator: Authenticator? = null): OkHttpClient {
         return OkHttpClient.Builder()
             .addInterceptor(HeadersInterceptor(userPreferences))
             .connectTimeout(20.seconds.toJavaDuration())
             .callTimeout(20.seconds.toJavaDuration())
             .readTimeout(20.seconds.toJavaDuration())
+            .cache(Cache(
+                directory = File(context.cacheDir, "coinbase"),
+                maxSize = 10L * 1024L * 1024L // 10 MB
+            ))
             .also { client ->
                 authenticator?.let { client.authenticator(it) }
                 if (BuildConfig.DEBUG) {

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/network/ResponseResource.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/network/ResponseResource.kt
@@ -18,7 +18,6 @@ package org.dash.wallet.integration.coinbase_integration.network
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import okhttp3.ResponseBody
 import retrofit2.HttpException
 
 sealed class ResponseResource<out T> {
@@ -26,7 +25,7 @@ sealed class ResponseResource<out T> {
     data class Failure(
         val isNetworkError: Boolean,
         val errorCode: Int?,
-        val errorBody: ResponseBody?
+        val errorBody: String?
     ) : ResponseResource<Nothing>()
 }
 
@@ -43,11 +42,11 @@ suspend fun <T> safeApiCall(
                     ResponseResource.Failure(
                         false,
                         throwable.code(),
-                        throwable.response()?.errorBody()
+                        throwable.response()?.errorBody()?.string()
                     )
                 }
                 else -> {
-                    ResponseResource.Failure(true, null, null)
+                    ResponseResource.Failure(true, null, throwable.message)
                 }
             }
         }

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/repository/CoinBaseRepository.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/repository/CoinBaseRepository.kt
@@ -16,6 +16,7 @@
  */
 package org.dash.wallet.integration.coinbase_integration.repository
 
+import android.content.Context
 import org.bitcoinj.core.Coin
 import org.dash.wallet.common.Configuration
 import org.dash.wallet.integration.coinbase_integration.*
@@ -26,14 +27,17 @@ import org.dash.wallet.integration.coinbase_integration.service.CoinBaseAuthApi
 import org.dash.wallet.integration.coinbase_integration.service.CoinBaseClientConstants
 import org.dash.wallet.integration.coinbase_integration.service.CoinBaseServicesApi
 import org.dash.wallet.integration.coinbase_integration.utils.CoinbaseConfig
+import java.io.File
 import java.math.BigDecimal
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.days
 
 class CoinBaseRepository @Inject constructor(
     private val servicesApi: CoinBaseServicesApi,
     private val authApi: CoinBaseAuthApi,
     private val userPreferences: Configuration,
     private val config: CoinbaseConfig,
+    private val context: Context,
     private val placeBuyOrderMapper: PlaceBuyOrderMapper,
     private val swapTradeMapper: SwapTradeMapper,
     private val commitBuyOrderMapper: CommitBuyOrderMapper,

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/repository/CoinBaseRepository.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/repository/CoinBaseRepository.kt
@@ -37,7 +37,6 @@ class CoinBaseRepository @Inject constructor(
     private val authApi: CoinBaseAuthApi,
     private val userPreferences: Configuration,
     private val config: CoinbaseConfig,
-    private val context: Context,
     private val placeBuyOrderMapper: PlaceBuyOrderMapper,
     private val swapTradeMapper: SwapTradeMapper,
     private val commitBuyOrderMapper: CommitBuyOrderMapper,

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/repository/CoinBaseRepository.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/repository/CoinBaseRepository.kt
@@ -16,6 +16,7 @@
  */
 package org.dash.wallet.integration.coinbase_integration.repository
 
+import org.bitcoinj.core.Coin
 import org.dash.wallet.common.Configuration
 import org.dash.wallet.integration.coinbase_integration.*
 import org.dash.wallet.integration.coinbase_integration.model.*
@@ -24,6 +25,7 @@ import org.dash.wallet.integration.coinbase_integration.network.safeApiCall
 import org.dash.wallet.integration.coinbase_integration.service.CoinBaseAuthApi
 import org.dash.wallet.integration.coinbase_integration.service.CoinBaseClientConstants
 import org.dash.wallet.integration.coinbase_integration.service.CoinBaseServicesApi
+import org.dash.wallet.integration.coinbase_integration.utils.CoinbaseConfig
 import java.math.BigDecimal
 import javax.inject.Inject
 
@@ -31,6 +33,7 @@ class CoinBaseRepository @Inject constructor(
     private val servicesApi: CoinBaseServicesApi,
     private val authApi: CoinBaseAuthApi,
     private val userPreferences: Configuration,
+    private val config: CoinbaseConfig,
     private val placeBuyOrderMapper: PlaceBuyOrderMapper,
     private val swapTradeMapper: SwapTradeMapper,
     private val commitBuyOrderMapper: CommitBuyOrderMapper,
@@ -53,7 +56,7 @@ class CoinBaseRepository @Inject constructor(
         }
         userAccountData?.also {
             userPreferences.setCoinBaseUserAccountId(it.id)
-            userPreferences.lastCoinbaseBalance = it.balance?.amount
+            config.setPreference(CoinbaseConfig.LAST_BALANCE, Coin.parseCoin(it.balance?.amount ?: "0.0").value)
         }
     }
 
@@ -90,15 +93,9 @@ class CoinBaseRepository @Inject constructor(
     override suspend fun disconnectCoinbaseAccount() {
         userPreferences.setLastCoinBaseAccessToken(null)
         userPreferences.setLastCoinBaseRefreshToken(null)
-        userPreferences.lastCoinbaseBalance = null
         userPreferences.setCoinBaseUserAccountId(null)
+        config.clearAll()
         safeApiCall { authApi.revokeToken() }
-    }
-
-    override fun saveLastCoinbaseDashAccountBalance(amount: String?) {
-        amount?.let {
-            userPreferences.lastCoinbaseBalance = it
-        }
     }
 
     override fun saveUserAccountId(accountId: String?) {
@@ -140,7 +137,6 @@ class CoinBaseRepository @Inject constructor(
         servicesApi.sendCoinsToWallet(accountId = userPreferences.coinbaseUserAccountId, sendTransactionToWalletParams = sendTransactionToWalletParams, api2FATokenVersion = api2FATokenVersion)
     }
 
-    override fun getUserLastCoinbaseBalance(): String = userPreferences.lastCoinbaseBalance ?: ""
     override fun isUserConnected(): Boolean = userPreferences.lastCoinbaseAccessToken.isNotEmpty()
 
     override suspend fun completeCoinbaseAuthentication(authorizationCode: String): ResponseResource<Boolean> = safeApiCall {
@@ -199,7 +195,6 @@ interface CoinBaseRepositoryInt {
     suspend fun getBaseIdForUSDModel(baseCurrency: String): ResponseResource<BaseIdForUSDModel?>
     suspend fun getExchangeRates(): ResponseResource<CoinBaseExchangeRates?>
     suspend fun disconnectCoinbaseAccount()
-    fun saveLastCoinbaseDashAccountBalance(amount: String?)
     fun saveUserAccountId(accountId: String?)
     suspend fun createAddress(): ResponseResource<String>
     suspend fun getUserAccountAddress(): ResponseResource<String>
@@ -207,7 +202,6 @@ interface CoinBaseRepositoryInt {
     suspend fun placeBuyOrder(placeBuyOrderParams: PlaceBuyOrderParams): ResponseResource<PlaceBuyOrderUIModel>
     suspend fun commitBuyOrder(buyOrderId: String): ResponseResource<CommitBuyOrderUIModel>
     suspend fun sendFundsToWallet(sendTransactionToWalletParams: SendTransactionToWalletParams, api2FATokenVersion: String?): ResponseResource<SendTransactionToWalletResponse?>
-    fun getUserLastCoinbaseBalance(): String
     fun isUserConnected(): Boolean
     suspend fun swapTrade(tradesRequest: TradesRequest): ResponseResource<SwapTradeUIModel>
     suspend fun commitSwapTrade(buyOrderId: String): ResponseResource<SwapTradeUIModel>

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/repository/remote/CustomCacheInterceptor.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/repository/remote/CustomCacheInterceptor.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2021 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dash.wallet.integration.coinbase_integration.repository.remote
+
+import android.content.Context
+import com.google.gson.Gson
+import kotlinx.coroutines.runBlocking
+import okhttp3.*
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.dash.wallet.integration.coinbase_integration.CoinbaseConstants
+import org.dash.wallet.integration.coinbase_integration.model.BaseIdForUSDModel
+import org.dash.wallet.integration.coinbase_integration.utils.CoinbaseConfig
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.io.FileReader
+import java.io.FileWriter
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.days
+
+class CustomCacheInterceptor @Inject constructor(
+    private val context: Context,
+    private val config: CoinbaseConfig
+) : Interceptor {
+
+    companion object {
+        private const val BASE_IDS_FILENAME = "base_ids.json"
+        private val log = LoggerFactory.getLogger(CustomCacheInterceptor::class.java)
+    }
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        if (!chain.request().url.toString().startsWith(
+            "${CoinbaseConstants.BASE_URL}${CoinbaseConstants.BASE_IDS_REQUEST_URL}")
+        ) {
+            // We only need custom cash for the BASE_IDS_REQUEST_URL
+            return chain.proceed(chain.request())
+        }
+
+        val gson = Gson()
+        val shouldUpdateBaseIds = runBlocking { config.getPreference(CoinbaseConfig.UPDATE_BASE_IDS) ?: true }
+        val cacheFile = File(CoinbaseConstants.getCacheDir(context), BASE_IDS_FILENAME)
+
+        if (shouldUpdateBaseIds || !cacheFile.exists()) {
+            // If UPDATE_BASE_IDS is set, refresh the cache
+            val response = chain.proceed(chain.request())
+
+            try {
+                val baseIds = gson.fromJson(response.body?.string(), BaseIdForUSDModel::class.java)
+                FileWriter(cacheFile, false).use {
+                    gson.toJson(baseIds, it)
+                }
+                val cached = readCached(chain.request(), cacheFile)
+                runBlocking { config.setPreference(CoinbaseConfig.UPDATE_BASE_IDS, false) }
+                return cached
+            } catch (ex: Exception) {
+                log.error("Failed to cache baseId", ex)
+                cacheFile.delete()
+            }
+
+            return response
+        }
+
+        val sixMonthsAgo = System.currentTimeMillis() - (30*6).days.inWholeMilliseconds
+
+        if(cacheFile.lastModified() < sixMonthsAgo) {
+            // Force update every ~ 6 months
+            runBlocking { config.setPreference(CoinbaseConfig.UPDATE_BASE_IDS, true) }
+        }
+
+        return try {
+            readCached(chain.request(), cacheFile)
+        } catch (ex: Exception) {
+            log.error("Failed to return cached baseId", ex)
+            cacheFile.delete()
+            // Retry with no cache
+            runBlocking { config.setPreference(CoinbaseConfig.UPDATE_BASE_IDS, true) }
+            intercept(chain)
+        }
+    }
+
+    private fun readCached(request: Request, cacheFile: File): Response {
+        return Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(200)
+            .message("")
+            .body(FileReader(cacheFile).readText()
+                .toResponseBody("application/json".toMediaType())
+            )
+            .build()
+    }
+}

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/repository/remote/HeadersInterceptor.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/repository/remote/HeadersInterceptor.kt
@@ -31,7 +31,7 @@ class HeadersInterceptor @Inject constructor(
         requestBuilder.header("Accept", "application/json")
 
         val accessToken = userPreferences.lastCoinbaseAccessToken
-        if (accessToken?.isEmpty()?.not() == true) {
+        if (accessToken.isNotEmpty()) {
             requestBuilder.header("Authorization", "Bearer $accessToken")
         }
 

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/repository/remote/TokenAuthenticator.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/repository/remote/TokenAuthenticator.kt
@@ -27,11 +27,13 @@ import org.dash.wallet.integration.coinbase_integration.network.ResponseResource
 import org.dash.wallet.integration.coinbase_integration.network.safeApiCall
 import org.dash.wallet.integration.coinbase_integration.service.CloseCoinbasePortalBroadcaster
 import org.dash.wallet.integration.coinbase_integration.service.CoinBaseTokenRefreshApi
+import org.dash.wallet.integration.coinbase_integration.utils.CoinbaseConfig
 import javax.inject.Inject
 
 class TokenAuthenticator @Inject constructor(
     private val tokenApi: CoinBaseTokenRefreshApi,
     private val userPreferences: Configuration,
+    private val config: CoinbaseConfig,
     private val closeCoinbasePortalBroadcaster: CloseCoinbasePortalBroadcaster
 ) : Authenticator {
 
@@ -50,7 +52,7 @@ class TokenAuthenticator @Inject constructor(
                 else -> {
                     userPreferences.setLastCoinBaseAccessToken(null)
                     userPreferences.setLastCoinBaseRefreshToken(null)
-                    userPreferences.lastCoinbaseBalance = null
+                    config.clearAll()
                     closeCoinbasePortalBroadcaster.dispatchCall()
                     null
                 }

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/service/CoinBaseClientConstants.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/service/CoinBaseClientConstants.kt
@@ -1,3 +1,22 @@
+/*
+ *
+ *  * Copyright 2022 Dash Core Group.
+ *  *
+ *  * This program is free software: you can redistribute it and/or modify
+ *  * it under the terms of the GNU General Public License as published by
+ *  * the Free Software Foundation, either version 3 of the License, or
+ *  * (at your option) any later version.
+ *  *
+ *  * This program is distributed in the hope that it will be useful,
+ *  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  * GNU General Public License for more details.
+ *  *
+ *  * You should have received a copy of the GNU General Public License
+ *  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 package org.dash.wallet.integration.coinbase_integration.service
 
 object CoinBaseClientConstants {

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/service/CoinBaseServicesApi.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/service/CoinBaseServicesApi.kt
@@ -60,7 +60,7 @@ interface CoinBaseServicesApi {
         @Body sendTransactionToWalletParams: SendTransactionToWalletParams
     ): SendTransactionToWalletResponse?
 
-    @GET("v2/assets/prices?filter=holdable&resolution=latest")
+    @GET(CoinbaseConstants.BASE_IDS_REQUEST_URL)
     suspend fun getBaseIdForUSDModel(
         @Header(CoinbaseConstants.CB_VERSION_KEY) apiVersion: String = CoinbaseConstants.CB_VERSION_VALUE,
         @Query("base") baseCurrency: String,

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/service/CoinBaseTokenRefreshApi.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/service/CoinBaseTokenRefreshApi.kt
@@ -17,7 +17,6 @@
 package org.dash.wallet.integration.coinbase_integration.service
 
 import org.dash.wallet.integration.coinbase_integration.model.TokenResponse
-import retrofit2.Response
 import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
 import retrofit2.http.POST

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/ui/CoinbaseConvertCryptoFragment.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/ui/CoinbaseConvertCryptoFragment.kt
@@ -271,7 +271,7 @@ class CoinbaseConvertCryptoFragment : Fragment(R.layout.fragment_coinbase_conver
                 }
                 is BaseIdForFaitDataUIState.Error ->{
                     if (uiState.isError) {
-                        //TODO retry in case of error
+                        // Retry in case of error
                         sharedViewModel.getBaseIdForFaitModel()
                     }
                 }

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/ui/CoinbaseConvertCryptoFragment.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/ui/CoinbaseConvertCryptoFragment.kt
@@ -283,8 +283,8 @@ class CoinbaseConvertCryptoFragment : Fragment(R.layout.fragment_coinbase_conver
         val swapValueErrorType = convertViewModel.checkEnteredAmountValue(checkSendingConditions)
         if (swapValueErrorType == SwapValueErrorType.NOError) {
             if (!request.dashToCrypto && convertViewModel.dashToCrypto.value == true) {
-                request.fiatAmount?.let { fait ->
-                    if ((viewModel.userPreference.lastCoinbaseBalance?.toDouble() ?: 0.0) < fait.toPlainString().toDouble()) {
+                lifecycleScope.launch {
+                    if (viewModel.getLastBalance() < (request.amount ?: Coin.ZERO)) {
                         showNoAssetsError()
                     }
                 }

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/ui/CoinbaseServicesFragment.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/ui/CoinbaseServicesFragment.kt
@@ -108,7 +108,7 @@ class CoinbaseServicesFragment : Fragment(R.layout.fragment_coinbase_services) {
             safeNavigate(CoinbaseServicesFragmentDirections.servicesToTransferDash())
         }
 
-        binding.walletBalanceDash.setFormat(viewModel.config.format.noCode())
+        binding.walletBalanceDash.setFormat(viewModel.balanceFormat)
         binding.walletBalanceDash.setApplyMarkup(false)
         binding.walletBalanceDash.setAmount(Coin.ZERO)
 

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/ui/convert_currency/model/BaseIdForFaitDataUIState.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/ui/convert_currency/model/BaseIdForFaitDataUIState.kt
@@ -1,6 +1,5 @@
 package org.dash.wallet.integration.coinbase_integration.ui.convert_currency.model
 
-import org.dash.wallet.common.ui.payment_method_picker.PaymentMethod
 import org.dash.wallet.integration.coinbase_integration.model.BaseIdForUSDData
 
 sealed class BaseIdForFaitDataUIState {

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/utils/CoinbaseConfig.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/utils/CoinbaseConfig.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.dash.wallet.integration.coinbase_integration.utils
+
+import android.content.Context
+import android.preference.PreferenceManager
+import androidx.datastore.preferences.core.*
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import org.bitcoinj.core.Coin
+import java.io.IOException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class CoinbaseConfig @Inject constructor(private val context: Context) {
+    companion object {
+        private const val PREFS_KEY_LAST_COINBASE_BALANCE = "last_coinbase_balance"
+        val LAST_BALANCE = longPreferencesKey("last_balance")
+    }
+
+    private val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+
+    private val Context.dataStore by preferencesDataStore("coinbase")
+    private val dataStore = context.dataStore.data
+        .catch { exception ->
+            if (exception is IOException) {
+                emit(emptyPreferences())
+            } else {
+                throw exception
+            }
+        }
+
+    fun <T> observePreference(key: Preferences.Key<T>): Flow<T?> {
+        return dataStore.map { preferences -> preferences[key] }
+    }
+
+    suspend fun <T> getPreference(key: Preferences.Key<T>): T? {
+        if (key == LAST_BALANCE && !prefs.getString(PREFS_KEY_LAST_COINBASE_BALANCE, null).isNullOrEmpty()) {
+            // TODO: finish migration of this preference
+            val balanceValue = Coin.parseCoin(prefs.getString(PREFS_KEY_LAST_COINBASE_BALANCE, "0.0")).value
+            setPreference(LAST_BALANCE, balanceValue)
+            prefs.edit().putString(PREFS_KEY_LAST_COINBASE_BALANCE, null).apply()
+        }
+
+        return dataStore.map { preferences -> preferences[key] }.first()
+    }
+
+    suspend fun <T> setPreference(key: Preferences.Key<T>, value: T) {
+        context.dataStore.edit { preferences ->
+            preferences[key] = value
+        }
+    }
+
+    suspend fun clearAll() {
+        context.dataStore.edit { it.clear() }
+    }
+}

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/viewmodels/CoinbaseBuyDashOrderReviewViewModel.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/viewmodels/CoinbaseBuyDashOrderReviewViewModel.kt
@@ -85,7 +85,7 @@ class CoinbaseBuyDashOrderReviewViewModel @Inject constructor(
             }
             is ResponseResource.Failure -> {
                 _showLoading.value = false
-                val error = result.errorBody?.string()
+                val error = result.errorBody
                 if (error.isNullOrEmpty()) {
                     commitBuyOrderFailureState.call()
                 } else {
@@ -120,7 +120,7 @@ class CoinbaseBuyDashOrderReviewViewModel @Inject constructor(
             is ResponseResource.Failure -> {
                 _showLoading.value = false
 
-                val error = result.errorBody?.string()
+                val error = result.errorBody
                 if (error.isNullOrEmpty()) {
                     placeBuyOrderFailedCallback.call()
                 } else {

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/viewmodels/CoinbaseBuyDashViewModel.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/viewmodels/CoinbaseBuyDashViewModel.kt
@@ -112,7 +112,7 @@ class CoinbaseBuyDashViewModel @Inject constructor(private val coinBaseRepositor
             is ResponseResource.Failure -> {
                 _showLoading.value = false
 
-                val error = result.errorBody?.string()
+                val error = result.errorBody
                 if (error.isNullOrEmpty()) {
                     placeBuyOrderFailedCallback.call()
                 } else {

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/viewmodels/CoinbaseConversionPreviewViewModel.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/viewmodels/CoinbaseConversionPreviewViewModel.kt
@@ -109,7 +109,7 @@ class CoinbaseConversionPreviewViewModel @Inject constructor(
             }
             is ResponseResource.Failure -> {
                 _showLoading.value = false
-                val error = result.errorBody?.string()
+                val error = result.errorBody
                 if (error.isNullOrEmpty()) {
                     commitSwapTradeFailureState.call()
                 } else {
@@ -151,7 +151,7 @@ class CoinbaseConversionPreviewViewModel @Inject constructor(
                 is ResponseResource.Failure -> {
                     _showLoading.value = false
 
-                    val error = result.errorBody?.string() // TODO: this is a blocking call in main thread. Better to switch contexts
+                    val error = result.errorBody
                     if (error.isNullOrEmpty()) {
                         swapTradeFailureState.call()
                     } else {

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/viewmodels/CoinbaseConvertCryptoViewModel.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/viewmodels/CoinbaseConvertCryptoViewModel.kt
@@ -122,7 +122,7 @@ class CoinbaseConvertCryptoViewModel @Inject constructor(
             is ResponseResource.Failure -> {
                 _showLoading.value = false
 
-                val error = result.errorBody?.string()
+                val error = result.errorBody
                 if (error.isNullOrEmpty()) {
                     swapTradeFailedCallback.call()
                 } else {

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/viewmodels/CoinbaseConvertCryptoViewModel.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/viewmodels/CoinbaseConvertCryptoViewModel.kt
@@ -40,6 +40,7 @@ import org.dash.wallet.integration.coinbase_integration.CoinbaseConstants
 import org.dash.wallet.integration.coinbase_integration.model.*
 import org.dash.wallet.integration.coinbase_integration.network.ResponseResource
 import org.dash.wallet.integration.coinbase_integration.repository.CoinBaseRepositoryInt
+import org.dash.wallet.integration.coinbase_integration.utils.CoinbaseConfig
 import javax.inject.Inject
 
 @ExperimentalCoroutinesApi
@@ -47,6 +48,7 @@ import javax.inject.Inject
 class CoinbaseConvertCryptoViewModel @Inject constructor(
     private val coinBaseRepository: CoinBaseRepositoryInt,
     val userPreference: Configuration,
+    private val config: CoinbaseConfig,
     private val walletDataProvider: WalletDataProvider,
     var exchangeRates: ExchangeRatesProvider,
     var networkState: NetworkStateInt,
@@ -154,6 +156,10 @@ class CoinbaseConvertCryptoViewModel @Inject constructor(
 
     fun logEvent(eventName: String) {
         analyticsService.logEvent(eventName, bundleOf())
+    }
+
+    suspend fun getLastBalance(): Coin {
+        return Coin.valueOf(config.getPreference(CoinbaseConfig.LAST_BALANCE) ?: 0)
     }
 
     private fun isValidCoinBaseAccount(

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/viewmodels/EnterTwoFaCodeViewModel.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integration/coinbase_integration/viewmodels/EnterTwoFaCodeViewModel.kt
@@ -95,7 +95,7 @@ class EnterTwoFaCodeViewModel @Inject constructor(
                 is ResponseResource.Failure -> {
                     _loadingState.value = false
                     try {
-                        val error = result.errorBody?.string()
+                        val error = result.errorBody
                         if (result.errorCode == 400 || result.errorCode == 402 || result.errorCode == 429) {
                             error?.let { errorMsg ->
                                 val errorContent = CoinbaseErrorResponse.getErrorMessage(errorMsg)

--- a/integrations/coinbase/src/test/java/org/dash/wallet/integration/coinbase_integration/CoinBaseRepositoryTest.kt
+++ b/integrations/coinbase/src/test/java/org/dash/wallet/integration/coinbase_integration/CoinBaseRepositoryTest.kt
@@ -29,6 +29,7 @@ import org.dash.wallet.integration.coinbase_integration.network.ResponseResource
 import org.dash.wallet.integration.coinbase_integration.repository.CoinBaseRepository
 import org.dash.wallet.integration.coinbase_integration.service.CoinBaseAuthApi
 import org.dash.wallet.integration.coinbase_integration.service.CoinBaseServicesApi
+import org.dash.wallet.integration.coinbase_integration.utils.CoinbaseConfig
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.`is`
 import org.junit.Before
@@ -38,6 +39,7 @@ class CoinBaseRepositoryTest {
     @MockK lateinit var coinBaseServicesApi: CoinBaseServicesApi
     @MockK lateinit var coinBaseAuthApi: CoinBaseAuthApi
     @MockK lateinit var configuration: Configuration
+    @MockK lateinit var config: CoinbaseConfig
     @MockK lateinit var placeBuyOrderMapper: PlaceBuyOrderMapper
     @MockK lateinit var swapTradeMapper: SwapTradeMapper
     @MockK lateinit var commitBuyOrderMapper: CommitBuyOrderMapper
@@ -52,6 +54,7 @@ class CoinBaseRepositoryTest {
             coinBaseServicesApi,
             coinBaseAuthApi,
             configuration,
+            config,
             placeBuyOrderMapper,
             swapTradeMapper,
             commitBuyOrderMapper,

--- a/integrations/crowdnode/build.gradle
+++ b/integrations/crowdnode/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation "androidx.navigation:navigation-fragment-ktx:$navigationVersion"
     implementation "androidx.navigation:navigation-ui-ktx:$navigationVersion"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycleVersion"
-    implementation "androidx.datastore:datastore-preferences:1.0.0"
+    implementation "androidx.datastore:datastore-preferences:$datastoreVersion"
 
     // DI
     implementation "com.google.dagger:hilt-android:$hiltVersion"

--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -95,6 +95,7 @@ dependencies {
     // Prefs
     implementation 'androidx.preference:preference-ktx:1.1.1'
     implementation 'com.scottyab:secure-preferences-lib:0.1.7'
+    implementation "androidx.datastore:datastore-preferences:$datastoreVersion"
 
     implementation 'androidx.multidex:multidex:2.0.1'
 

--- a/wallet/src/de/schildbach/wallet/ui/buy_sell/IntegrationOverviewViewModel.kt
+++ b/wallet/src/de/schildbach/wallet/ui/buy_sell/IntegrationOverviewViewModel.kt
@@ -55,7 +55,7 @@ class IntegrationOverviewViewModel @Inject constructor(
             }
 
             is ResponseResource.Failure -> {
-                log.error("Coinbase login error ${response.errorCode}: ${response.errorBody?.string() ?: "empty"}")
+                log.error("Coinbase login error ${response.errorCode}: ${response.errorBody ?: "empty"}")
             }
         }
 


### PR DESCRIPTION
Base ids of currencies are required for making swaps with them. The request to get base ids returns 100kb of data and often times out, so we want to cache them.

## Issue being fixed or feature implemented
- Added caching for Coinbase network layer in general.
- Added custom cache for the `assets/prices` endpoint.
- Added datastore config for Coinbase and began to move some prefs in there.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
