### PR TITLE
fix(explore): cleanup old databases

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/Configuration.java
+++ b/common/src/main/java/org/dash/wallet/common/Configuration.java
@@ -107,7 +107,6 @@ public class Configuration {
     // Explore Dash
     public static final String PREFS_KEY_HAS_INFO_SCREEN_BEEN_SHOWN_ALREADY = "has_info_screen_been_shown";
     public static final String PREFS_KEY_HAS_LOCATION_DIALOG_BEEN_SHOWN = "has_location_dialog_been_shown";
-    public static final String PREFS_KEY_EXPLORE_DATABASE_NAME = "explore_database_name";
 
     // CrowdNode
     public static final String PREFS_KEY_CROWDNODE_ACCOUNT_ADDRESS = "crowdnode_account_address";
@@ -521,17 +520,6 @@ public class Configuration {
 
     public void setHasExploreDashLocationDialogBeenShown(boolean isShown) {
         prefs.edit().putBoolean(PREFS_KEY_HAS_LOCATION_DIALOG_BEEN_SHOWN, isShown).apply();
-    }
-
-    public String setExploreDatabaseName(Long timestamp) {
-        String dbName = "explore-database-" + timestamp;
-        prefs.edit().putString(PREFS_KEY_EXPLORE_DATABASE_NAME, dbName).apply();
-        return dbName;
-    }
-
-    @NonNull
-    public String getExploreDatabaseName() {
-        return prefs.getString(PREFS_KEY_EXPLORE_DATABASE_NAME, "explore-database");
     }
 
     // Coinbase

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ExploreDatabase.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ExploreDatabase.kt
@@ -19,6 +19,7 @@ package org.dash.wallet.features.exploredash
 
 import android.content.Context
 import android.database.sqlite.SQLiteException
+import android.preference.PreferenceManager
 import androidx.annotation.VisibleForTesting
 import androidx.room.Database
 import androidx.room.Room
@@ -75,6 +76,8 @@ abstract class ExploreDatabase : RoomDatabase() {
         }
 
         private fun open(context: Context): ExploreDatabase {
+            fixObsoleteName(context)
+
             val dbBuilder = Room.databaseBuilder(
                 context,
                 ExploreDatabase::class.java,
@@ -177,6 +180,14 @@ abstract class ExploreDatabase : RoomDatabase() {
             cursor.close()
 
             return merchantCount > 0 && atmCount > 0
+        }
+
+        private fun fixObsoleteName(context: Context) {
+            val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+            prefs.getString("explore_database_name", null)?.let { previousName ->
+                val file = context.getDatabasePath(previousName)
+                file.renameTo(context.getDatabasePath(EXPLORE_DB_NAME))
+            }
         }
 
         private fun cleanupPreviousDatabases(context: Context) {

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ExploreSyncWorker.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ExploreSyncWorker.kt
@@ -26,7 +26,6 @@ import dagger.assisted.AssistedInject
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.dash.wallet.common.Configuration
 import org.dash.wallet.common.services.analytics.AnalyticsService
 import org.dash.wallet.features.exploredash.repository.ExploreDataSyncStatus
 import org.dash.wallet.features.exploredash.repository.ExploreRepository
@@ -41,8 +40,7 @@ class ExploreSyncWorker @AssistedInject constructor(
     @Assisted workerParams: WorkerParameters,
     private val analytics: AnalyticsService,
     private val exploreRepository: ExploreRepository,
-    private val syncStatus: ExploreDataSyncStatus,
-    private val config: Configuration
+    private val syncStatus: ExploreDataSyncStatus
 ): CoroutineWorker(appContext, workerParams) {
     companion object {
         const val USE_TEST_DB_KEY = "use_test_database"
@@ -96,7 +94,6 @@ class ExploreSyncWorker @AssistedInject constructor(
                         // and a newer preloaded DB
                         ExploreDatabase.updateDatabase(
                             appContext,
-                            config,
                             exploreRepository
                         )
                         exploreRepository.preloadedOnTimestamp = preloadedDbTimestamp
@@ -134,7 +131,6 @@ class ExploreSyncWorker @AssistedInject constructor(
 
                 ExploreDatabase.updateDatabase(
                     appContext,
-                    config,
                     exploreRepository
                 )
             }

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/di/ExploreDatabaseModule.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/di/ExploreDatabaseModule.kt
@@ -23,7 +23,6 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import org.dash.wallet.common.Configuration
 import org.dash.wallet.features.exploredash.ExploreDatabase
 import org.dash.wallet.features.exploredash.data.AtmDao
 import org.dash.wallet.features.exploredash.data.MerchantDao
@@ -34,11 +33,8 @@ import javax.inject.Singleton
 object ExploreDatabaseModule {
     @Singleton
     @Provides
-    fun provideDatabase(
-        @ApplicationContext context: Context,
-        config: Configuration
-    ): ExploreDatabase {
-        return ExploreDatabase.getAppDatabase(context, config)
+    fun provideDatabase(@ApplicationContext context: Context): ExploreDatabase {
+        return ExploreDatabase.getAppDatabase(context)
     }
 
     @Provides

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/repository/ExploreRepository.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/repository/ExploreRepository.kt
@@ -49,12 +49,10 @@ interface ExploreRepository {
     fun getTimestamp(file: File): Long
     fun getUpdateFile(): File
     suspend fun download()
-    fun markDbForDeletion(dbFile: File)
     fun preloadFromAssetsInto(dbUpdateFile: File, checkTestDB: Boolean): Boolean
     fun finalizeUpdate()
 }
 
-@Suppress("BlockingMethodInNonBlockingContext")
 class GCExploreDatabase @Inject constructor(
     @ApplicationContext private val context: Context,
     private val preferences: SharedPreferences,
@@ -213,25 +211,6 @@ class GCExploreDatabase @Inject constructor(
 
     override fun getUpdateFile(): File {
         return File(context.cacheDir, DATA_FILE_NAME)
-    }
-
-    override fun markDbForDeletion(dbFile: File) {
-        try {
-            if (dbFile.exists()) {
-                dbFile.deleteOnExit()
-            }
-            val dbShmFile = File(dbFile.absolutePath + "-shm")
-            if (dbShmFile.exists()) {
-                dbShmFile.deleteOnExit()
-            }
-            val dbWalFile = File(dbFile.absolutePath + "-wal")
-            if (dbWalFile.exists()) {
-                dbWalFile.deleteOnExit()
-            }
-            log.info("existing explore db files to be deleted on exit")
-        } catch (ex: SecurityException) {
-            log.warn("unable to delete explore db", ex)
-        }
     }
 
     @Throws(IOException::class)

--- a/wallet/src/de/schildbach/wallet/Constants.java
+++ b/wallet/src/de/schildbach/wallet/Constants.java
@@ -98,7 +98,7 @@ public final class Constants {
                 IS_PROD_BUILD = false;
                 FILENAME_NETWORK_SUFFIX = "-chacha";
                 WALLET_NAME_CURRENCY_CODE = "tdash";
-                org.dash.wallet.common.util.Constants.EXPLORE_GC_FILE_PATH = "explore/explore-testnet.db";
+                org.dash.wallet.common.util.Constants.EXPLORE_GC_FILE_PATH = "explore/explore-devnet.db";
                 SYNC_FLAGS.add(MasternodeSync.SYNC_FLAGS.SYNC_HEADERS_MN_LIST_FIRST);
                 break;
             }


### PR DESCRIPTION
Old Explore databases aren't being deleted after a sync.

## Issue being fixed or feature implemented
- Timestamp suffix and associated logic is removed
- Journal mode set to TRUNCATE to avoid creating write-ahead logging files
- Previous database files are cleaned up before an update

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
