### PR TITLE
feat(explore): force sync button for TestNet builds [NMA-1446]

### DIFF
--- a/wallet/res/layout/activity_about.xml
+++ b/wallet/res/layout/activity_about.xml
@@ -63,20 +63,44 @@
         android:background="@drawable/rounded_background"
         android:theme="@style/SecondaryBackground">
 
-        <TextView
-            style="@style/Overline.Tertiary"
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="15dp"
-            android:text="@string/about_last_explore_device_sync" />
+            android:layout_height="wrap_content">
 
-        <TextView
-            android:id="@+id/explore_dash_last_device_sync"
-            style="@style/Caption"
-            android:layout_marginHorizontal="15dp"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            tools:text="Apr 27, 5:31 pm" />
+            <TextView
+                android:id="@+id/last_sync_label"
+                style="@style/Overline.Tertiary"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="15dp"
+                android:text="@string/about_last_explore_device_sync"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/force_sync_btn" />
+
+            <TextView
+                android:id="@+id/explore_dash_last_device_sync"
+                style="@style/Caption"
+                android:layout_marginHorizontal="15dp"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                tools:text="Apr 27, 5:31 pm"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/force_sync_btn"
+                app:layout_constraintTop_toBottomOf="@id/last_sync_label" />
+
+            <ImageButton
+                android:id="@+id/force_sync_btn"
+                android:layout_width="34dp"
+                android:layout_height="34dp"
+                style="@style/Button.Tertiary.Square"
+                android:layout_marginEnd="10dp"
+                android:src="@drawable/ic_refresh_white_24dp"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:tint="@color/content_tertiary" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
         <View
             android:layout_width="match_parent"

--- a/wallet/src/de/schildbach/wallet/WalletApplication.java
+++ b/wallet/src/de/schildbach/wallet/WalletApplication.java
@@ -276,25 +276,8 @@ public class WalletApplication extends MultiDexApplication
     }
 
     private void syncExploreData() {
-        Data.Builder inputData = new Data.Builder().putBoolean(
-                ExploreSyncWorker.USE_TEST_DB_KEY,
-                !Constants.NETWORK_PARAMETERS.getId().equals(NetworkParameters.ID_MAINNET)
-        );
-        OneTimeWorkRequest syncDataWorkRequest =
-                new OneTimeWorkRequest.Builder(ExploreSyncWorker.class)
-                        .setBackoffCriteria(
-                                BackoffPolicy.EXPONENTIAL,
-                                WorkRequest.DEFAULT_BACKOFF_DELAY_MILLIS,
-                                TimeUnit.MILLISECONDS
-                        )
-                        .setInputData(inputData.build())
-                        .build();
-
-        WorkManager.getInstance(this.getApplicationContext()).enqueueUniqueWork(
-                "Sync Explore Data",
-                ExistingWorkPolicy.KEEP,
-                syncDataWorkRequest
-        );
+        boolean isMainNet = Constants.NETWORK_PARAMETERS.getId().equals(NetworkParameters.ID_MAINNET);
+        ExploreSyncWorker.Companion.run(getApplicationContext(), isMainNet);
     }
 
     public void fullInitialization() {

--- a/wallet/src/de/schildbach/wallet/ui/more/AboutActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/more/AboutActivity.kt
@@ -25,6 +25,7 @@ import android.text.format.DateUtils
 import androidx.activity.viewModels
 import androidx.core.view.isVisible
 import dagger.hilt.android.AndroidEntryPoint
+import de.schildbach.wallet.Constants
 import de.schildbach.wallet.ui.LockScreenActivity
 import de.schildbach.wallet.ui.ReportIssueDialogBuilder
 import de.schildbach.wallet_test.BuildConfig
@@ -32,11 +33,18 @@ import de.schildbach.wallet_test.R
 import de.schildbach.wallet_test.databinding.ActivityAboutBinding
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.bitcoinj.core.VersionMessage
+import org.bitcoinj.params.MainNetParams
 import org.dash.wallet.common.services.analytics.AnalyticsConstants
+import org.dash.wallet.features.exploredash.ExploreSyncWorker
+import org.slf4j.LoggerFactory
 
 @AndroidEntryPoint
 @ExperimentalCoroutinesApi
 class AboutActivity : LockScreenActivity() {
+    companion object {
+        private val log = LoggerFactory.getLogger(AboutActivity::class.java)
+    }
+
     private val viewModel by viewModels<AboutViewModel>()
     private lateinit var binding: ActivityAboutBinding
 
@@ -59,6 +67,16 @@ class AboutActivity : LockScreenActivity() {
         binding.contactSupport.setOnClickListener {
             viewModel.logEvent(AnalyticsConstants.Settings.ABOUT_SUPPORT)
             handleReportIssue()
+        }
+
+        val isMainNet = Constants.NETWORK_PARAMETERS == MainNetParams.get()
+        binding.forceSyncBtn.isVisible = !isMainNet
+        binding.forceSyncBtn.setOnClickListener {
+            try {
+                ExploreSyncWorker.run(applicationContext, isMainNet)
+            } catch (ex: Exception) {
+                log.error(ex.message, ex)
+            }
         }
 
         showExploreDashSyncStatus()


### PR DESCRIPTION
We want a button to force the Explore sync process for testing convenience.

## Issue being fixed or feature implemented
- Added a button in the About screen that triggers the sync. Hidden in mainnet builds.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
