### PR TITLE
fix: update tx metadta once contacts are resolved

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/main/MainViewModel.kt
+++ b/wallet/src/de/schildbach/wallet/ui/main/MainViewModel.kt
@@ -321,12 +321,13 @@ class MainViewModel @Inject constructor(
             UsernameSortOrderBy.LAST_ACTIVITY,
             false
         ).distinctUntilChanged()
-         .onEach { contacts ->
+        .onEach { contacts ->
             this.minContactCreatedDate = contacts.minOfOrNull { it.dashPayProfile.createdAt }?.let {
-                Instant.ofEpochMilli(it).atZone(ZoneId.systemDefault()).toLocalDate()
+               Instant.ofEpochMilli(it).atZone(ZoneId.systemDefault()).toLocalDate()
             } ?: LocalDate.now()
             val contactsByIdentity = contacts.associate { it.dashPayProfile.userId to it.dashPayProfile }
             this.contacts = contactsByIdentity
+            refreshContactsForAllTransactions()
         }.launchIn(viewModelWorkerScope)
 
         walletData.observeWalletReset()
@@ -665,6 +666,21 @@ class MainViewModel @Inject constructor(
 
         _transactions.value = items
         this@MainViewModel.txByHash = txByHash
+        getContactsAndMetadataForTransactions(contactsToUpdate)
+    }
+
+    private fun refreshContactsForAllTransactions() {
+        val transactions = walletData.getTransactions()
+        val contactsToUpdate = mutableListOf<Transaction>()
+
+        for (tx in transactions) {
+            val dateKey = tx.updateTime.toInstant().atZone(ZoneId.systemDefault()).toLocalDate()
+
+            if (dateKey >= minContactCreatedDate) {
+                contactsToUpdate.add(tx)
+            }
+        }
+
         getContactsAndMetadataForTransactions(contactsToUpdate)
     }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Contacts are resolved after transactions, but contact metadata isn't updated.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced wallet data synchronization to ensure that updates to your contacts consistently trigger a refresh of related transaction information, resulting in more accurate and reliable wallet data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->