### PR TITLE
Fix back button handling in CreateUsernameFragment

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/username/CreateUsernameFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/username/CreateUsernameFragment.kt
@@ -12,6 +12,7 @@ import android.text.style.StyleSpan
 import android.view.View
 import android.view.animation.AnimationUtils
 import android.widget.TextView
+import androidx.activity.addCallback
 import androidx.core.content.res.ResourcesCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -101,6 +102,14 @@ class CreateUsernameFragment : Fragment(R.layout.fragment_create_username), Text
             }
         }
         binding.processingIdentityDismissBtn.setOnClickListener { requireActivity().finish() }
+
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+            if (binding.registrationContent.visibility == View.VISIBLE) {
+                binding.registerBtn.performClick()
+            } else {
+                requireActivity().finish()
+            }
+        }
 
         initViewModel()
         walletApplication = requireActivity().application as WalletApplication


### PR DESCRIPTION
## Summary
- intercept back button in CreateUsernameFragment
- send user forward when pressing back instead of reopening the fragment

## Testing
- `./gradlew --version` *(fails: No route to host)*