### PR TITLE
fix: retain gift card response in release builds

### DIFF
--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/model/purchase/PurchaseGiftCardResponse.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/model/purchase/PurchaseGiftCardResponse.kt
@@ -20,7 +20,7 @@ import com.google.gson.annotations.SerializedName
 
 data class PurchaseGiftCardResponse(
     @SerializedName("AccessToken") val accessToken: Any? = null,
-    @SerializedName("Data") val `data`: Data? = null,
+    @SerializedName("Data") val `data`: Data? = Data(),
     @SerializedName("DelayedToken") val delayedToken: Any? = null,
     @SerializedName("ErrorMessage") val errorMessage: String? = null,
     @SerializedName("IsDelayed") val isDelayed: Boolean? = null,


### PR DESCRIPTION
Proguard removes the data field from `PurchaseGiftCardResponse` class.

## Issue being fixed or feature implemented
- Assign default `Data` instance to the `data` field.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
