### PR TITLE
fix: integration sample on Android 11+

### DIFF
--- a/sample-integration-android/AndroidManifest.xml
+++ b/sample-integration-android/AndroidManifest.xml
@@ -14,7 +14,14 @@
         android:normalScreens="true"
         android:smallScreens="true" />
 
-	<application android:label="Dash in-app payment sample"
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="dash" />
+        </intent>
+    </queries>
+
+    <application android:label="Dash in-app payment sample"
         android:name="androidx.multidex.MultiDexApplication">
 
 		<activity


### PR DESCRIPTION
Android 11 requires apps that want to interact with other apps to declare visibility queries explicitly.
https://developer.android.com/training/package-visibility/declaring

## Issue being fixed or feature implemented
- Added `dash` queries element to the integration sample manifest.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
