### PR TITLE
fix: allow send if exchange rate is missing [NMA-1506]

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/ui/enter_amount/AmountView.kt
+++ b/common/src/main/java/org/dash/wallet/common/ui/enter_amount/AmountView.kt
@@ -41,7 +41,6 @@ import java.text.DecimalFormat
 import java.text.NumberFormat
 import java.util.*
 
-
 class AmountView(context: Context, attrs: AttributeSet) : ConstraintLayout(context, attrs) {
     private val binding = AmountViewBinding.inflate(LayoutInflater.from(context), this)
     val dashFormat = MonetaryFormat().withLocale(GenericUtils.getDeviceLocale())
@@ -90,14 +89,14 @@ class AmountView(context: Context, attrs: AttributeSet) : ConstraintLayout(conte
 
                 if (value) {
                     input = dashFormat.minDecimals(0)
-                        .optionalDecimals(0,6).format(dashAmount).toString()
+                        .optionalDecimals(0, 6).format(dashAmount).toString()
                 } else {
                     binding.resultAmount.text = dashFormat.format(dashAmount)
 
                     exchangeRate?.let {
                         fiatAmount = it.coinToFiat(dashAmount)
                         _input = fiatFormat.minDecimals(0)
-                            .optionalDecimals(0,2).format(fiatAmount).toString()
+                            .optionalDecimals(0, 2).format(fiatAmount).toString()
                         binding.inputAmount.text = formatInputWithCurrency()
                     }
                 }
@@ -157,11 +156,11 @@ class AmountView(context: Context, attrs: AttributeSet) : ConstraintLayout(conte
     private fun updateAmount() {
         binding.inputAmount.text = formatInputWithCurrency()
         val rate = exchangeRate
+        val pair = parseAmounts(input, rate)
+        dashAmount = pair.first
 
-        if (rate != null) {
-            val pair = parseAmounts(input, rate)
-            dashAmount = pair.first
-            fiatAmount = pair.second
+        if (pair.second != null) {
+            fiatAmount = pair.second!!
 
             binding.resultAmount.text = if (dashToFiat) {
                 GenericUtils.fiatToString(fiatAmount)
@@ -174,15 +173,15 @@ class AmountView(context: Context, attrs: AttributeSet) : ConstraintLayout(conte
         }
     }
 
-    private fun parseAmounts(input: String, rate: ExchangeRate): Pair<Coin, Fiat> {
+    private fun parseAmounts(input: String, rate: ExchangeRate?): Pair<Coin, Fiat?> {
         val cleanedValue = GenericUtils.formatFiatWithoutComma(input)
-        val dashAmount: Coin
-        val fiatAmount: Fiat
+        var dashAmount: Coin = Coin.ZERO
+        var fiatAmount: Fiat? = null
 
         if (dashToFiat) {
             dashAmount = Coin.parseCoin(cleanedValue)
-            fiatAmount = rate.coinToFiat(dashAmount)
-        } else {
+            fiatAmount = rate?.coinToFiat(dashAmount)
+        } else if (rate != null) {
             fiatAmount = Fiat.parseFiat(rate.fiat.currencyCode, cleanedValue)
             dashAmount = rate.fiatToCoin(fiatAmount)
         }
@@ -242,7 +241,7 @@ class AmountView(context: Context, attrs: AttributeSet) : ConstraintLayout(conte
     private fun isValidInput(input: String): Boolean {
         return try {
             // Only show the Paste popup if the value in the clipboard is valid
-            parseAmounts(input, exchangeRate!!)
+            parseAmounts(input, exchangeRate)
             true
         } catch (ex: Exception) {
             false

--- a/common/src/main/java/org/dash/wallet/common/ui/enter_amount/EnterAmountFragment.kt
+++ b/common/src/main/java/org/dash/wallet/common/ui/enter_amount/EnterAmountFragment.kt
@@ -111,10 +111,6 @@ class EnterAmountFragment: Fragment(R.layout.fragment_enter_amount) {
         viewModel.canContinue.observe(viewLifecycleOwner) {
             binding.continueBtn.isEnabled = it
         }
-
-        viewModel.canContinue.observe(viewLifecycleOwner) {
-            binding.continueBtn.isEnabled = it
-        }
     }
 
     fun setViewDetails(continueText: String, keyboardHeader: View? = null) {
@@ -143,9 +139,11 @@ class EnterAmountFragment: Fragment(R.layout.fragment_enter_amount) {
     fun setAmount(amount: Coin) {
         if (binding.amountView.dashToFiat) {
             binding.amountView.input = amount.toPlainString()
-        } else viewModel.selectedExchangeRate.value?.let {
-            val rate = ExchangeRate(it.fiat)
-            binding.amountView.input = binding.amountView.fiatFormat.format(rate.coinToFiat(amount)).toString()
+        } else {
+            viewModel.selectedExchangeRate.value?.let {
+                val rate = ExchangeRate(it.fiat)
+                binding.amountView.input = binding.amountView.fiatFormat.format(rate.coinToFiat(amount)).toString()
+            }
         }
     }
 

--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.kt
@@ -191,8 +191,8 @@ class SendCoinsFragment: Fragment(R.layout.send_coins_fragment) {
         val editedAmount = enterAmountViewModel.amount.value
         val rate = enterAmountViewModel.selectedExchangeRate.value
 
-        if (rate != null && editedAmount != null) {
-            val exchangeRate = ExchangeRate(Coin.COIN, rate.fiat)
+        if (editedAmount != null) {
+            val exchangeRate = rate?.fiat?.let { ExchangeRate(Coin.COIN, it) }
 
             try {
                 viewModel.logEvent(AnalyticsConstants.SendReceive.ENTER_AMOUNT_SEND)


### PR DESCRIPTION
If the exchange rate is null, our Send button is disabled and then even if we enable it, send won't work.

## Issue being fixed or feature implemented
- Allow send if the exchange rate is missing.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
