### PR TITLE
fix: prevent rescan blockchain failure on old wallets

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         kotlin_version = '1.8.22'
         coroutinesVersion = '1.6.4'
         ok_http_version = '4.9.1'
-        dashjVersion = '20.0.1-SNAPSHOT'
+        dashjVersion = '20.0.2'
         hiltVersion = '2.45'
         hiltWorkVersion = '1.0.0'
         workRuntimeVersion='2.7.1'

--- a/wallet/src/de/schildbach/wallet/service/BootstrapReceiver.java
+++ b/wallet/src/de/schildbach/wallet/service/BootstrapReceiver.java
@@ -138,7 +138,7 @@ public class BootstrapReceiver extends BroadcastReceiver {
         WalletExtension extension = extensions.get(AuthenticationGroupExtension.EXTENSION_ID);
         if (extension != null) {
             // reset will rescan existing transactions and rebuild the authentication usage info
-            ((AuthenticationGroupExtension) extension).reset();
+            ((AuthenticationGroupExtension) extension).rescanWallet();
         }
 
         // Maybe upgrade wallet to secure chain


### PR DESCRIPTION
* only rescan transactions for masternode key usage on upgrade

<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
DashJ has the actual fix to the bug

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->
https://github.com/dashpay/dashj/pull/241
## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [x] I have added or updated relevant unit/integration/functional/e2e tests
