### PR TITLE
chore(dashdirect): retries in case of error

### DIFF
--- a/.deploy/exploredata.rb
+++ b/.deploy/exploredata.rb
@@ -3,7 +3,7 @@ project_id = "dash-wallet-firebase"
 key_file   = ".deploy/gc-storage-service-account.json"
 bucket_name = "dash-wallet-firebase.appspot.com"
 flavor = ARGV[0]
-file_name = "explore/explore-devnet.db"
+file_name = "explore/explore-testnet.db"
 if flavor == "prod"
   puts "Downloading the production database"
 else

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -86,5 +86,6 @@
 
     <!-- Send coins -->
     <string name="payment_request_problem_title">Payment was not acknowledged</string>
+    <string name="payment_protocol_default_error_title">Payment error</string>
     <string name="payment_request_problem_message">Your payment could not be processed by the server, please inquire with the merchant</string>
 </resources>

--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -391,15 +391,6 @@ android {
             freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
         }
     }
-    lint {
-        abortOnError false
-        disable 'MissingTranslation'
-    }
-    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-        kotlinOptions {
-            freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
-        }
-    }
 }
 
 apply from: file("../gradle/google-services.gradle")

--- a/wallet/res/values/strings.xml
+++ b/wallet/res/values/strings.xml
@@ -378,7 +378,6 @@
     <string name="activity_security_hide_balance">Autohide Balance</string>
     <string name="reset_to_default">Reset to Default</string>
 
-    <string name="payment_protocol_default_error_title">Payment error</string>
     <string name="payment_protocol_insufficient_funds_error_title">Insufficient Funds</string>
     <string name="payment_protocol_insufficient_funds_error_message">You do not have sufficient funds to complete this transaction</string>
 

--- a/wallet/src/de/schildbach/wallet/Constants.java
+++ b/wallet/src/de/schildbach/wallet/Constants.java
@@ -74,7 +74,7 @@ public final class Constants {
                 IS_PROD_BUILD = true;
                 FILENAME_NETWORK_SUFFIX = "";
                 WALLET_NAME_CURRENCY_CODE = "dash";
-                org.dash.wallet.common.util.Constants.INSTANCE.setEXPLORE_GC_FILE_PATH("explore/explore-devnet.db");
+                org.dash.wallet.common.util.Constants.INSTANCE.setEXPLORE_GC_FILE_PATH("explore/explore-testnet.db");
                 SYNC_FLAGS.add(MasternodeSync.SYNC_FLAGS.SYNC_HEADERS_MN_LIST_FIRST);
                 break;
             }

--- a/wallet/test/de/schildbach/wallet/util/viewModels/MainViewModelTest.kt
+++ b/wallet/test/de/schildbach/wallet/util/viewModels/MainViewModelTest.kt
@@ -25,8 +25,6 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.lifecycle.SavedStateHandle
 import de.schildbach.wallet.Constants
 import de.schildbach.wallet.WalletUIConfig
-import de.schildbach.wallet.data.BlockchainStateDao
-import de.schildbach.wallet.transactions.TxDirection
 import de.schildbach.wallet.ui.main.MainViewModel
 import io.mockk.*
 import junit.framework.TestCase.assertEquals


### PR DESCRIPTION
Given some timing issues DashDirect API has, we want to retry in the case PaymentStatus request returns an error. Subsequent requests might return a different result.

## Issue being fixed or feature implemented
- Initial delay increased to 1s
- Ticker delay increased to 1.5s
- Retry counter added for 3 retries in the case of an error

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
