### PR TITLE
fix(dashdirect): restore tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         kotlin_version = '1.7.10'
-        coroutines_version = '1.6.4'
+        coroutinesVersion = '1.6.4'
         ok_http_version = '4.9.1'
         dashjVersion = '0.18.3'
         workRuntimeVersion='2.7.1'
@@ -33,6 +33,7 @@ buildscript {
 
         // Tests
         junitVersion = '4.13.2'
+        testCoreVersion = '1.5.0'
         mockitoVersion = '4.0.0'
         espressoVersion = '3.4.0'
         coilVersion = '1.4.0'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation "org.dashj:dashj-core:$dashjVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
 
     // Firebase
     implementation platform("com.google.firebase:firebase-bom:$firebaseVersion")

--- a/common/src/main/java/org/dash/wallet/common/data/BaseConfig.kt
+++ b/common/src/main/java/org/dash/wallet/common/data/BaseConfig.kt
@@ -77,11 +77,11 @@ abstract class BaseConfig(
         return data.map { preferences -> preferences[key] }
     }
 
-    suspend fun <T> get(key: Preferences.Key<T>): T? {
+    open suspend fun <T> get(key: Preferences.Key<T>): T? {
         return data.map { preferences -> preferences[key] }.first()
     }
 
-    suspend fun <T> set(key: Preferences.Key<T>, value: T) {
+    open suspend fun <T> set(key: Preferences.Key<T>, value: T) {
         context.dataStore.edit { preferences ->
             preferences[key] = value
         }

--- a/features/exploredash/build.gradle
+++ b/features/exploredash/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     // Core
     implementation "androidx.core:core-ktx:$jetpackVersion"
     implementation "androidx.appcompat:appcompat:$appCompatVersion"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:$coroutines_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:$coroutinesVersion"
     implementation "androidx.work:work-runtime-ktx:$workRuntimeVersion"
     implementation "org.dashj:dashj-core:$dashjVersion"
 
@@ -114,7 +114,8 @@ dependencies {
 
     // Tests
     testImplementation "junit:junit:$junitVersion"
-    testImplementation 'androidx.test:core-ktx:1.4.0'
+    testImplementation "androidx.test:core-ktx:$testCoreVersion"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoVersion"
     testImplementation "androidx.arch.core:core-testing:$coreTestingVersion"
     testImplementation "org.robolectric:robolectric:4.8.1"

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ExploreDatabase.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ExploreDatabase.kt
@@ -25,8 +25,6 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import androidx.sqlite.db.SupportSQLiteDatabase
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.dash.wallet.common.data.RoomConverters
 import org.dash.wallet.features.exploredash.data.explore.AtmDao

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ExploreDatabase.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ExploreDatabase.kt
@@ -25,6 +25,8 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import androidx.sqlite.db.SupportSQLiteDatabase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import org.dash.wallet.common.data.RoomConverters
 import org.dash.wallet.features.exploredash.data.explore.AtmDao

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/repository/ExploreRepository.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/repository/ExploreRepository.kt
@@ -75,6 +75,7 @@ class GCExploreDatabase @Inject constructor(
 
     private var remoteDataRef: StorageReference? = null
     private var updateTimestampCache = -1L
+
     @VisibleForTesting
     val configScope = CoroutineScope(Dispatchers.IO)
 

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/repository/ExploreRepository.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/repository/ExploreRepository.kt
@@ -18,6 +18,7 @@
 package org.dash.wallet.features.exploredash.repository
 
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseAuthException
 import com.google.firebase.auth.FirebaseUser
@@ -74,7 +75,8 @@ class GCExploreDatabase @Inject constructor(
 
     private var remoteDataRef: StorageReference? = null
     private var updateTimestampCache = -1L
-    private val configScope = CoroutineScope(Dispatchers.IO)
+    @VisibleForTesting
+    val configScope = CoroutineScope(Dispatchers.IO)
 
     override suspend fun getRemoteTimestamp(): Long {
         val remoteDataInfo =

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/utils/ExploreConfig.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/utils/ExploreConfig.kt
@@ -36,7 +36,7 @@ data class ExploreDatabasePrefs(
 )
 
 @Singleton
-class ExploreConfig @Inject constructor(
+open class ExploreConfig @Inject constructor(
     private val context: Context,
     walletDataProvider: WalletDataProvider
 ) : BaseConfig(

--- a/features/exploredash/src/test/java/org/dash/wallet/features/exploredash/ExploreDatabaseTest.kt
+++ b/features/exploredash/src/test/java/org/dash/wallet/features/exploredash/ExploreDatabaseTest.kt
@@ -18,19 +18,19 @@
 package org.dash.wallet.features.exploredash
 
 import android.content.Context
-import android.content.SharedPreferences
 import android.content.res.Resources
 import android.database.sqlite.SQLiteException
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import junit.framework.TestCase.*
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
 import net.lingala.zip4j.ZipFile
 import org.dash.wallet.features.exploredash.repository.GCExploreDatabase
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
+import org.dash.wallet.features.exploredash.utils.ExploreConfig
+import org.junit.*
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.kotlin.*
@@ -38,38 +38,28 @@ import org.robolectric.RobolectricTestRunner
 import java.io.File
 import java.lang.IllegalArgumentException
 import java.lang.RuntimeException
-import kotlin.time.ExperimentalTime
 
-@ExperimentalTime
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 class ExploreDatabaseTest {
     @get:Rule var instantTaskExecutorRule = InstantTaskExecutorRule()
 
     private var timestamp = -1L
-    private val editor = mock<SharedPreferences.Editor>()
-    private val mockPreferences =
-        mock<SharedPreferences> {
-            on { getLong(any(), any()) } doReturn timestamp
-            on { edit() } doReturn editor
-        }
+    private val mockPreferences = mock<ExploreConfig>()
     private val appContext = ApplicationProvider.getApplicationContext<Context>()
     private val repo = GCExploreDatabase(appContext, mockPreferences, mock(), mock())
 
     @Before
     fun setup() {
-        editor.stub {
-            on { putLong(any(), anyLong()) } doAnswer
-                { i ->
-                    timestamp = i.arguments[1] as Long
-                    editor
-                }
+        timestamp = -1L
+        mockPreferences.stub {
+            onBlocking { get<Long>(any()) }.doReturn(timestamp)
+            onBlocking { set(any(), anyLong()) } doAnswer { i -> timestamp = i.arguments[1] as Long }
         }
     }
 
     @Test
-    fun noPreloadedDb_throwAndDoesNotUpdateLocalTimestamp() = runBlocking {
-        timestamp = -1L
-
+    fun noPreloadedDb_throwAndDoesNotUpdateLocalTimestamp() = runTest {
         val dbBuilder =
             Room.databaseBuilder(appContext, ExploreDatabase::class.java, "explore.db").allowMainThreadQueries()
 
@@ -88,9 +78,7 @@ class ExploreDatabaseTest {
     }
 
     @Test
-    fun emptyPreloadedDb_throwDoesNotUpdateLocalTimestamp() = runBlocking {
-        timestamp = -1L
-
+    fun emptyPreloadedDb_throwDoesNotUpdateLocalTimestamp() = runTest {
         val dbBuilder =
             Room.databaseBuilder(appContext, ExploreDatabase::class.java, "explore.db").allowMainThreadQueries()
 
@@ -111,9 +99,7 @@ class ExploreDatabaseTest {
     }
 
     @Test
-    fun badPreloadedDb_throwsAndDoesNotUpdateLocalTimestamp() = runBlocking {
-        timestamp = -1L
-
+    fun badPreloadedDb_throwsAndDoesNotUpdateLocalTimestamp() = runTest {
         val dbBuilder =
             Room.databaseBuilder(appContext, ExploreDatabase::class.java, "explore.db").allowMainThreadQueries()
 
@@ -132,23 +118,24 @@ class ExploreDatabaseTest {
     }
 
     @Test
-    fun goodPreloadedDb_updatesLocalTimestamp() = runBlocking {
-        timestamp = -1L
+    fun goodPreloadedDb_updatesLocalTimestamp() = runTest {
+        repo.configScope.launch {
+            val dbBuilder =
+                Room.databaseBuilder(appContext, ExploreDatabase::class.java, "explore.db").allowMainThreadQueries()
 
-        val dbBuilder =
-            Room.databaseBuilder(appContext, ExploreDatabase::class.java, "explore.db").allowMainThreadQueries()
+            val resource = javaClass.classLoader?.getResource("explore.db")
+            val updateFile = File(resource?.file ?: throw Resources.NotFoundException("explore.db not found"))
+            val zipFile = ZipFile(updateFile)
+            val comment = zipFile.comment.split("#".toRegex()).toTypedArray()
+            val databaseTimestamp = comment[0].toLong()
+            zipFile.close()
 
-        val resource = javaClass.classLoader?.getResource("explore.db")
-        val updateFile = File(resource?.file ?: throw Resources.NotFoundException("explore.db not found"))
-        val zipFile = ZipFile(updateFile)
-        val comment = zipFile.comment.split("#".toRegex()).toTypedArray()
-        val databaseTimestamp = comment[0].toLong()
-        zipFile.close()
+            val database = ExploreDatabase.preloadAndOpen(dbBuilder, repo, updateFile)
 
-        val database = ExploreDatabase.preloadAndOpen(dbBuilder, repo, updateFile)
-
-        assertTrue("This case should update the timestamp", timestamp > 0)
-        assertEquals("Wrong timestamp set;", databaseTimestamp, timestamp)
-        database.close()
+            println(timestamp)
+            assertTrue("This case should update the timestamp", timestamp > 0)
+            assertEquals("Wrong timestamp set;", databaseTimestamp, timestamp)
+            database.close()
+        }
     }
 }

--- a/features/exploredash/src/test/java/org/dash/wallet/features/exploredash/ExploreViewModelTest.kt
+++ b/features/exploredash/src/test/java/org/dash/wallet/features/exploredash/ExploreViewModelTest.kt
@@ -17,19 +17,15 @@
 
 package org.dash.wallet.features.exploredash
 
-import android.content.Context
-import android.net.ConnectivityManager
-import android.net.NetworkCapabilities.TRANSPORT_CELLULAR
-import android.net.NetworkCapabilities.TRANSPORT_WIFI
-import android.net.NetworkInfo
-import android.net.NetworkRequest
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runBlocking
 import org.dash.wallet.common.data.Resource
+import org.dash.wallet.common.services.NetworkStateInt
 import org.dash.wallet.common.services.analytics.AnalyticsService
 import org.dash.wallet.features.exploredash.data.explore.ExploreDataSource
 import org.dash.wallet.features.exploredash.data.explore.model.GeoBounds
@@ -40,8 +36,8 @@ import org.dash.wallet.features.exploredash.repository.DataSyncStatusService
 import org.dash.wallet.features.exploredash.services.UserLocationStateInt
 import org.dash.wallet.features.exploredash.ui.explore.ExploreViewModel
 import org.dash.wallet.features.exploredash.ui.explore.FilterMode
+import org.dash.wallet.features.exploredash.utils.ExploreConfig
 import org.junit.Assert.assertEquals
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
@@ -58,227 +54,202 @@ class ExploreViewModelTest {
                 updateDate = "2021-09-08 12:22",
                 deeplink = "",
                 paymentMethod = "gift card"
-            )
-                .apply {
-                    id = 1
-                    name = "Google Play"
-                    active = true
-                    address1 = "Address1 1"
-                    address2 = "Address2 1"
-                    address3 = "Address3 1"
-                    address4 = "Address4 1 Birmingham"
-                    latitude = 35.223312
-                    longitude = -119.130063
-                    territory = "Alabama"
-                    website = ""
-                    phone = ""
-                    type = "online"
-                    logoLocation = ""
-                },
+            ).apply {
+                id = 1
+                name = "Google Play"
+                active = true
+                address1 = "Address1 1"
+                address2 = "Address2 1"
+                address3 = "Address3 1"
+                address4 = "Address4 1 Birmingham"
+                latitude = 35.223312
+                longitude = -119.130063
+                territory = "Alabama"
+                website = ""
+                phone = ""
+                type = "online"
+                logoLocation = ""
+            },
             Merchant(
                 plusCode = "",
                 addDate = "2021-09-09 11:23",
                 updateDate = "2021-09-09 12:23",
                 deeplink = "",
                 paymentMethod = "dash"
-            )
-                .apply {
-                    id = 2
-                    name = "Amazon"
-                    active = true
-                    address1 = "Address1 2"
-                    address2 = "Address2 2"
-                    address3 = "Address3 2"
-                    address4 = "Address4 2 New Orleans"
-                    latitude = 35.223312
-                    longitude = -119.130063
-                    territory = "Louisiana"
-                    website = ""
-                    phone = ""
-                    type = "both"
-                    logoLocation = ""
-                },
+            ).apply {
+                id = 2
+                name = "Amazon"
+                active = true
+                address1 = "Address1 2"
+                address2 = "Address2 2"
+                address3 = "Address3 2"
+                address4 = "Address4 2 New Orleans"
+                latitude = 35.223312
+                longitude = -119.130063
+                territory = "Louisiana"
+                website = ""
+                phone = ""
+                type = "both"
+                logoLocation = ""
+            },
             Merchant(
                 plusCode = "",
                 addDate = "2021-09-10 11:24",
                 updateDate = "2021-09-10 12:24",
                 deeplink = "",
                 paymentMethod = "dash"
-            )
-                .apply {
-                    id = 3
-                    name = "Bark Box"
-                    active = true
-                    address1 = "Address1 3"
-                    address2 = "Address2 3"
-                    address3 = "Address3 3"
-                    address4 = "Address4 3 Houston"
-                    latitude = 35.223312
-                    longitude = -119.130063
-                    territory = "Texas"
-                    website = ""
-                    phone = ""
-                    type = "physical"
-                    logoLocation = ""
-                },
+            ).apply {
+                id = 3
+                name = "Bark Box"
+                active = true
+                address1 = "Address1 3"
+                address2 = "Address2 3"
+                address3 = "Address3 3"
+                address4 = "Address4 3 Houston"
+                latitude = 35.223312
+                longitude = -119.130063
+                territory = "Texas"
+                website = ""
+                phone = ""
+                type = "physical"
+                logoLocation = ""
+            },
             Merchant(
                 plusCode = "",
                 addDate = "2021-09-11 11:25",
                 updateDate = "2021-09-11 12:25",
                 deeplink = "",
                 paymentMethod = "gift card"
-            )
-                .apply {
-                    id = 4
-                    name = "Dunkin Donuts"
-                    active = true
-                    address1 = "Address1 4"
-                    address2 = "Address2 4"
-                    address3 = "Address3 4"
-                    address4 = "Address4 4 Austin"
-                    latitude = 35.223312
-                    longitude = -119.130063
-                    territory = "Texas"
-                    website = ""
-                    phone = ""
-                    type = "physical"
-                    logoLocation = ""
-                },
+            ).apply {
+                id = 4
+                name = "Dunkin Donuts"
+                active = true
+                address1 = "Address1 4"
+                address2 = "Address2 4"
+                address3 = "Address3 4"
+                address4 = "Address4 4 Austin"
+                latitude = 35.223312
+                longitude = -119.130063
+                territory = "Texas"
+                website = ""
+                phone = ""
+                type = "physical"
+                logoLocation = ""
+            },
             Merchant(
                 plusCode = "",
                 addDate = "2021-09-11 11:25",
                 updateDate = "2021-09-11 12:25",
                 deeplink = "",
                 paymentMethod = "dash"
-            )
-                .apply {
-                    id = 5
-                    name = "Merchant 1"
-                    active = true
-                    address1 = "Address1 5"
-                    address2 = "Address2 5"
-                    address3 = "Address3 5"
-                    address4 = "Address4 5"
-                    latitude = 35.223312
-                    longitude = -119.130063
-                    territory = ""
-                    website = ""
-                    phone = ""
-                    type = "online"
-                    logoLocation = ""
-                },
+            ).apply {
+                id = 5
+                name = "Merchant 1"
+                active = true
+                address1 = "Address1 5"
+                address2 = "Address2 5"
+                address3 = "Address3 5"
+                address4 = "Address4 5"
+                latitude = 35.223312
+                longitude = -119.130063
+                territory = ""
+                website = ""
+                phone = ""
+                type = "online"
+                logoLocation = ""
+            },
             Merchant(
                 plusCode = "",
                 addDate = "2021-09-11 11:25",
                 updateDate = "2021-09-11 12:25",
                 deeplink = "",
                 paymentMethod = "gift card"
-            )
-                .apply {
-                    id = 6
-                    name = "Merchant 2"
-                    active = true
-                    address1 = "Address1 6"
-                    address2 = "Address2 6"
-                    address3 = "Address3 6"
-                    address4 = "Address4 6"
-                    latitude = 35.223312
-                    longitude = -119.130063
-                    territory = ""
-                    website = ""
-                    phone = ""
-                    type = "both"
-                    logoLocation = ""
-                },
+            ).apply {
+                id = 6
+                name = "Merchant 2"
+                active = true
+                address1 = "Address1 6"
+                address2 = "Address2 6"
+                address3 = "Address3 6"
+                address4 = "Address4 6"
+                latitude = 35.223312
+                longitude = -119.130063
+                territory = ""
+                website = ""
+                phone = ""
+                type = "both"
+                logoLocation = ""
+            },
             Merchant(
                 plusCode = "",
                 addDate = "2021-09-11 11:25",
                 updateDate = "2021-09-11 12:25",
                 deeplink = "",
                 paymentMethod = "dash"
-            )
-                .apply {
-                    id = 7
-                    name = "Merchant 3"
-                    active = true
-                    address1 = "Address1 7"
-                    address2 = "Address2 7"
-                    address3 = "Address3 7"
-                    address4 = "Address4 7"
-                    latitude = 35.223312
-                    longitude = -119.130063
-                    territory = "Louisiana"
-                    website = ""
-                    phone = ""
-                    type = "physical"
-                    logoLocation = ""
-                },
+            ).apply {
+                id = 7
+                name = "Merchant 3"
+                active = true
+                address1 = "Address1 7"
+                address2 = "Address2 7"
+                address3 = "Address3 7"
+                address4 = "Address4 7"
+                latitude = 35.223312
+                longitude = -119.130063
+                territory = "Louisiana"
+                website = ""
+                phone = ""
+                type = "physical"
+                logoLocation = ""
+            },
             Merchant(
                 plusCode = "",
                 addDate = "",
                 updateDate = "",
                 deeplink = "https://dashdirect.page.link/AMC",
                 paymentMethod = "gift card"
-            )
-                .apply {
-                    id = 19630
-                    name = "AMC Theatres"
-                    active = true
-                    address1 = "3760 Princeton Lakes Pkwy."
-                    latitude = 33.658332
-                    longitude = -84.5100182
-                    website = "http://www.amctheatres.com"
-                    territory = "Georgia"
-                    city = "Atlanta"
-                    type = "both"
-                    logoLocation = "https://api.giftango.com/imageservice/Images/042507_logo_600x380.png"
-                },
+            ).apply {
+                id = 19630
+                name = "AMC Theatres"
+                active = true
+                address1 = "3760 Princeton Lakes Pkwy."
+                latitude = 33.658332
+                longitude = -84.5100182
+                website = "http://www.amctheatres.com"
+                territory = "Georgia"
+                city = "Atlanta"
+                type = "both"
+                logoLocation = "https://api.giftango.com/imageservice/Images/042507_logo_600x380.png"
+            },
             Merchant(
                 plusCode = "",
                 addDate = "",
                 updateDate = "",
                 deeplink = "https://dashdirect.page.link/Applebees",
                 paymentMethod = "gift card"
-            )
-                .apply {
-                    id = 20826
-                    name = "Applebee's"
-                    active = true
-                    address1 = "New Spring Road S.E."
-                    latitude = 33.8846705
-                    longitude = -84.4731042
-                    website = "http://www.applebees.com"
-                    territory = "Georgia"
-                    city = "Atlanta"
-                    type = "both"
-                    logoLocation = "https://api.giftango.com/imageservice/Images/0117472_logo_600x380.png"
-                }
+            ).apply {
+                id = 20826
+                name = "Applebee's"
+                active = true
+                address1 = "New Spring Road S.E."
+                latitude = 33.8846705
+                longitude = -84.4731042
+                website = "http://www.applebees.com"
+                territory = "Georgia"
+                city = "Atlanta"
+                type = "both"
+                logoLocation = "https://api.giftango.com/imageservice/Images/0117472_logo_600x380.png"
+            }
         )
 
     @get:Rule var rule: TestRule = InstantTaskExecutorRule()
 
-    private val networkInfo =
-        mock<NetworkInfo> {
-            on { isConnectedOrConnecting } doReturn true
-            on { isAvailable } doReturn true
-            on { isConnected } doReturn true
-        }
+    private val networkState = mock<NetworkStateInt> {
+        on { isConnected } doReturn MutableStateFlow(true)
+    }
 
-    private val connectivityManager =
-        mock<ConnectivityManager> { on { getNetworkInfo(ConnectivityManager.TYPE_WIFI) } doReturn networkInfo }
-
-    private val context =
-        mock<Context> { on { getSystemService(Context.CONNECTIVITY_SERVICE) } doReturn connectivityManager }
-
-    private val networkRequestBuilder =
-        mock<NetworkRequest.Builder> {
-            on { addTransportType(TRANSPORT_CELLULAR) } doReturn mock
-            on { addTransportType(TRANSPORT_WIFI) } doReturn mock
-        }
-
-    @Before
-    fun before() {
-        networkRequestBuilder.addTransportType(TRANSPORT_WIFI)
+    private val mockPreferences = mock<ExploreConfig>().stub {
+        onBlocking { get<Long>(any()) }.doReturn(-1L)
     }
 
     @Test
@@ -303,7 +274,14 @@ class ExploreViewModelTest {
                 }
             val analyticsService = mock<AnalyticsService>()
 
-            val viewModel = ExploreViewModel(context, dataSource, locationState, dataSyncStatus, analyticsService)
+            val viewModel = ExploreViewModel(
+                dataSource,
+                locationState,
+                dataSyncStatus,
+                networkState,
+                mockPreferences,
+                analyticsService
+            )
             viewModel.setSelectedTerritory(territory)
             viewModel.setFilterMode(FilterMode.All)
             viewModel.searchBounds = GeoBounds.noBounds
@@ -351,7 +329,14 @@ class ExploreViewModelTest {
                 }
             val analyticsService = mock<AnalyticsService>()
 
-            val viewModel = ExploreViewModel(context, dataSource, locationState, dataSyncStatus, analyticsService)
+            val viewModel = ExploreViewModel(
+                dataSource,
+                locationState,
+                dataSyncStatus,
+                networkState,
+                mockPreferences,
+                analyticsService
+            )
             viewModel.setFilterMode(FilterMode.Nearby)
             viewModel.searchBounds = bounds
             viewModel.paymentMethodFilter = PaymentMethod.DASH
@@ -403,7 +388,14 @@ class ExploreViewModelTest {
                 }
             val analyticsService = mock<AnalyticsService>()
 
-            val viewModel = ExploreViewModel(context, dataSource, locationState, dataSyncStatus, analyticsService)
+            val viewModel = ExploreViewModel(
+                dataSource,
+                locationState,
+                dataSyncStatus,
+                networkState,
+                mockPreferences,
+                analyticsService
+            )
             viewModel.setSelectedTerritory(territory)
             viewModel.searchBounds = GeoBounds.noBounds
             viewModel.setFilterMode(FilterMode.All)
@@ -447,10 +439,7 @@ class ExploreViewModelTest {
                                 merchants
                                     .filter { it.type != MerchantType.ONLINE }
                                     .filter {
-                                        (
-                                            it.latitude
-                                                ?: 0.0
-                                            ) < bounds.northLat &&
+                                        (it.latitude ?: 0.0) < bounds.northLat &&
                                             (it.latitude ?: 0.0) > bounds.southLat &&
                                             (it.longitude ?: 0.0) < bounds.eastLng &&
                                             (it.longitude ?: 0.0) > bounds.westLng
@@ -468,7 +457,14 @@ class ExploreViewModelTest {
                 }
             val analyticsService = mock<AnalyticsService>()
 
-            val viewModel = ExploreViewModel(context, dataSource, locationMock, dataSyncStatus, analyticsService)
+            val viewModel = ExploreViewModel(
+                dataSource,
+                locationMock,
+                dataSyncStatus,
+                networkState,
+                mockPreferences,
+                analyticsService
+            )
             viewModel.searchBounds =
                 GeoBounds(90.0, 180.0, -90.0, -180.0, userLat, userLng).apply {
                     zoomLevel = ExploreViewModel.MIN_ZOOM_LEVEL + 1
@@ -480,10 +476,7 @@ class ExploreViewModelTest {
                     .filter { (it.type == MerchantType.PHYSICAL || it.type == MerchantType.BOTH) }
                     .filter { it.active != false }
                     .filter {
-                        (
-                            it.latitude
-                                ?: 0.0
-                            ) < bounds.northLat &&
+                        (it.latitude ?: 0.0) < bounds.northLat &&
                             (it.latitude ?: 0.0) > bounds.southLat &&
                             (it.longitude ?: 0.0) < bounds.eastLng &&
                             (it.longitude ?: 0.0) > bounds.westLng
@@ -509,7 +502,14 @@ class ExploreViewModelTest {
                 }
             val analyticsService = mock<AnalyticsService>()
 
-            val viewModel = ExploreViewModel(context, dataSource, locationMock, dataSyncStatus, analyticsService)
+            val viewModel = ExploreViewModel(
+                dataSource,
+                locationMock,
+                dataSyncStatus,
+                networkState,
+                mockPreferences,
+                analyticsService
+            )
             viewModel.setPhysicalResults(merchants)
             viewModel.onMapMarkerSelected(5)
 

--- a/integrations/coinbase/build.gradle
+++ b/integrations/coinbase/build.gradle
@@ -92,7 +92,7 @@ dependencies {
     testImplementation "io.mockk:mockk:1.9.3"
     implementation 'org.hamcrest:hamcrest:2.2'
     testImplementation "androidx.test:core-ktx:1.4.0"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion"
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/integrations/crowdnode/build.gradle
+++ b/integrations/crowdnode/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     // Tests
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoVersion"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion"
     testImplementation "androidx.arch.core:core-testing:$coreTestingVersion"
     testImplementation 'com.google.guava:guava:28.2-android'
     androidTestImplementation "androidx.test.ext:junit:$junitExtVersion"

--- a/integrations/crowdnode/src/test/java/org/dash/wallet/integrations/crowdnode/CrowdNodeApiAggregatorTest.kt
+++ b/integrations/crowdnode/src/test/java/org/dash/wallet/integrations/crowdnode/CrowdNodeApiAggregatorTest.kt
@@ -45,13 +45,13 @@ import kotlin.time.ExperimentalTime
 @ExperimentalCoroutinesApi
 class CrowdNodeApiAggregatorTest {
     private val networkParams = TestNet3Params.get()
-    private val welcomeData = "020000000263779831af3973f7f8f1c390c363c3eae19bcc60c0296852ecea832e16022769010000006a473044022042dcb3849c7018cc99879bcea881284c3a5848ae5caf4c7d1390a9cbde812e780220557da9f91b088c5a59db6ed82ea34e5f5a4f5d1bf10fa5ccff920c4a461ecb4a012102bf7c36100b0d394e79a1704b8bf9e030a62e139a293f5da891671c56d555f732feffffff90bd741046ab7e68d532ac0466920729f3070b1184a4703ac620601ff594d0ff000000006a47304402202b512d7a20279a1aed12dd05619a2951412ff3d0ded96327a43ddd02dba0c1ad0220337f62aafb3721575e2ccd3c6bac97591186e6cca92f54896e08c1cd529e7be6012102bf7c36100b0d394e79a1704b8bf9e030a62e139a293f5da891671c56d555f732feffffff02244e0000000000001976a914f57766c540e7e165092e739e115383bd04d2c21888ac5c1dc4680a0000001976a9140d5bcbeeb459af40f97fcb4a98e9d1ed13e904c888acfbdc0a00"
+    private val welcomeData = "020000000263779831af3973f7f8f1c390c363c3eae19bcc60c0296852ecea832e16022769010000006a473044022042dcb3849c7018cc99879bcea881284c3a5848ae5caf4c7d1390a9cbde812e780220557da9f91b088c5a59db6ed82ea34e5f5a4f5d1bf10fa5ccff920c4a461ecb4a012102bf7c36100b0d394e79a1704b8bf9e030a62e139a293f5da891671c56d555f732feffffff90bd741046ab7e68d532ac0466920729f3070b1184a4703ac620601ff594d0ff000000006a47304402202b512d7a20279a1aed12dd05619a2951412ff3d0ded96327a43ddd02dba0c1ad0220337f62aafb3721575e2ccd3c6bac97591186e6cca92f54896e08c1cd529e7be6012102bf7c36100b0d394e79a1704b8bf9e030a62e139a293f5da891671c56d555f732feffffff02244e0000000000001976a914f57766c540e7e165092e739e115383bd04d2c21888ac5c1dc4680a0000001976a9140d5bcbeeb459af40f97fcb4a98e9d1ed13e904c888acfbdc0a00" // ktlint-disable max-line-length
     private val welcomeResponseTx = Transaction(networkParams, Utils.HEX.decode(welcomeData))
-    private val confirmationTxData = "01000000016fdb75611fd8892d8d19707f0d0958da5b930c635750f2c8c5bf5a48458a8ffd000000006b483045022100ff77055377b33afb8fc2f622fda59816394a567c50e98569fe8ab68d797948b802204b05504b3f837e80f4d0d8c3c6d98107e770572a8eaae66ddd14a660fe9674f101210275ab1f1c864e594c5e075ac45fbd01a45285701e429b842f8d0a1c872cf3a7baffffffff0149d00000000000001976a9140d5bcbeeb459af40f97fcb4a98e9d1ed13e904c888ac00000000"
+    private val confirmationTxData = "01000000016fdb75611fd8892d8d19707f0d0958da5b930c635750f2c8c5bf5a48458a8ffd000000006b483045022100ff77055377b33afb8fc2f622fda59816394a567c50e98569fe8ab68d797948b802204b05504b3f837e80f4d0d8c3c6d98107e770572a8eaae66ddd14a660fe9674f101210275ab1f1c864e594c5e075ac45fbd01a45285701e429b842f8d0a1c872cf3a7baffffffff0149d00000000000001976a9140d5bcbeeb459af40f97fcb4a98e9d1ed13e904c888ac00000000" // ktlint-disable max-line-length
     private val confirmationTx = Transaction(networkParams, Utils.HEX.decode(confirmationTxData))
 
     private val localConfig = mock<CrowdNodeConfig> {
-        onBlocking { getPreference(CrowdNodeConfig.BACKGROUND_ERROR) } doReturn ""
+        onBlocking { get(CrowdNodeConfig.BACKGROUND_ERROR) } doReturn ""
     }
 
     private val globalConfig = mock<Configuration> {
@@ -78,11 +78,11 @@ class CrowdNodeApiAggregatorTest {
 
     @Before
     fun setup() {
-        val welcomeConnected = "0200000002f7f6beb8d49ec4639394a663cd3ae08d9382ecfbb38e9cb85deaf835b74ad1be000000006a47304402202b467d0ae5f40633500096b01dbc5952efca40d50143739dc92f2b9fc8cf479c02206d3a04f11538ce4ff664b168abad0b02d135b3ec571b390616ac76f888e0ecaf012102bf7c36100b0d394e79a1704b8bf9e030a62e139a293f5da891671c56d555f732feffffffd979b8815c9a17e956011b7b9767dcb1237501832392a1f5d2ed2e0d785754c2010000006a473044022079f2e9dd53d838978fe82a6034894c062381ac32bce190e0d862efff7e4a5ef002200eee7a5bd39f084cd8dc73d50d1fc1388e998750db3fadbd74ff2537bef0cd8e012102bf7c36100b0d394e79a1704b8bf9e030a62e139a293f5da891671c56d555f732feffffff02224e0000000000001976a914f57766c540e7e165092e739e115383bd04d2c21888acf91ec3680a0000001976a9140d5bcbeeb459af40f97fcb4a98e9d1ed13e904c888acfadc0a00"
+        val welcomeConnected = "0200000002f7f6beb8d49ec4639394a663cd3ae08d9382ecfbb38e9cb85deaf835b74ad1be000000006a47304402202b467d0ae5f40633500096b01dbc5952efca40d50143739dc92f2b9fc8cf479c02206d3a04f11538ce4ff664b168abad0b02d135b3ec571b390616ac76f888e0ecaf012102bf7c36100b0d394e79a1704b8bf9e030a62e139a293f5da891671c56d555f732feffffffd979b8815c9a17e956011b7b9767dcb1237501832392a1f5d2ed2e0d785754c2010000006a473044022079f2e9dd53d838978fe82a6034894c062381ac32bce190e0d862efff7e4a5ef002200eee7a5bd39f084cd8dc73d50d1fc1388e998750db3fadbd74ff2537bef0cd8e012102bf7c36100b0d394e79a1704b8bf9e030a62e139a293f5da891671c56d555f732feffffff02224e0000000000001976a914f57766c540e7e165092e739e115383bd04d2c21888acf91ec3680a0000001976a9140d5bcbeeb459af40f97fcb4a98e9d1ed13e904c888acfadc0a00" // ktlint-disable max-line-length
         val welcomeConnectedTx = Transaction(networkParams, Utils.HEX.decode(welcomeConnected))
         welcomeResponseTx.inputs[0].connect(welcomeConnectedTx.outputs[0])
 
-        val confirmationConnected = "01000000017a4c4461b44d14a3866bc89482bdd35c800961879d65fc4e0542a377232f124b000000006a47304402206beee5884010d44501dee9094d9922af0c22b63f3afc1f3aa5c43bfcf59f38070220676e5bbeb712cbbbadbde6959cdee3367d1578bd06204178630cb1ba729073a20121025e25aa5f744bdd42f386a11efc584fa25afdaa299477038d2b86ac655287305effffffff0231d40000000000001976a914dcd48b7080eafd7b4db3bac7ea8480ccc3b1093388ac7d54a750000000001976a9149701a96ac4f8bb1a627be9928ccbc717ccce485788ac00000000"
+        val confirmationConnected = "01000000017a4c4461b44d14a3866bc89482bdd35c800961879d65fc4e0542a377232f124b000000006a47304402206beee5884010d44501dee9094d9922af0c22b63f3afc1f3aa5c43bfcf59f38070220676e5bbeb712cbbbadbde6959cdee3367d1578bd06204178630cb1ba729073a20121025e25aa5f744bdd42f386a11efc584fa25afdaa299477038d2b86ac655287305effffffff0231d40000000000001976a914dcd48b7080eafd7b4db3bac7ea8480ccc3b1093388ac7d54a750000000001976a9149701a96ac4f8bb1a627be9928ccbc717ccce485788ac00000000" // ktlint-disable max-line-length
         val confirmationConnectedTx = Transaction(networkParams, Utils.HEX.decode(confirmationConnected))
         confirmationTx.inputs[0].connect(confirmationConnectedTx.outputs[0])
     }
@@ -91,9 +91,9 @@ class CrowdNodeApiAggregatorTest {
     fun stopTrackingLinked_resetsInProgressStatus() {
         runBlocking {
             localConfig.stub {
-                onBlocking { getPreference(CrowdNodeConfig.ONLINE_ACCOUNT_STATUS) } doReturn OnlineAccountStatus.Linking.ordinal
+                onBlocking { get(CrowdNodeConfig.ONLINE_ACCOUNT_STATUS) } doReturn OnlineAccountStatus.Linking.ordinal
             }
-            val api = CrowdNodeApiAggregator(webApi, blockchainApi, walletData, mock(), mock(), localConfig, globalConfig, mock(), mock(), mock())
+            val api = CrowdNodeApiAggregator(webApi, blockchainApi, walletData, mock(), mock(), localConfig, globalConfig, mock(), mock(), mock()) // ktlint-disable max-line-length
             api.restoreStatus()
             api.stopTrackingLinked()
 
@@ -106,9 +106,14 @@ class CrowdNodeApiAggregatorTest {
     fun stopTrackingLinked_doesNotDemoteConfirmedStatus() {
         runBlocking {
             localConfig.stub {
-                onBlocking { getPreference(CrowdNodeConfig.ONLINE_ACCOUNT_STATUS) } doReturn OnlineAccountStatus.Confirming.ordinal
+                onBlocking {
+                    get(CrowdNodeConfig.ONLINE_ACCOUNT_STATUS)
+                } doReturn OnlineAccountStatus.Confirming.ordinal
             }
-            val api = CrowdNodeApiAggregator(mock(), blockchainApi, walletData, mock(), mock(), localConfig, globalConfig, mock(), mock(), mock())
+            val api = CrowdNodeApiAggregator(
+                mock(), blockchainApi, walletData, mock(), mock(),
+                localConfig, globalConfig, mock(), mock(), mock()
+            )
             api.restoreStatus()
             api.stopTrackingLinked()
 
@@ -121,7 +126,7 @@ class CrowdNodeApiAggregatorTest {
     fun stopTrackingLinked_doesNotDemoteApiSignUpStatus() {
         runBlocking {
             localConfig.stub {
-                onBlocking { getPreference(CrowdNodeConfig.ONLINE_ACCOUNT_STATUS) } doReturn OnlineAccountStatus.None.ordinal
+                onBlocking { get(CrowdNodeConfig.ONLINE_ACCOUNT_STATUS) } doReturn OnlineAccountStatus.None.ordinal
             }
             globalConfig.stub {
                 on { crowdNodePrimaryAddress } doReturn ""
@@ -134,7 +139,7 @@ class CrowdNodeApiAggregatorTest {
             blockchainApi.stub {
                 on { getFullSignUpTxSet() } doReturn mockFullSet
             }
-            val api = CrowdNodeApiAggregator(webApi, blockchainApi, walletData, mock(), mock(), localConfig, globalConfig, mock(), mock(), mock())
+            val api = CrowdNodeApiAggregator(webApi, blockchainApi, walletData, mock(), mock(), localConfig, globalConfig, mock(), mock(), mock()) // ktlint-disable max-line-length
             api.restoreStatus()
             assertEquals(SignUpStatus.Finished, api.signUpStatus.value)
             assertEquals(OnlineAccountStatus.None, api.onlineAccountStatus.value)
@@ -150,9 +155,12 @@ class CrowdNodeApiAggregatorTest {
     fun refreshBalance_notSignedIn_doesNotCallWebApi() {
         runBlocking {
             localConfig.stub {
-                onBlocking { getPreference(CrowdNodeConfig.ONLINE_ACCOUNT_STATUS) } doReturn OnlineAccountStatus.None.ordinal
+                onBlocking { get(CrowdNodeConfig.ONLINE_ACCOUNT_STATUS) } doReturn OnlineAccountStatus.None.ordinal
             }
-            val api = CrowdNodeApiAggregator(webApi, blockchainApi, walletData, mock(), mock(), localConfig, globalConfig, mock(), mock(), mock())
+            val api = CrowdNodeApiAggregator(
+                webApi, blockchainApi, walletData, mock(), mock(),
+                localConfig, globalConfig, mock(), mock(), mock()
+            )
             api.restoreStatus()
             api.refreshBalance()
 
@@ -165,23 +173,29 @@ class CrowdNodeApiAggregatorTest {
     fun onlineStatusDone_restoredCorrectly() {
         runBlocking {
             localConfig.stub {
-                onBlocking { getPreference(CrowdNodeConfig.ONLINE_ACCOUNT_STATUS) } doReturn 6
+                onBlocking { get(CrowdNodeConfig.ONLINE_ACCOUNT_STATUS) } doReturn 6
             }
-            val api = CrowdNodeApiAggregator(webApi, blockchainApi, walletData, mock(), mock(), localConfig, globalConfig, mock(), mock(), mock())
+            val api = CrowdNodeApiAggregator(
+                webApi, blockchainApi, walletData, mock(), mock(),
+                localConfig, globalConfig, mock(), mock(), mock()
+            )
             api.restoreStatus()
             assertEquals(SignUpStatus.LinkedOnline, api.signUpStatus.value)
             assertEquals(OnlineAccountStatus.Done, api.onlineAccountStatus.value)
         }
     }
 
-    @Test
     // TODO: remove when there is no 7.5.0 in the wild
+    @Test
     fun oldOnlineStatusDoneValue_restoredCorrectly() {
         runBlocking {
             localConfig.stub {
-                onBlocking { getPreference(CrowdNodeConfig.ONLINE_ACCOUNT_STATUS) } doReturn 4
+                onBlocking { get(CrowdNodeConfig.ONLINE_ACCOUNT_STATUS) } doReturn 4
             }
-            val api = CrowdNodeApiAggregator(webApi, blockchainApi, walletData, mock(), mock(), localConfig, globalConfig, mock(), mock(), mock())
+            val api = CrowdNodeApiAggregator(
+                webApi, blockchainApi, walletData, mock(), mock(),
+                localConfig, globalConfig, mock(), mock(), mock()
+            )
             api.restoreStatus()
             assertEquals(SignUpStatus.LinkedOnline, api.signUpStatus.value)
             assertEquals(OnlineAccountStatus.Done, api.onlineAccountStatus.value)
@@ -192,7 +206,7 @@ class CrowdNodeApiAggregatorTest {
     fun onlineStatusCreating_restoredCorrectly() {
         runBlocking {
             localConfig.stub {
-                onBlocking { getPreference(CrowdNodeConfig.ONLINE_ACCOUNT_STATUS) } doReturn 4
+                onBlocking { get(CrowdNodeConfig.ONLINE_ACCOUNT_STATUS) } doReturn 4
             }
             globalConfig.stub {
                 on { crowdNodePrimaryAddress } doReturn ""
@@ -205,7 +219,10 @@ class CrowdNodeApiAggregatorTest {
             blockchainApi.stub {
                 on { getFullSignUpTxSet() } doReturn mockFullSet
             }
-            val api = CrowdNodeApiAggregator(webApi, blockchainApi, walletData, mock(), mock(), localConfig, globalConfig, mock(), mock(), mock())
+            val api = CrowdNodeApiAggregator(
+                webApi, blockchainApi, walletData, mock(), mock(),
+                localConfig, globalConfig, mock(), mock(), mock()
+            )
             api.restoreStatus()
             assertEquals(SignUpStatus.Finished, api.signUpStatus.value)
             assertEquals(OnlineAccountStatus.Creating, api.onlineAccountStatus.value)
@@ -215,7 +232,7 @@ class CrowdNodeApiAggregatorTest {
     @Test
     fun `linked online account restored correctly from confirmation transaction`(): Unit = runBlocking {
         localConfig.stub {
-            onBlocking { getPreference(CrowdNodeConfig.ONLINE_ACCOUNT_STATUS) } doReturn 0
+            onBlocking { get(CrowdNodeConfig.ONLINE_ACCOUNT_STATUS) } doReturn 0
         }
         globalConfig.stub {
             on { crowdNodeAccountAddress } doReturn ""
@@ -231,10 +248,15 @@ class CrowdNodeApiAggregatorTest {
             on { transactionBag } doReturn bagMock
         }
         webApi.stub {
-            onBlocking { isApiAddressInUse(any()) } doReturn Pair(true, Address.fromBase58(networkParams, "yd9CUc7wvATUS3GfdmcAhRZhG7719jhNf9"))
+            onBlocking {
+                isApiAddressInUse(any())
+            } doReturn Pair(true, Address.fromBase58(networkParams, "yd9CUc7wvATUS3GfdmcAhRZhG7719jhNf9"))
         }
 
-        val api = CrowdNodeApiAggregator(webApi, blockchainApi, walletData, mock(), mock(), localConfig, globalConfig, mock(), mock(), mock())
+        val api = CrowdNodeApiAggregator(
+            webApi, blockchainApi, walletData, mock(), mock(),
+            localConfig, globalConfig, mock(), mock(), mock()
+        )
         api.restoreStatus()
 
         assertTrue(

--- a/integrations/crowdnode/src/test/java/org/dash/wallet/integrations/crowdnode/CrowdNodeBalanceConditionTest.kt
+++ b/integrations/crowdnode/src/test/java/org/dash/wallet/integrations/crowdnode/CrowdNodeBalanceConditionTest.kt
@@ -36,7 +36,7 @@ class CrowdNodeBalanceConditionTest {
     @Test
     fun check_zeroBalance_passes() {
         val crowdNodeConfig = mock<CrowdNodeConfig> {
-            onBlocking { getPreference(CrowdNodeConfig.LAST_BALANCE) } doReturn 0
+            onBlocking { get(CrowdNodeConfig.LAST_BALANCE) } doReturn 0
         }
         CrowdNodeBalanceCondition().check(
             Coin.COIN,
@@ -50,7 +50,7 @@ class CrowdNodeBalanceConditionTest {
     @Test
     fun check_nonZeroBalance_throws() {
         val crowdNodeConfig = mock<CrowdNodeConfig> {
-            onBlocking { getPreference(CrowdNodeConfig.LAST_BALANCE) } doReturn 5000
+            onBlocking { get(CrowdNodeConfig.LAST_BALANCE) } doReturn 5000
         }
 
         val thrown: LeftoverBalanceException = assertThrows(
@@ -70,7 +70,7 @@ class CrowdNodeBalanceConditionTest {
     @Test
     fun check_zeroBalance_sendingToCrowdNode_throws() {
         val crowdNodeConfig = mock<CrowdNodeConfig> {
-            onBlocking { getPreference(CrowdNodeConfig.LAST_BALANCE) } doReturn 0
+            onBlocking { get(CrowdNodeConfig.LAST_BALANCE) } doReturn 0
         }
 
         val thrown: LeftoverBalanceException = assertThrows(
@@ -90,7 +90,7 @@ class CrowdNodeBalanceConditionTest {
     @Test
     fun check_unknownAddress_zeroBalance_passes() {
         val crowdNodeConfig = mock<CrowdNodeConfig> {
-            onBlocking { getPreference(CrowdNodeConfig.LAST_BALANCE) } doReturn 0
+            onBlocking { get(CrowdNodeConfig.LAST_BALANCE) } doReturn 0
         }
         CrowdNodeBalanceCondition().check(
             Coin.COIN,

--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
 
     // Firebase
     // Import the BoM for the Firebase platform
@@ -139,10 +139,10 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     testImplementation "io.mockk:mockk:1.12.3"
     testImplementation "androidx.arch.core:core-testing:$coreTestingVersion"
-    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion"
 
     // Instrumental tests
-    androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
+    androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion"
     androidTestImplementation "androidx.room:room-testing:$roomVersion"
     androidTestImplementation "androidx.test.ext:junit:$junitExtVersion"
     androidTestImplementation('androidx.test:runner:1.3.0') {


### PR DESCRIPTION
Some Explore tests are broken in dashdirect branch after migrating to DataStore.

## Issue being fixed or feature implemented
- Made `BaseConfig` methods `open` for mocking
- Replaced `runBlocking` with `runTest` since calling one `runBlocking` inside another causes a deadlock.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
