### PR TITLE
fix: clearing Explore prefs on wallet reset

### DIFF
--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/di/ExploreDashModule.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/di/ExploreDashModule.kt
@@ -44,9 +44,11 @@ import org.dash.wallet.features.exploredash.services.UserLocationStateInt
 @InstallIn(SingletonComponent::class)
 abstract class ExploreDashModule {
     companion object {
+        val PREFERENCES_FILENAME = "explore"
+
         @Provides
         fun provideSharedPrefs(@ApplicationContext context: Context): SharedPreferences {
-            return context.getSharedPreferences("explore", Context.MODE_PRIVATE)
+            return context.getSharedPreferences(PREFERENCES_FILENAME, Context.MODE_PRIVATE)
         }
 
         @Provides

--- a/wallet/src/de/schildbach/wallet/WalletApplication.java
+++ b/wallet/src/de/schildbach/wallet/WalletApplication.java
@@ -30,6 +30,7 @@ import android.app.job.JobScheduler;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.database.sqlite.SQLiteException;
@@ -85,6 +86,7 @@ import org.dash.wallet.common.transactions.filters.TransactionFilter;
 import org.dash.wallet.common.transactions.TransactionWrapper;
 import org.dash.wallet.features.exploredash.ExploreSyncWorker;
 import org.dash.wallet.common.services.TransactionMetadataProvider;
+import org.dash.wallet.features.exploredash.di.ExploreDashModule;
 import org.dash.wallet.integration.coinbase_integration.service.CoinBaseClientConstants;
 import de.schildbach.wallet.ui.buy_sell.LiquidClient;
 import org.dash.wallet.integration.uphold.api.UpholdClient;
@@ -688,6 +690,11 @@ public class WalletApplication extends MultiDexApplication
         }
     }
 
+    private void clearExploreConfig() {
+        SharedPreferences prefs = getSharedPreferences(ExploreDashModule.Companion.getPREFERENCES_FILENAME(), Context.MODE_PRIVATE);
+        prefs.edit().clear().apply();
+    }
+
     private void clearWebCookies() {
         CookieManager.getInstance().removeAllCookies(null);
         CookieManager.getInstance().flush();
@@ -910,6 +917,7 @@ public class WalletApplication extends MultiDexApplication
         shutdownAndDeleteWallet();
         cleanupFiles();
         config.clear();
+        clearExploreConfig();
         clearDatastorePrefs();
         clearWebCookies();
         notifyWalletWipe();


### PR DESCRIPTION
When the wallet is reset, Explore prefs are not cleared. This causes the data to be empty in some cases because the saved timestamp is higher than the preloaded db or remote timestamp.

## Issue being fixed or feature implemented
- Clear Explore prefs when the wallet is reset.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
