### PR TITLE
fix: make ExchangeRatesConfig a singleton

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/data/ExchangeRatesConfig.kt
+++ b/common/src/main/java/org/dash/wallet/common/data/ExchangeRatesConfig.kt
@@ -5,7 +5,9 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import org.dash.wallet.common.WalletDataProvider
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class ExchangeRatesConfig
     @Inject
     constructor(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
```
java.lang.IllegalStateException: There are multiple DataStores active for the same file: files/datastore/exchange_rates_config.preferences_pb. You should either maintain your DataStore as a singleton or confirm that there is no two DataStore's active on the same file (by confirming that the scope is cancelled).
	at androidx.datastore.core.SingleProcessDataStore$file$2.invoke(SingleProcessDataStore.kt:168)
	at androidx.datastore.core.SingleProcessDataStore$file$2.invoke(SingleProcessDataStore.kt:163)
	at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74)
	at androidx.datastore.core.SingleProcessDataStore.getFile(SingleProcessDataStore.kt:163)
	at androidx.datastore.core.SingleProcessDataStore.readData(SingleProcessDataStore.kt:380)
	at androidx.datastore.core.SingleProcessDataStore.readDataOrHandleCorruption(SingleProcessDataStore.kt:359)
	at androidx.datastore.core.SingleProcessDataStore.readAndInit(SingleProcessDataStore.kt:322)
```
## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->
None
## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has not yet been tested
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
