### PR TITLE
feat: add privacy modes to CoinJoinService

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/dashpay/CreateIdentityService.kt
+++ b/wallet/src/de/schildbach/wallet/ui/dashpay/CreateIdentityService.kt
@@ -15,6 +15,7 @@ import de.schildbach.wallet.data.BlockchainIdentityData.CreationState
 import de.schildbach.wallet.data.DashPayProfile
 import de.schildbach.wallet.data.InvitationLinkData
 import de.schildbach.wallet.security.SecurityGuard
+import de.schildbach.wallet.service.CoinJoinMode
 import de.schildbach.wallet.service.CoinJoinService
 import de.schildbach.wallet.service.platform.PlatformSyncService
 import de.schildbach.wallet.ui.dashpay.work.SendContactRequestOperation
@@ -332,7 +333,7 @@ class CreateIdentityService : LifecycleService() {
 
             coinJoinService.prepareAndStartMixing()
 
-            coinJoinService.waitForMixing();
+            coinJoinService.waitForMixing()
         }
 
         if (blockchainIdentityData.creationState <= CreationState.CREDIT_FUNDING_TX_CREATING) {
@@ -342,7 +343,7 @@ class CreateIdentityService : LifecycleService() {
             //
             // check to see if the funding transaction exists
             if (blockchainIdentity.creditFundingTransaction == null) {
-                platformRepo.createCreditFundingTransactionAsync(blockchainIdentity, encryptionKey)
+                platformRepo.createCreditFundingTransactionAsync(blockchainIdentity, encryptionKey, coinJoinService.getMode()  != CoinJoinMode.BASIC)
             }
         }
 

--- a/wallet/src/de/schildbach/wallet/ui/dashpay/PlatformRepo.kt
+++ b/wallet/src/de/schildbach/wallet/ui/dashpay/PlatformRepo.kt
@@ -603,10 +603,10 @@ class PlatformRepo private constructor(val walletApplication: WalletApplication)
     //
     // Step 2 is to create the credit funding transaction
     //
-    suspend fun createCreditFundingTransactionAsync(blockchainIdentity: BlockchainIdentity, keyParameter: KeyParameter?) {
+    suspend fun createCreditFundingTransactionAsync(blockchainIdentity: BlockchainIdentity, keyParameter: KeyParameter?, useCoinJoin: Boolean) {
         withContext(Dispatchers.IO) {
             Context.propagate(walletApplication.wallet!!.context)
-            val cftx = blockchainIdentity.createCreditFundingTransaction(Constants.DASH_PAY_FEE, keyParameter, true)
+            val cftx = blockchainIdentity.createCreditFundingTransaction(Constants.DASH_PAY_FEE, keyParameter, useCoinJoin)
             blockchainIdentity.initializeCreditFundingTransaction(cftx)
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
To use this:

1. inject CoinJoinService into your view model
2. call coinJoinService.setMode, using `BASIC`, `INTERMEDIATE` or `ADVANCED`. 

Known issues:  If the app is restarted in INTERMEDIATE or ADVANCED mode, it will restart in BASIC mode because this setting is not saved.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
