### PR TITLE
fix: refactor WalletActivity permission launcher to avoid InvalidStat…

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/main/WalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/main/WalletActivity.java
@@ -25,6 +25,8 @@ import android.nfc.NfcAdapter;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.PowerManager;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.core.app.ActivityCompat;
 import androidx.lifecycle.ViewModelProvider;
 
@@ -76,6 +78,7 @@ public final class WalletActivity extends AbstractBindServiceActivity
     private BaseAlertDialogBuilder baseAlertDialogBuilder;
     private MainViewModel viewModel;
 
+    ActivityResultLauncher<String> requestPermissionLauncher = registerForActivityResult(new ActivityResultContracts.RequestPermission(), result -> WalletActivityExt.INSTANCE.requestDisableBatteryOptimisation(WalletActivity.this));
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {

--- a/wallet/src/de/schildbach/wallet/ui/main/WalletActivityExt.kt
+++ b/wallet/src/de/schildbach/wallet/ui/main/WalletActivityExt.kt
@@ -203,11 +203,6 @@ object WalletActivityExt {
         }
     }
 
-    private val WalletActivity.requestPermissionLauncher: ActivityResultLauncher<String>
-        get() = registerForActivityResult(ActivityResultContracts.RequestPermission()) {
-            requestDisableBatteryOptimisation()
-        }
-
     /**
      * Android 13 - Show system dialog to get notification permission from user, if not granted
      * ask again with each app upgrade if not granted.  This logic is handled by
@@ -238,7 +233,7 @@ object WalletActivityExt {
         configuration.showNotificationsExplainer = false
     }
 
-    private fun WalletActivity.requestDisableBatteryOptimisation() {
+    fun WalletActivity.requestDisableBatteryOptimisation() {
         val powerManager: PowerManager = getSystemService(PowerManager::class.java)
         if (ContextCompat.checkSelfPermission(
                 walletApplication,


### PR DESCRIPTION
…eException

<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
Fix:
```
Fatal Exception: java.lang.IllegalStateException
LifecycleOwner de.schildbach.wallet.ui.main.WalletActivity@1e0e6df is attempting to register while current state is RESUMED. LifecycleOwners must call register before they are STARTED.

androidx.activity.result.ActivityResultRegistry.register (ActivityResultRegistry.java:123)
androidx.activity.ComponentActivity.registerForActivityResult (ComponentActivity.java:842)
de.schildbach.wallet.ui.main.WalletActivityExt.getRequestPermissionLauncher (WalletActivityExt.kt:207)
de.schildbach.wallet.ui.main.WalletActivityExt.explainPushNotifications (WalletActivityExt.kt:224)
de.schildbach.wallet.ui.main.WalletActivity.onLockScreenDeactivated (WalletActivity.java:362) 
```
## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->
none
## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [x] I have added or updated relevant unit/integration/functional/e2e tests
