### PR TITLE
fix: render the platform private/public key (base64) correctly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         kotlin_version = '1.8.22'
         coroutines_version = '1.6.1'
         ok_http_version = '4.9.1'
-        dashjVersion = '19.0.3'
+        dashjVersion = '19.0.4-SNAPSHOT'
         hiltVersion = '2.45'
         hiltWorkVersion = '1.0.0'
         workRuntimeVersion='2.7.1'

--- a/wallet/src/de/schildbach/wallet/ui/more/masternode_keys/MasternodeKeysViewModel.kt
+++ b/wallet/src/de/schildbach/wallet/ui/more/masternode_keys/MasternodeKeysViewModel.kt
@@ -309,7 +309,7 @@ class MasternodeKeysViewModel @Inject constructor(
         val bytes = ByteArray(64)
         decryptedKey.privKeyBytes.copyInto(bytes, 0, 0, 32)
         // public key bytes have a 0x00 prefix byte that is ignored
-        decryptedKey.pubKey.copyInto(bytes, 32, 1, 32)
+        decryptedKey.pubKey.copyInto(bytes, 32, 1, 33)
         val privatePublicKeyBase64 = Base64.toBase64String(bytes)
 
         return MasternodeKeyInfo(key, privateKeyHex, privateKeyWif, privatePublicKeyBase64)


### PR DESCRIPTION
* The last byte was always set to zero (0x00)

<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
Fix the HPMN Operator private / public keypair rendering in base64 format.
## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
