### PR TITLE
fix: adjust font size for the shortcut text

### DIFF
--- a/wallet/res/layout/home_content.xml
+++ b/wallet/res/layout/home_content.xml
@@ -91,11 +91,10 @@
         <de.schildbach.wallet.ui.widget.ShortcutsPane
             android:id="@+id/shortcuts_pane"
             android:layout_width="match_parent"
-            android:layout_height="90dp"
+            android:layout_height="92dp"
             android:layout_marginStart="16dp"
             android:layout_marginEnd="16dp"
-            android:paddingTop="4dp"
-            android:paddingBottom="4dp"
+            android:paddingHorizontal="2dp"
             app:layout_anchor="@id/buttons_anchor"
             app:layout_behavior="de.schildbach.wallet.ui.CollapsingImageBehavior" />
 

--- a/wallet/res/layout/shortcut_button.xml
+++ b/wallet/res/layout/shortcut_button.xml
@@ -32,7 +32,10 @@
         android:lineSpacingMultiplier="0.9"
         android:maxLines="2"
         android:minLines="1"
-        tools:ignore="SmallSp"
+        android:autoSizeTextType="uniform"
+        android:autoSizeMinTextSize="10sp"
+        android:autoSizeMaxTextSize="12sp"
+        android:autoSizeStepGranularity="1sp"
         tools:text="Send" />
 
 </merge>

--- a/wallet/src/de/schildbach/wallet/ui/widget/ShortcutsPane.kt
+++ b/wallet/src/de/schildbach/wallet/ui/widget/ShortcutsPane.kt
@@ -81,15 +81,6 @@ class ShortcutsPane(context: Context, attrs: AttributeSet) : FlexboxLayout(conte
             this
         )
     }
-    val configButton: ShortcutButton by lazy {
-        ShortcutButton(
-            context,
-            R.drawable.ic_shortcut_add,
-            R.string.shortcut_add_shortcut,
-            this
-        )
-    }
-
     val explore: ShortcutButton by lazy {
         ShortcutButton(
             context,
@@ -170,7 +161,10 @@ class ShortcutsPane(context: Context, attrs: AttributeSet) : FlexboxLayout(conte
     private fun addShortcut(shortcut: ShortcutButton) {
         if (!children.contains(shortcut)) {
             val index = min(childCount, shortcuts.indexOf(shortcut))
-            val layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+            val layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
             addView(shortcut, index, layoutParams)
         }
     }


### PR DESCRIPTION
In some languages, shortcut text doesn't fit and is cut off.

## Issue being fixed or feature implemented
- Increase shortcut bar height slightly to fit 2 lines of text.
- Make the label adjustable between 10 and 12 sp.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
before / after
<img src="https://github.com/dashpay/dash-wallet/assets/7733989/268ed31c-690a-451c-875f-7eda515f48e4" width="240">&emsp;<img src="https://github.com/dashpay/dash-wallet/assets/7733989/a4f6d6f6-b973-4053-b899-4f4e03dc8b81" width="240">

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
