### PR TITLE
fix(dashpay): only set tx icon in updateIcon method 

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/transactions/TransactionResultViewBinder.kt
+++ b/wallet/src/de/schildbach/wallet/ui/transactions/TransactionResultViewBinder.kt
@@ -320,7 +320,6 @@ class TransactionResultViewBinder(
             binding.openTaxCategoryCard.isVisible = false
             binding.dashAmount.setStrikeThru(true)
             binding.fiatValue.setStrikeThru(true)
-            binding.checkIcon.setImageResource(R.drawable.ic_transaction_failed)
             binding.transactionTitle.text = context.getText(R.string.transaction_failed_details)
 
             var rescanText = ""
@@ -345,26 +344,16 @@ class TransactionResultViewBinder(
             }
         } else {
             if (tx.getValue(wallet).signum() < 0) {
-                binding.checkIcon.setImageResource(
-                    if (tx.isEntirelySelf(wallet)) {
-                        R.drawable.ic_internal
-                    } else {
-                        R.drawable.ic_transaction_sent
-                    }
-                )
-
                 binding.transactionTitle.setTextColor(ContextCompat.getColor(context, R.color.dash_blue))
                 binding.transactionTitle.text = context.getText(R.string.transaction_details_amount_sent)
                 binding.transactionAmountSignal.text = "-"
                 binding.transactionAmountSignal.isVisible = true
             } else {
-                binding.checkIcon.setImageResource(R.drawable.ic_transaction_received)
                 binding.transactionTitle.setTextColor(ContextCompat.getColor(context, R.color.system_green))
                 binding.transactionTitle.text = context.getText(R.string.transaction_details_amount_received)
                 binding.transactionAmountSignal.isVisible = true
                 binding.transactionAmountSignal.text = "+"
             }
-            binding.checkIcon.isVisible = true
             binding.feeContainer.isVisible = isFeeAvailable(tx.fee)
         }
     }


### PR DESCRIPTION
`TransactionResultViewBinder` has some extra code related to setting the icon that should be removed.

## Issue being fixed or feature implemented
- Remove all icon-setting code except for updateIcon

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
