### PR TITLE
fix(dashspend): barcode generation

### DIFF
--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ctxspend/dialogs/GiftCardDetailsDialog.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ctxspend/dialogs/GiftCardDetailsDialog.kt
@@ -145,6 +145,7 @@ class GiftCardDetailsDialog : OffsetDialogFragment(R.layout.dialog_gift_card_det
             } else {
                 binding.purchaseCardBarcode.isVisible = false
                 binding.barcodePlaceholder.isVisible = true
+                binding.barcodePlaceholderText.isVisible = true
                 binding.barcodeLoadingError.isVisible = false
             }
 
@@ -216,7 +217,6 @@ class GiftCardDetailsDialog : OffsetDialogFragment(R.layout.dialog_gift_card_det
                 }
 
                 if (bitmap != null) {
-                    binding.barcodeLoadingError.isVisible = false
                     binding.barcodePlaceholder.isVisible = false
                     binding.purchaseCardBarcode.isVisible = true
 
@@ -229,7 +229,8 @@ class GiftCardDetailsDialog : OffsetDialogFragment(R.layout.dialog_gift_card_det
                     showBarcode(bitmap)
                 } else {
                     binding.purchaseCardBarcode.isVisible = false
-                    binding.barcodePlaceholder.isVisible = false
+                    binding.barcodePlaceholder.isVisible = true
+                    binding.barcodePlaceholderText.isVisible = false
                     binding.barcodeLoadingError.isVisible = true
                 }
             }
@@ -245,8 +246,9 @@ class GiftCardDetailsDialog : OffsetDialogFragment(R.layout.dialog_gift_card_det
                     setMaxBrightness(true)
                 },
                 onError = { _, _ ->
-                    binding.barcodePlaceholder.isVisible = false
                     binding.purchaseCardBarcode.isVisible = false
+                    binding.barcodePlaceholder.isVisible = true
+                    binding.barcodePlaceholderText.isVisible = false
                     binding.barcodeLoadingError.isVisible = true
                     setMaxBrightness(false)
                 }

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ctxspend/dialogs/GiftCardDetailsViewModel.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ctxspend/dialogs/GiftCardDetailsViewModel.kt
@@ -18,8 +18,10 @@
 package org.dash.wallet.features.exploredash.ui.ctxspend.dialogs
 
 import android.graphics.Bitmap
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.zxing.BarcodeFormat
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
@@ -157,9 +159,8 @@ class GiftCardDetailsViewModel @Inject constructor(
                             if (!giftCard.cardNumber.isNullOrEmpty()) {
                                 cancelTicker()
                                 updateGiftCard(giftCard.cardNumber, giftCard.cardPin)
-                                if (!giftCard.barcodeUrl.isNullOrEmpty()) {
-                                    saveBarcode(giftCard.barcodeUrl)
-                                }
+                                log.info("CTXSpend: saving barcode for: ${giftCard.barcodeUrl}")
+                                saveBarcode(giftCard.cardNumber)
                             } else if (giftCard.redeemUrl.isNotEmpty()) {
                                 log.error("CTXSpend returned a redeem url card: not supported")
                                 _uiState.update {
@@ -233,25 +234,16 @@ class GiftCardDetailsViewModel @Inject constructor(
         logOnPurchaseEvents(giftCard)
     }
 
-    private fun saveBarcode(barcodeUrl: String) {
+    private fun saveBarcode(giftCardNumber: String) {
         applicationScope.launch {
             try {
-                val result = Constants.HTTP_CLIENT.get(barcodeUrl)
-                require(result.isSuccessful && result.body != null) { "call is not successful" }
-                val bitmap = result.body!!.decodeBitmap()
-                val decodeResult = Qr.scanBarcode(bitmap)
-
-                if (decodeResult != null) {
-                    metadataProvider.updateGiftCardBarcode(
-                        transactionId,
-                        decodeResult.first.replace(" ", ""),
-                        decodeResult.second
-                    )
-                } else {
-                    log.error("ScanBarcode returned null: $barcodeUrl")
-                }
+                metadataProvider.updateGiftCardBarcode(
+                    transactionId,
+                    giftCardNumber.replace(" ", ""),
+                    BarcodeFormat.CODE_128 // Assuming CTX barcodes are all CODE_128
+                )
             } catch (ex: Exception) {
-                log.error("Failed to resize and decode barcode: $barcodeUrl", ex)
+                log.error("Failed to save barcode for $giftCardNumber", ex)
             }
         }
     }

--- a/features/exploredash/src/main/res/layout/dialog_gift_card_details.xml
+++ b/features/exploredash/src/main/res/layout/dialog_gift_card_details.xml
@@ -145,13 +145,26 @@
                         tools:background="@color/gray_50">
 
                         <TextView
+                            android:id="@+id/barcode_placeholder_text"
                             style="@style/Caption"
-                            android:layout_width="wrap_content"
+                            android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:gravity="center"
                             android:textAlignment="gravity"
                             android:layout_margin="20dp"
                             android:text="@string/barcode_placeholder"/>
+
+                        <TextView
+                            android:id="@+id/barcode_loading_error"
+                            style="@style/Overline.Red"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:text="@string/gift_card_barcode_failed"
+                            android:gravity="center"
+                            android:textAlignment="gravity"
+                            android:visibility="gone"
+                            android:layout_margin="20dp"
+                            tools:visibility="gone" />
                     </FrameLayout>
 
                     <ImageView
@@ -165,20 +178,6 @@
                         tools:src="@drawable/ic_dash_pay"
                         tools:visibility="gone" />
                 </FrameLayout>
-
-                <TextView
-                    android:id="@+id/barcode_loading_error"
-                    style="@style/Overline.Red"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="15dp"
-                    android:text="@string/gift_card_barcode_failed"
-                    android:visibility="gone"
-                    app:layout_constraintBottom_toTopOf="@+id/original_purchase_label"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    tools:visibility="gone" />
 
                 <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/original_purchase_label"


### PR DESCRIPTION
We don't need to "scan" the barcode before saving its data since the barcodes are generated from the gift card number.

## Issue being fixed or feature implemented
- Generate a barcode from the gift card number. Use the default format.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
