### PR TITLE
fix: send coins crash

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/send/ConfirmTransactionDialog.kt
+++ b/wallet/src/de/schildbach/wallet/ui/send/ConfirmTransactionDialog.kt
@@ -16,7 +16,6 @@
 
 package de.schildbach.wallet.ui.send
 
-
 import android.os.Bundle
 import android.text.TextUtils
 import android.view.LayoutInflater
@@ -49,20 +48,16 @@ class ConfirmTransactionDialog(
         private const val ARG_PAYEE_NAME = "arg_payee_name"
         private const val ARG_PAYEE_VERIFIED_BY = "arg_payee_verified_by"
 
-        @JvmStatic
-        fun showDialog(
-            activity: FragmentActivity,
-            address: String, amount: String, amountFiat: String, fiatSymbol: String, fee: String, total: String,
-                         payeeName: String? = null, payeeVerifiedBy: String? = null, buttonText: String? = null,
-        ) {
-            val dialog = ConfirmTransactionDialog()
-            val bundle = setBundle(address, amount, amountFiat, fiatSymbol, fee, total, payeeName, payeeVerifiedBy, buttonText)
-            show(dialog, bundle, activity)
-        }
-
         private fun setBundle(
-            address: String, amount: String, amountFiat: String, fiatSymbol: String, fee: String, total: String,
-            payeeName: String? = null, payeeVerifiedBy: String? = null, buttonText: String? = null
+            address: String,
+            amount: String,
+            amountFiat: String,
+            fiatSymbol: String,
+            fee: String,
+            total: String,
+            payeeName: String? = null,
+            payeeVerifiedBy: String? = null,
+            buttonText: String? = null
         ): Bundle {
             return Bundle().apply {
                 putString(ARG_ADDRESS, address)
@@ -77,26 +72,34 @@ class ConfirmTransactionDialog(
             }
         }
 
-        private fun show(confirmTransactionDialog: ConfirmTransactionDialog,
-                         bundle: Bundle,
-                         activity: FragmentActivity) {
+        private fun show(
+            confirmTransactionDialog: ConfirmTransactionDialog,
+            bundle: Bundle,
+            activity: FragmentActivity
+        ) {
             confirmTransactionDialog.arguments = bundle
             confirmTransactionDialog.show(activity.supportFragmentManager, TAG)
         }
 
-        suspend fun showDialogAsync(activity: FragmentActivity,
-                                    address: String, amount: String, amountFiat: String, fiatSymbol: String,
-                                    fee: String, total: String) = suspendCancellableCoroutine<Boolean> { coroutine ->
+        suspend fun showDialogAsync(
+            activity: FragmentActivity,
+            address: String,
+            amount: String,
+            amountFiat: String,
+            fiatSymbol: String,
+            fee: String,
+            total: String
+        ) = suspendCancellableCoroutine<Boolean> { coroutine ->
             val confirmTransactionDialog = ConfirmTransactionDialog {
-                if (coroutine.isActive){
+                if (coroutine.isActive) {
                     coroutine.resume(it)
                 }
             }
             try {
                 val bundle = setBundle(address, amount, amountFiat, fiatSymbol, fee, total)
                 show(confirmTransactionDialog, bundle, activity)
-            } catch (e: Exception){
-                if (coroutine.isActive){
+            } catch (e: Exception) {
+                if (coroutine.isActive) {
                     coroutine.resumeWithException(e)
                 }
             }

--- a/wallet/src/de/schildbach/wallet/ui/send/PaymentProtocolFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/send/PaymentProtocolFragment.kt
@@ -78,10 +78,7 @@ class PaymentProtocolFragment : Fragment(R.layout.fragment_payment_protocol) {
         }
 
         initObservers()
-
-        if (savedInstanceState == null) {
-            viewModel.initPaymentIntent(args.paymentIntent)
-        }
+        viewModel.initPaymentIntent(args.paymentIntent)
     }
 
     private fun authenticateOrConfirm() {

--- a/wallet/src/de/schildbach/wallet/ui/send/PaymentProtocolFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/send/PaymentProtocolFragment.kt
@@ -28,14 +28,14 @@ import de.schildbach.wallet.data.PaymentIntent
 import de.schildbach.wallet.livedata.Status
 import de.schildbach.wallet.ui.transactions.TransactionResultActivity
 import de.schildbach.wallet_test.R
+import de.schildbach.wallet_test.databinding.FragmentPaymentProtocolBinding
+import kotlinx.coroutines.launch
 import org.bitcoinj.core.Coin
 import org.bitcoinj.core.InsufficientMoneyException
 import org.bitcoinj.core.Transaction
 import org.bitcoinj.protocols.payments.PaymentProtocolException
 import org.bitcoinj.utils.MonetaryFormat
 import org.bitcoinj.wallet.SendRequest
-import de.schildbach.wallet_test.databinding.FragmentPaymentProtocolBinding
-import kotlinx.coroutines.launch
 import org.dash.wallet.common.Configuration
 import org.dash.wallet.common.services.AuthenticationManager
 import org.dash.wallet.common.ui.dialogs.AdaptiveDialog
@@ -97,7 +97,7 @@ class PaymentProtocolFragment : Fragment(R.layout.fragment_payment_protocol) {
     }
 
     private fun confirmWhenAuthorizedAndNoException() {
-        if(viewModel.finalPaymentIntent!!.expired) {
+        if (viewModel.finalPaymentIntent!!.expired) {
             showRequestExpiredMessage()
             return
         }
@@ -206,7 +206,13 @@ class PaymentProtocolFragment : Fragment(R.layout.fragment_payment_protocol) {
         val payeeVerifiedBy = viewModel.finalPaymentIntent!!.payeeVerifiedBy
         requireActivity().run {
             val transactionResultIntent = TransactionResultActivity.createIntent(
-                    this, intent.action, transaction, userAuthorizedDuring, paymentMemo, payeeVerifiedBy)
+                this,
+                intent.action,
+                transaction,
+                userAuthorizedDuring,
+                paymentMemo,
+                payeeVerifiedBy
+            )
             startActivity(transactionResultIntent)
             finish()
         }
@@ -262,7 +268,7 @@ class PaymentProtocolFragment : Fragment(R.layout.fragment_payment_protocol) {
 
         binding.paymentRequest.memo.text = paymentIntent.memo
         binding.paymentRequest.payeeSecuredBy.text = paymentIntent.payeeVerifiedBy
-                ?: getString(R.string.send_coins_fragment_payee_verified_by_unknown)
+            ?: getString(R.string.send_coins_fragment_payee_verified_by_unknown)
 
         val forceMarqueeOnClickListener = View.OnClickListener {
             it.isSelected = false

--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsActivity.kt
@@ -24,17 +24,15 @@ import android.net.Uri
 import android.nfc.NdefMessage
 import android.nfc.NfcAdapter
 import android.os.Bundle
-import android.util.Log
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
-import kotlin.coroutines.resume
 import androidx.navigation.fragment.NavHostFragment
 import dagger.hilt.android.AndroidEntryPoint
 import de.schildbach.wallet.data.PaymentIntent
 import de.schildbach.wallet.integration.android.BitcoinIntegration
-import de.schildbach.wallet.ui.util.InputParser
 import de.schildbach.wallet.ui.LockScreenActivity
+import de.schildbach.wallet.ui.util.InputParser
 import de.schildbach.wallet.ui.util.InputParserException
 import de.schildbach.wallet.util.Nfc
 import de.schildbach.wallet_test.R
@@ -47,6 +45,7 @@ import org.bitcoinj.core.VerificationException
 import org.bitcoinj.protocols.payments.PaymentProtocol
 import org.dash.wallet.common.ui.dialogs.AdaptiveDialog
 import java.io.FileNotFoundException
+import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 @AndroidEntryPoint
@@ -249,9 +248,12 @@ open class SendCoinsActivity : LockScreenActivity() {
             }
         )
 
-        navController.setGraph(navGraph, bundleOf(
-            INTENT_EXTRA_PAYMENT_INTENT to paymentIntent
-        ))
+        navController.setGraph(
+            navGraph,
+            bundleOf(
+                INTENT_EXTRA_PAYMENT_INTENT to paymentIntent
+            )
+        )
     }
 
     private fun Uri.hasValidScheme() =

--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsBaseViewModel.kt
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsBaseViewModel.kt
@@ -25,8 +25,8 @@ import org.bitcoinj.utils.MonetaryFormat
 import org.bitcoinj.wallet.SendRequest
 import org.bitcoinj.wallet.ZeroConfCoinSelector
 import org.dash.wallet.common.Configuration
-import org.dash.wallet.common.util.Constants
 import org.dash.wallet.common.WalletDataProvider
+import org.dash.wallet.common.util.Constants
 import javax.inject.Inject
 
 @HiltViewModel
@@ -59,7 +59,8 @@ open class SendCoinsBaseViewModel @Inject constructor(
         signInputs: Boolean,
         forceEnsureMinRequiredFee: Boolean
     ): SendRequest {
-        paymentIntent.setInstantX(false) // to make sure the correct instance of Transaction class is used in toSendRequest() method
+        // to make sure the correct instance of Transaction class is used in toSendRequest() method
+        paymentIntent.setInstantX(false)
         val sendRequest = paymentIntent.toSendRequest()
         sendRequest.coinSelector = ZeroConfCoinSelector.get()
         sendRequest.useInstantSend = false

--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.kt
@@ -85,9 +85,9 @@ class SendCoinsFragment: Fragment(R.layout.send_coins_fragment) {
             requireActivity().finish()
         }
 
-        if (savedInstanceState == null) {
-            viewModel.initPaymentIntent(args.paymentIntent)
+        viewModel.initPaymentIntent(args.paymentIntent)
 
+        if (savedInstanceState == null) {
             val intentAmount = args.paymentIntent.amount
             var dashToFiat = viewModel.isDashToFiatPreferred
             // If an amount is specified (in Dash), then set the active currency to Dash
@@ -106,6 +106,10 @@ class SendCoinsFragment: Fragment(R.layout.send_coins_fragment) {
                 .add(R.id.enter_amount_fragment_placeholder, fragment)
                 .commitNow()
             enterAmountFragment = fragment
+        } else {
+            enterAmountFragment = childFragmentManager.findFragmentById(
+                R.id.enter_amount_fragment_placeholder
+            ) as EnterAmountFragment
         }
 
         binding.hideButton.setOnClickListener {

--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.kt
@@ -129,7 +129,7 @@ class SendCoinsFragment: Fragment(R.layout.send_coins_fragment) {
         }
 
         enterAmountViewModel.amount.observe(viewLifecycleOwner) { viewModel.currentAmount = it }
-        enterAmountViewModel.dashToFiatDirection.observe(viewLifecycleOwner) { viewModel.isDashToFiatPreferred = it}
+        enterAmountViewModel.dashToFiatDirection.observe(viewLifecycleOwner) { viewModel.isDashToFiatPreferred = it }
         enterAmountViewModel.onContinueEvent.observe(viewLifecycleOwner) {
             lifecycleScope.launch { authenticateOrConfirm() }
         }
@@ -154,15 +154,19 @@ class SendCoinsFragment: Fragment(R.layout.send_coins_fragment) {
 
         enterAmountFragment?.setError(errorMessage)
         enterAmountViewModel.blockContinue = errorMessage.isNotEmpty() ||
-                !viewModel.everythingPlausible() ||
-                viewModel.isBlockchainReplaying.value ?: false
+            !viewModel.everythingPlausible() ||
+            viewModel.isBlockchainReplaying.value ?: false
 
-        enterAmountFragment?.setViewDetails(getString(when (state) {
-            SendCoinsViewModel.State.INPUT -> R.string.send_coins_fragment_button_send
-            SendCoinsViewModel.State.SENDING -> R.string.send_coins_sending_msg
-            SendCoinsViewModel.State.SENT -> R.string.send_coins_sent_msg
-            SendCoinsViewModel.State.FAILED -> R.string.send_coins_failed_msg
-        }))
+        enterAmountFragment?.setViewDetails(
+            getString(
+                when (state) {
+                    SendCoinsViewModel.State.INPUT -> R.string.send_coins_fragment_button_send
+                    SendCoinsViewModel.State.SENDING -> R.string.send_coins_sending_msg
+                    SendCoinsViewModel.State.SENT -> R.string.send_coins_sent_msg
+                    SendCoinsViewModel.State.FAILED -> R.string.send_coins_failed_msg
+                }
+            )
+        )
     }
 
     private suspend fun authenticateOrConfirm() {
@@ -257,8 +261,13 @@ class SendCoinsFragment: Fragment(R.layout.send_coins_fragment) {
         val fee = txFee?.toPlainString() ?: ""
 
         val confirmed = ConfirmTransactionDialog.showDialogAsync(
-            requireActivity(), address, amountStr, amountFiat,
-            fiatSymbol, fee, total ?: ""
+            requireActivity(),
+            address,
+            amountStr,
+            amountFiat,
+            fiatSymbol,
+            fee,
+            total ?: ""
         )
 
         if (confirmed) {
@@ -292,7 +301,9 @@ class SendCoinsFragment: Fragment(R.layout.send_coins_fragment) {
 
         val transactionResultIntent = TransactionResultActivity.createIntent(
             requireActivity(),
-            requireActivity().intent.action, transaction, false
+            requireActivity().intent.action,
+            transaction,
+            false
         )
         startActivity(transactionResultIntent)
     }
@@ -308,7 +319,8 @@ class SendCoinsFragment: Fragment(R.layout.send_coins_fragment) {
         if (soundResId > 0) {
             RingtoneManager.getRingtone(
                 requireActivity(),
-                Uri.parse("android.resource://" + requireActivity().packageName + "/" + soundResId))
+                Uri.parse("android.resource://" + requireActivity().packageName + "/" + soundResId)
+            )
                 .play()
         }
     }
@@ -399,11 +411,13 @@ class SendCoinsFragment: Fragment(R.layout.send_coins_fragment) {
         }
 
         revealBalance = isRevealing
-        viewModel.logEvent(if (revealBalance) {
-            AnalyticsConstants.SendReceive.ENTER_AMOUNT_SHOW_BALANCE
-        } else {
-            AnalyticsConstants.SendReceive.ENTER_AMOUNT_HIDE_BALANCE
-        })
+        viewModel.logEvent(
+            if (revealBalance) {
+                AnalyticsConstants.SendReceive.ENTER_AMOUNT_SHOW_BALANCE
+            } else {
+                AnalyticsConstants.SendReceive.ENTER_AMOUNT_HIDE_BALANCE
+            }
+        )
         viewModel.maxOutputAmount.value?.let { balance ->
             updateBalanceLabel(balance, enterAmountViewModel.selectedExchangeRate.value)
         }

--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsViewModel.kt
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsViewModel.kt
@@ -59,7 +59,7 @@ class SendCoinsViewModel @Inject constructor(
     }
 
     enum class State {
-        INPUT,  // asks for confirmation
+        INPUT, // asks for confirmation
         SENDING, SENT, FAILED // sending states
     }
 
@@ -117,8 +117,10 @@ class SendCoinsViewModel @Inject constructor(
         super.initPaymentIntent(paymentIntent)
 
         if (paymentIntent.hasPaymentRequestUrl()) {
-            throw IllegalArgumentException(PaymentProtocolFragment::class.java.simpleName
-                    + "class should be used to handle Payment requests (BIP70 and BIP270)")
+            throw IllegalArgumentException(
+                PaymentProtocolFragment::class.java.simpleName +
+                    "class should be used to handle Payment requests (BIP70 and BIP270)"
+            )
         }
 
         log.info("got {}", paymentIntent)
@@ -172,7 +174,7 @@ class SendCoinsViewModel @Inject constructor(
 
     fun shouldAdjustAmount(): Boolean {
         return dryRunException is InsufficientMoneyException &&
-                currentAmount.isLessThan(maxOutputAmount.value ?: Coin.ZERO)
+            currentAmount.isLessThan(maxOutputAmount.value ?: Coin.ZERO)
     }
 
     fun getAdjustedAmount(): Coin {

--- a/wallet/src/de/schildbach/wallet/ui/send/UpholdTransferActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/send/UpholdTransferActivity.kt
@@ -32,7 +32,6 @@ import androidx.core.content.res.ResourcesCompat
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import de.schildbach.wallet.Constants
-//import de.schildbach.wallet.ui.send.EnterAmountSharedViewModel
 import de.schildbach.wallet_test.R
 import kotlinx.coroutines.launch
 import org.bitcoinj.core.Coin
@@ -88,8 +87,8 @@ class UpholdTransferActivity : InteractionAwareActivity() {
         if (savedInstanceState == null) {
             val fragment = EnterAmountFragment.newInstance()
             supportFragmentManager.beginTransaction()
-                    .replace(R.id.container, fragment)
-                    .commitNow()
+                .replace(R.id.container, fragment)
+                .commitNow()
 
             val drawableDash = ResourcesCompat.getDrawable(resources, R.drawable.ic_dash_d_black, null)
             drawableDash!!.setBounds(0, 0, 38, 38)
@@ -144,34 +143,53 @@ class UpholdTransferActivity : InteractionAwareActivity() {
     private fun showPaymentConfirmation(amount: Coin) {
         val receiveAddress = walletDataProvider.freshReceiveAddress()
 
-        withdrawalDialog = UpholdWithdrawalHelper(BigDecimal(balance.toPlainString()), object : OnTransferListener {
-            override fun onConfirm(transaction: UpholdTransaction) {
-                val address: String = receiveAddress.toBase58()
-                val amountStr = transaction.origin.base.toPlainString()
+        withdrawalDialog = UpholdWithdrawalHelper(
+            BigDecimal(balance.toPlainString()),
+            object : OnTransferListener {
+                override fun onConfirm(transaction: UpholdTransaction) {
+                    val address: String = receiveAddress.toBase58()
+                    val amountStr = transaction.origin.base.toPlainString()
 
-                // if the exchange rate is not available, then show "Not Available"
-                val exchangeRate = enterAmountViewModel.selectedExchangeRate.value?.let { ExchangeRate(Coin.COIN, it.fiat) }
-                val fiatAmount = exchangeRate?.coinToFiat(amount)
-                val amountFiat = if (fiatAmount != null) Constants.LOCAL_FORMAT.format(fiatAmount).toString() else getString(R.string.transaction_row_rate_not_available)
-                val fiatSymbol = if (fiatAmount != null) GenericUtils.currencySymbol(fiatAmount.currencyCode) else ""
+                    // if the exchange rate is not available, then show "Not Available"
+                    val exchangeRate = enterAmountViewModel.selectedExchangeRate.value?.let {
+                        ExchangeRate(Coin.COIN, it.fiat)
+                    }
+                    val fiatAmount = exchangeRate?.coinToFiat(amount)
+                    val amountFiat = if (fiatAmount != null) {
+                        Constants.LOCAL_FORMAT.format(fiatAmount).toString()
+                    } else {
+                        getString(R.string.transaction_row_rate_not_available)
+                    }
+                    val fiatSymbol = fiatAmount?.let { GenericUtils.currencySymbol(it.currencyCode) } ?: ""
 
-                val fee = transaction.origin.fee.toPlainString()
-                val total = transaction.origin.amount.toPlainString()
-                lifecycleScope.launch {
-                    val toContinue = ConfirmTransactionDialog.showDialogAsync(this@UpholdTransferActivity, address, amountStr, amountFiat, fiatSymbol, fee, total)
+                    val fee = transaction.origin.fee.toPlainString()
+                    val total = transaction.origin.amount.toPlainString()
+                    lifecycleScope.launch {
+                        val toContinue = ConfirmTransactionDialog.showDialogAsync(
+                            this@UpholdTransferActivity,
+                            address,
+                            amountStr,
+                            amountFiat,
+                            fiatSymbol,
+                            fee,
+                            total
+                        )
 
-                    if (toContinue) {
-                        withdrawalDialog.commitTransaction(this@UpholdTransferActivity)
+                        if (toContinue) {
+                            withdrawalDialog.commitTransaction(this@UpholdTransferActivity)
+                        }
                     }
                 }
-            }
 
-            override fun onTransfer() {
-                transactionMetadataProvider.markAddressAsTransferInAsync(receiveAddress.toBase58(), ServiceName.Uphold)
-                finish()
+                override fun onTransfer() {
+                    transactionMetadataProvider.markAddressAsTransferInAsync(
+                        receiveAddress.toBase58(),
+                        ServiceName.Uphold
+                    )
+                    finish()
+                }
             }
-
-        })
+        )
         withdrawalDialog.transfer(this, receiveAddress.toBase58(), BigDecimal(amount.toPlainString()), false)
     }
 


### PR DESCRIPTION
When the system restores SendCoinsFragment after killing the app process, the payment intent ends up being not initialized.

## Issue being fixed or feature implemented
- Re-initialize the payment intent from the saved state.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
