### PR TITLE
Fix datagram socket leak

### DIFF
--- a/wallet/src/de/schildbach/wallet/util/TimeUtils.kt
+++ b/wallet/src/de/schildbach/wallet/util/TimeUtils.kt
@@ -16,28 +16,28 @@ private fun queryNtpTime(server: String): Long? {
         val message = ByteArray(48)
         message[0] = 0b00100011 // NTP mode client (3) and version (4)
 
-        val socket = DatagramSocket().apply {
-            soTimeout = 3000 // Set timeout to 3000ms
+        DatagramSocket().use { socket ->
+            socket.soTimeout = 3000 // Set timeout to 3000ms
+
+            val request = DatagramPacket(message, message.size, address, 123)
+            socket.send(request) // Send request
+
+            // Receive response
+            val response = DatagramPacket(message, message.size)
+            socket.receive(response)
+
+            // Timestamp starts at byte 40 of the received packet and is four bytes,
+            // or two words, long. First byte is the high-order byte of the integer;
+            // the last byte is the low-order byte. The high word is the seconds field,
+            // and the low word is the fractional field.
+            val seconds = message[40].toLong() and 0xff shl 24 or
+                (message[41].toLong() and 0xff shl 16) or
+                (message[42].toLong() and 0xff shl 8) or
+                (message[43].toLong() and 0xff)
+
+            // Convert seconds to milliseconds and adjust from 1900 to epoch (1970)
+            return (seconds - 2208988800L) * 1000
         }
-
-        val request = DatagramPacket(message, message.size, address, 123)
-        socket.send(request) // Send request
-
-        // Receive response
-        val response = DatagramPacket(message, message.size)
-        socket.receive(response)
-
-        // Timestamp starts at byte 40 of the received packet and is four bytes,
-        // or two words, long. First byte is the high-order byte of the integer;
-        // the last byte is the low-order byte. The high word is the seconds field,
-        // and the low word is the fractional field.
-        val seconds = message[40].toLong() and 0xff shl 24 or
-            (message[41].toLong() and 0xff shl 16) or
-            (message[42].toLong() and 0xff shl 8) or
-            (message[43].toLong() and 0xff)
-
-        // Convert seconds to milliseconds and adjust from 1900 to epoch (1970)
-        return (seconds - 2208988800L) * 1000
     } catch (e: Exception) {
         // swallow
     }


### PR DESCRIPTION
## Summary
- ensure `DatagramSocket` is closed when querying NTP time

## Testing
- `gradle :wallet:compileDebugKotlin -x lint` *(fails: plugin not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal resource management to ensure sockets are closed automatically, enhancing reliability and maintainability. No changes to app behavior or visible features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->