### PR TITLE
fix: allow reset wallet to finish

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/AbstractBindServiceActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/AbstractBindServiceActivity.java
@@ -78,7 +78,7 @@ public abstract class AbstractBindServiceActivity extends LockScreenActivity {
         super.onPause();
     }
 
-    protected void doUnbindService() {
+    public void doUnbindService() {
         if (shouldUnbind) {
             unbindService(serviceConnection);
             shouldUnbind = false;

--- a/wallet/src/de/schildbach/wallet/ui/more/SecurityFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/more/SecurityFragment.kt
@@ -198,6 +198,7 @@ class SecurityFragment : Fragment(R.layout.fragment_security) {
         viewModel.logEvent(AnalyticsConstants.Security.RESET_WALLET)
         val dialog = AdaptiveDialog.progress(getString(R.string.perm_lock_wipe_wallet))
         dialog.show(requireActivity())
+        (requireActivity() as AbstractBindServiceActivity).doUnbindService()
         viewModel.triggerWipe() {
             dialog.dismissAllowingStateLoss()
             startActivity(OnboardingActivity.createIntent(requireContext()))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
Reset wallet doesn't finish, this will ensure that it does.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the wallet reset functionality to ensure that background processes are properly disconnected before data is wiped, resulting in a more reliable reset operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->