### PR TITLE
refactor: move explainer dialogs to WalletActivityExt

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/main/WalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/main/WalletActivity.java
@@ -17,24 +17,15 @@
 
 package de.schildbach.wallet.ui.main;
 
-import android.Manifest;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
-import android.net.Uri;
 import android.nfc.NdefMessage;
 import android.nfc.NfcAdapter;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.PowerManager;
-import android.provider.Settings;
-
-import androidx.activity.result.ActivityResultLauncher;
-import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat;
 import androidx.lifecycle.ViewModelProvider;
 
 import com.google.common.collect.ImmutableList;
@@ -125,7 +116,7 @@ public final class WalletActivity extends AbstractBindServiceActivity
         super.onStart();
 
         if (!getLockScreenDisplayed() && configuration.getShowNotificationsExplainer()) {
-            explainPushNotifications();
+            WalletActivityExt.INSTANCE.explainPushNotifications(this);
         }
     }
 
@@ -368,60 +359,7 @@ public final class WalletActivity extends AbstractBindServiceActivity
     @Override
     public void onLockScreenDeactivated() {
         if (configuration.getShowNotificationsExplainer()) {
-            explainPushNotifications();
-        }
-    }
-
-    private final ActivityResultLauncher<String> requestPermissionLauncher =
-            registerForActivityResult(new ActivityResultContracts.RequestPermission(), granted -> {
-                // do nothing
-                requestDisableBatteryOptimisation();
-            });
-
-    /**
-     * Android 13 - Show system dialog to get notification permission from user, if not granted
-     *              ask again with each app upgrade if not granted.  This logic is handled by
-     *              {@link #onLockScreenDeactivated} and {@link #onStart}.
-     * Android 12 and below - show a explainer dialog once only.
-     */
-    private void explainPushNotifications() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
-                ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
-            requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS);
-        } else if (configuration.getShowNotificationsExplainer()) {
-            AdaptiveDialog dialog = AdaptiveDialog.create(
-                    R.drawable.ic_info_blue,
-                    getString(R.string.notification_explainer_title),
-                    getString(R.string.notification_explainer_message),
-                    "",
-                    getString(R.string.button_okay)
-            );
-
-            dialog.show(this, result -> {
-                requestDisableBatteryOptimisation();
-                return Unit.INSTANCE;
-            });
-        }
-        // only show either the permissions dialog (Android >= 13) or the explainer (Android <= 12) once
-        configuration.setShowNotificationsExplainer(false);
-    }
-
-    private void requestDisableBatteryOptimisation() {
-        PowerManager powerManager = getSystemService(PowerManager.class);
-        if (ContextCompat.checkSelfPermission(walletApplication, Manifest.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS) == PackageManager.PERMISSION_GRANTED &&
-                !powerManager.isIgnoringBatteryOptimizations(walletApplication.getPackageName())) {
-            AdaptiveDialog.create(
-                    R.drawable.ic_bolt_border,
-                getString(R.string.battery_optimization_dialog_optimized_title),
-                getString(R.string.battery_optimization_dialog_message_optimized),
-                getString(R.string.permission_deny),
-                getString(R.string.permission_allow)
-            ).show(this, (allow) -> {
-                if (allow) {
-                    startActivity(new Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS, Uri.parse("package:" + getPackageName())));
-                }
-                return Unit.INSTANCE;
-            });
+            WalletActivityExt.INSTANCE.explainPushNotifications(this);
         }
     }
 }

--- a/wallet/src/de/schildbach/wallet/ui/main/WalletActivityExt.kt
+++ b/wallet/src/de/schildbach/wallet/ui/main/WalletActivityExt.kt
@@ -17,13 +17,20 @@
 
 package de.schildbach.wallet.ui.main
 
+import android.Manifest
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.os.PowerManager
 import android.os.storage.StorageManager
 import android.provider.Settings
 import android.view.MenuItem
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
@@ -36,6 +43,7 @@ import de.schildbach.wallet_test.R
 import kotlinx.coroutines.launch
 import org.dash.wallet.common.services.analytics.AnalyticsConstants
 import org.dash.wallet.common.ui.dialogs.AdaptiveDialog
+import org.dash.wallet.common.ui.dialogs.AdaptiveDialog.Companion.create
 import org.dash.wallet.common.util.openCustomTab
 
 object WalletActivityExt {
@@ -191,6 +199,68 @@ object WalletActivityExt {
         ).show(this) { openSettings ->
             if (openSettings == true && hasStorageManager) {
                 startActivity(storageManagerIntent)
+            }
+        }
+    }
+
+    private val WalletActivity.requestPermissionLauncher: ActivityResultLauncher<String>
+        get() = registerForActivityResult(ActivityResultContracts.RequestPermission()) {
+            requestDisableBatteryOptimisation()
+        }
+
+    /**
+     * Android 13 - Show system dialog to get notification permission from user, if not granted
+     * ask again with each app upgrade if not granted.  This logic is handled by
+     * [.onLockScreenDeactivated] and [.onStart].
+     * Android 12 and below - show a explainer dialog once only.
+     */
+    fun WalletActivity.explainPushNotifications() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        } else if (configuration.showNotificationsExplainer) {
+            val dialog = create(
+                R.drawable.ic_info_blue,
+                getString(R.string.notification_explainer_title),
+                getString(R.string.notification_explainer_message),
+                "",
+                getString(R.string.button_okay)
+            )
+            dialog.show(this) {
+                requestDisableBatteryOptimisation()
+            }
+        }
+        // only show either the permissions dialog (Android >= 13) or the explainer (Android <= 12) once
+        configuration.showNotificationsExplainer = false
+    }
+
+    private fun WalletActivity.requestDisableBatteryOptimisation() {
+        val powerManager: PowerManager = getSystemService(PowerManager::class.java)
+        if (ContextCompat.checkSelfPermission(
+                walletApplication,
+                Manifest.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
+            ) == PackageManager.PERMISSION_GRANTED &&
+            !powerManager.isIgnoringBatteryOptimizations(walletApplication.packageName)
+        ) {
+            create(
+                R.drawable.ic_bolt_border,
+                getString(R.string.battery_optimization_dialog_optimized_title),
+                getString(R.string.battery_optimization_dialog_message_optimized),
+                getString(R.string.permission_deny),
+                getString(R.string.permission_allow)
+            ).show(this) { allow: Boolean? ->
+                if (allow == true) {
+                    startActivity(
+                        Intent(
+                            Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+                            Uri.parse("package:$packageName")
+                        )
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
* fix crash when request disable battery opt dialog is cancelled

<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
Some code is moved to `WalletActivityExt` which will make it a little easier to merge with DashPay.
## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
