### PR TITLE
fix: use original icon hash for id

### DIFF
--- a/wallet/src/de/schildbach/wallet/service/WalletTransactionMetadataProvider.kt
+++ b/wallet/src/de/schildbach/wallet/service/WalletTransactionMetadataProvider.kt
@@ -586,12 +586,15 @@ class WalletTransactionMetadataProvider @Inject constructor(
                 response.body?.let {
                     syncScope.launch {
                         try {
-                            val bitmap = it.decodeBitmap()
-                            val icon = resizeIcon(bitmap)
-                            val imageData = getBitmapData(icon)
-                            val imageHash = Sha256Hash.of(imageData)
+                            val originalImageData = it.bytes()
+                            // Calculate hash from original image data to have it unified across platforms
+                            val imageHash = Sha256Hash.of(originalImageData)
 
-                            iconBitmapDao.addBitmap(IconBitmap(imageHash, imageData, iconUrl, icon.height, icon.width))
+                            val bitmap = BitmapFactory.decodeByteArray(originalImageData, 0, originalImageData.size)
+                            val icon = resizeIcon(bitmap)
+                            val resizedImageData = getBitmapData(icon)
+
+                            iconBitmapDao.addBitmap(IconBitmap(imageHash, resizedImageData, iconUrl, icon.height, icon.width))
                             transactionMetadataDao.updateIconId(txId, imageHash)
                         } catch (ex: Exception) {
                             log.error("Failed to resize and save the icon for url: $iconUrl", ex)


### PR DESCRIPTION
To maintain compatibility with iOS in the case of uploading icon metadata to the platform, we need to use the same IDs for the icons. Currently, the ID hash is calculated from the resized icon data, while it is nearly impossible to resize the icon in the same way across platforms.

## Issue being fixed or feature implemented
- Use the original icon data to calculate ID instead of the resized one.

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency of icon image handling and hashing for transaction metadata across platforms. This ensures more reliable display and identification of transaction icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->