### PR TITLE
fix: avoid leaking balance info by error message or continue button

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/ui/enter_amount/EnterAmountFragment.kt
+++ b/common/src/main/java/org/dash/wallet/common/ui/enter_amount/EnterAmountFragment.kt
@@ -88,6 +88,10 @@ class EnterAmountFragment : Fragment(R.layout.fragment_enter_amount) {
         private set
     var didAuthorize: Boolean = false
 
+    private val requirePinForBalance by lazy {
+        requireArguments().getBoolean(ARG_REQUIRE_PIN_MAX_BUTTON)
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -132,8 +136,12 @@ class EnterAmountFragment : Fragment(R.layout.fragment_enter_amount) {
             }
         }
 
-        viewModel.canContinue.observe(viewLifecycleOwner) {
-            binding.continueBtn.isEnabled = it
+        viewModel.canContinue.observe(viewLifecycleOwner) { canContinue ->
+            binding.continueBtn.isEnabled = if (!didAuthorize && requirePinForBalance) {
+                viewModel.amount.value?.isPositive ?: false
+            } else {
+                canContinue
+            }
         }
     }
 
@@ -201,7 +209,7 @@ class EnterAmountFragment : Fragment(R.layout.fragment_enter_amount) {
     }
 
     private suspend fun onMaxAmountButtonClick() {
-        if (!didAuthorize && requireArguments().getBoolean(ARG_REQUIRE_PIN_MAX_BUTTON)) {
+        if (!didAuthorize && requirePinForBalance) {
             authManager.authenticate(requireActivity(), false) ?: return
             didAuthorize = true
         }

--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.kt
@@ -74,10 +74,12 @@ class SendCoinsFragment: Fragment(R.layout.send_coins_fragment) {
             enterAmountFragment?.didAuthorize = value
         }
 
+    private val requirePinForBalance by lazy {
+        (requireActivity() as LockScreenActivity).keepUnlocked
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        val requirePinForBalance = (requireActivity() as LockScreenActivity).keepUnlocked
 
         binding.titleBar.setNavigationOnClickListener {
             requireActivity().finish()
@@ -150,7 +152,11 @@ class SendCoinsFragment: Fragment(R.layout.send_coins_fragment) {
         } else if (dryRunException != null) {
             errorMessage = when (dryRunException) {
                 is Wallet.DustySendRequested -> getString(R.string.send_coins_error_dusty_send)
-                is InsufficientMoneyException -> getString(R.string.send_coins_error_insufficient_money)
+                is InsufficientMoneyException -> if (!requirePinForBalance || userAuthorizedDuring) {
+                    getString(R.string.send_coins_error_insufficient_money)
+                } else {
+                    ""
+                }
                 is Wallet.CouldNotAdjustDownwards -> getString(R.string.send_coins_error_dusty_send)
                 else -> dryRunException.toString()
             }


### PR DESCRIPTION
When the user launches Send screen from the locked state, the balance info can still be leaked because we show an "Insufficient funds" error and block the Continue button.

## Issue being fixed or feature implemented
- Don't show the error until the user authenticates.
- Don't block the button until the user authenticates (except for zero amount).

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
