### PR TITLE
fix: eliminate crash issues when fragments/dialogs recreated and address network error

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/ui/enter_amount/EnterAmountFragment.kt
+++ b/common/src/main/java/org/dash/wallet/common/ui/enter_amount/EnterAmountFragment.kt
@@ -199,6 +199,17 @@ class EnterAmountFragment : Fragment(R.layout.fragment_enter_amount) {
         }
     }
 
+    private fun setAmountFromSavedState() {
+        if (binding.amountView.dashToFiat) {
+            binding.amountView.input = viewModel.amount.value?.toPlainString() ?: Coin.ZERO.toPlainString()
+        } else {
+            //viewModel.selectedExchangeRate.value?.let {
+                //val rate = ExchangeRate(it.fiat)
+                binding.amountView.input = viewModel.fiatAmount.value?.toPlainString() ?: Fiat.valueOf(viewModel.selectedCurrencyCode, 0).toPlainString()
+            //}
+        }
+    }
+
     private fun setupAmountView(dashToFiat: Boolean) {
         pickedCurrencyOption = if (dashToFiat) 1 else 0
         binding.currencyOptions.setViewCompositionStrategy(
@@ -223,6 +234,7 @@ class EnterAmountFragment : Fragment(R.layout.fragment_enter_amount) {
                 binding.amountView.dashToFiat = currency.title == Constants.DASH_CURRENCY
             }
         }
+        setAmountFromSavedState()
 
         binding.maxButton.setOnClickListener {
             lifecycleScope.launch { onMaxAmountButtonClick() }

--- a/common/src/main/java/org/dash/wallet/common/ui/enter_amount/EnterAmountViewModel.kt
+++ b/common/src/main/java/org/dash/wallet/common/ui/enter_amount/EnterAmountViewModel.kt
@@ -18,6 +18,7 @@
 package org.dash.wallet.common.ui.enter_amount
 
 import androidx.lifecycle.*
+import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
@@ -34,14 +35,24 @@ import javax.inject.Inject
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class EnterAmountViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
     val exchangeRates: ExchangeRatesProvider,
     private val walletUIConfig: WalletUIConfig
 ) : ViewModel() {
-    private val _selectedCurrencyCode = MutableStateFlow(Constants.DEFAULT_EXCHANGE_CURRENCY)
+    companion object {
+        private const val KEY_SELECTED_CURRENCY = "selected_currency_code"
+        private const val KEY_AMOUNT = "amount"
+        private const val KEY_FIAT_AMOUNT = "fiat_amount"
+    }
+
+    private val _selectedCurrencyCode = MutableStateFlow(
+        savedStateHandle.get<String>(KEY_SELECTED_CURRENCY) ?: Constants.DEFAULT_EXCHANGE_CURRENCY
+    )
     var selectedCurrencyCode: String
         get() = _selectedCurrencyCode.value
         set(value) {
             _selectedCurrencyCode.value = value
+            savedStateHandle[KEY_SELECTED_CURRENCY] = value
         }
 
     private val _selectedExchangeRate = MutableLiveData<ExchangeRate?>()
@@ -62,11 +73,23 @@ class EnterAmountViewModel @Inject constructor(
     val maxAmount: LiveData<Coin>
         get() = _maxAmount
 
-    internal val _amount = MutableLiveData<Coin>()
+    internal val _amount = MutableLiveData<Coin>().apply {
+        savedStateHandle.get<Long>(KEY_AMOUNT)?.let {
+            value = Coin.valueOf(it)
+        }
+    }
     val amount: LiveData<Coin>
         get() = _amount
 
-    internal val _fiatAmount = MutableLiveData<Fiat>()
+    internal val _fiatAmount = MutableLiveData<Fiat>().apply {
+        savedStateHandle.get<String>(KEY_FIAT_AMOUNT)?.let { fiatString ->
+            try {
+                value = Fiat.parseFiat(selectedCurrencyCode, fiatString)
+            } catch (_: Exception) {
+                // Ignore parsing errors for saved state
+            }
+        }
+    }
     val fiatAmount: LiveData<Fiat>
         get() = _fiatAmount
 
@@ -112,6 +135,16 @@ class EnterAmountViewModel @Inject constructor(
             .filterNotNull()
             .onEach { _selectedCurrencyCode.value = it }
             .launchIn(viewModelScope)
+
+        // Save amount changes to SavedStateHandle
+        _amount.observeForever { coin ->
+            savedStateHandle[KEY_AMOUNT] = coin?.value
+        }
+
+        // Save fiat amount changes to SavedStateHandle
+        _fiatAmount.observeForever { fiat ->
+            savedStateHandle[KEY_FIAT_AMOUNT] = fiat?.toPlainString()
+        }
     }
 
     fun setMaxAmount(coin: Coin) {

--- a/common/src/main/java/org/dash/wallet/common/ui/enter_amount/EnterAmountViewModel.kt
+++ b/common/src/main/java/org/dash/wallet/common/ui/enter_amount/EnterAmountViewModel.kt
@@ -165,4 +165,12 @@ class EnterAmountViewModel @Inject constructor(
             _selectedCurrencyCode.value = walletUIConfig.getExchangeCurrencyCode()
         }
     }
+
+    fun clearSavedState() {
+        _amount.value = Coin.ZERO
+        _fiatAmount.value = Fiat.valueOf(selectedCurrencyCode, 0)
+        savedStateHandle.remove<String>(KEY_SELECTED_CURRENCY)
+        savedStateHandle.remove<Long>(KEY_AMOUNT)
+        savedStateHandle.remove<String>(KEY_FIAT_AMOUNT)
+    }
 }

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/explore/ExploreDataSource.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/explore/ExploreDataSource.kt
@@ -81,6 +81,7 @@ interface ExploreDataSource {
     suspend fun getMerchantTerritories(): List<String>
     suspend fun getAtmTerritories(): List<String>
     fun sanitizeQuery(query: String): String
+    suspend fun getMerchantById(merchantId: String): Merchant?
 }
 
 open class MerchantAtmDataSource @Inject constructor(
@@ -508,5 +509,9 @@ open class MerchantAtmDataSource @Inject constructor(
     override fun sanitizeQuery(query: String): String {
         val escapedQuotes = query.replace(Regex.fromLiteral("\""), "\"\"")
         return "\"$escapedQuotes*\""
+    }
+
+    override suspend fun getMerchantById(merchantId: String): Merchant? {
+        return merchantDao.getMerchantById(merchantId)
     }
 }

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/explore/MerchantDao.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/explore/MerchantDao.kt
@@ -489,4 +489,7 @@ interface MerchantDao : BaseDao<Merchant> {
 
     @Query("SELECT count(*) FROM merchant")
     suspend fun getCount(): Int
+
+    @Query("SELECT * FROM merchant where merchantId = :merchantId")
+    suspend fun getMerchantById(merchantId: String): Merchant?
 }

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/repository/CTXSpendRepository.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/repository/CTXSpendRepository.kt
@@ -34,12 +34,14 @@ import org.dash.wallet.features.exploredash.utils.CTXSpendConfig
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
+import javax.net.ssl.SSLHandshakeException
 
 class CTXSpendException(
     message: String,
     val errorCode: Int? = null,
-    val errorBody: String? = null
-) : Exception(message) {
+    val errorBody: String? = null,
+    cause: Exception? = null
+) : Exception(message, cause) {
     var resourceString: ResourceString? = null
     private val errorMap: Map<String, Any>
 
@@ -65,6 +67,8 @@ class CTXSpendException(
             val fiatAmount = ((errorMap["fields"] as? Map<*, *>)?.get("fiatAmount") as? List<*>)?.firstOrNull()
             return errorCode == 400 && (fiatAmount == "above threshold" || fiatAmount == "below threshold")
         }
+    val isNetworkError: Boolean
+        get() = cause?.let { it is SSLHandshakeException } ?: false
 }
 
 class CTXSpendRepository @Inject constructor(

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ctxspend/CTXSpendViewModel.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ctxspend/CTXSpendViewModel.kt
@@ -139,12 +139,21 @@ class CTXSpendViewModel @Inject constructor(
         giftCardMerchant?.merchantId?.let {
             val amountValue = giftCardPaymentValue.value
 
-            val response = repository.purchaseGiftCard(
-                merchantId = it,
-                fiatAmount = MonetaryFormat.FIAT.noCode().format(amountValue).toString(),
-                fiatCurrency = "USD",
-                cryptoCurrency = Constants.DASH_CURRENCY
-            )
+            val response = try {
+                repository.purchaseGiftCard(
+                    merchantId = it,
+                    fiatAmount = MonetaryFormat.FIAT.noCode().format(amountValue).toString(),
+                    fiatCurrency = "USD",
+                    cryptoCurrency = Constants.DASH_CURRENCY
+                )
+            } catch (ex: Exception) {
+                log.error("purchaseGiftCard network error", ex)
+                throw CTXSpendException(
+                    "network-connection-error",
+                    null,
+                    ex.message
+                )
+            }
 
             when (response) {
                 is ResponseResource.Success -> {

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ctxspend/CTXSpendViewModel.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ctxspend/CTXSpendViewModel.kt
@@ -161,7 +161,8 @@ class CTXSpendViewModel @Inject constructor(
                 throw CTXSpendException(
                     "network-connection-error",
                     null,
-                    ex.message
+                    ex.message,
+                    ex
                 )
             }
 

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ctxspend/PurchaseGiftCardFragment.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ctxspend/PurchaseGiftCardFragment.kt
@@ -344,7 +344,6 @@ class PurchaseGiftCardFragment : Fragment(R.layout.fragment_purchase_ctxspend_gi
             merchant.logoLocation,
             R.drawable.ic_image_placeholder
         )
-        viewModel.setIsFixedDenomination(merchant.fixedDenomination)
         viewModel.updateMerchantDetails(merchant)
 
         if (setMerchantEnabled()) {

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ctxspend/PurchaseGiftCardFragment.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ctxspend/PurchaseGiftCardFragment.kt
@@ -87,7 +87,7 @@ class PurchaseGiftCardFragment : Fragment(R.layout.fragment_purchase_ctxspend_gi
         viewLifecycleOwner.lifecycleScope.launch {
             if (savedMerchantId != null && currentMerchant == null) {
                 // restore state if saved merchant exists
-                if (setupMerchant(savedMerchantId)) {
+                if (!setupMerchant(savedMerchantId)) {
                     findNavController().popBackStack()
                 }
             } else if (currentMerchant is Merchant && currentMerchant.merchantId != null && !currentMerchant.source.isNullOrEmpty()) {

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ctxspend/PurchaseGiftCardFragment.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ctxspend/PurchaseGiftCardFragment.kt
@@ -76,7 +76,10 @@ class PurchaseGiftCardFragment : Fragment(R.layout.fragment_purchase_ctxspend_gi
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.titleBar.setNavigationOnClickListener { findNavController().popBackStack() }
+        binding.titleBar.setNavigationOnClickListener { 
+            enterAmountViewModel.clearSavedState()
+            findNavController().popBackStack() 
+        }
 
         setPaymentHeader()
 

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ctxspend/PurchaseGiftCardFragment.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ctxspend/PurchaseGiftCardFragment.kt
@@ -76,9 +76,9 @@ class PurchaseGiftCardFragment : Fragment(R.layout.fragment_purchase_ctxspend_gi
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.titleBar.setNavigationOnClickListener { 
+        binding.titleBar.setNavigationOnClickListener {
             enterAmountViewModel.clearSavedState()
-            findNavController().popBackStack() 
+            findNavController().popBackStack()
         }
 
         setPaymentHeader()
@@ -93,7 +93,9 @@ class PurchaseGiftCardFragment : Fragment(R.layout.fragment_purchase_ctxspend_gi
                 if (!setupMerchant(savedMerchantId)) {
                     findNavController().popBackStack()
                 }
-            } else if (currentMerchant is Merchant && currentMerchant.merchantId != null && !currentMerchant.source.isNullOrEmpty()) {
+            } else if (currentMerchant is Merchant && currentMerchant.merchantId != null &&
+                !currentMerchant.source.isNullOrEmpty()
+            ) {
                 setupMerchant(currentMerchant)
             } else {
                 // No valid merchant available
@@ -373,7 +375,7 @@ class PurchaseGiftCardFragment : Fragment(R.layout.fragment_purchase_ctxspend_gi
     @Composable
     private fun DenominationsBottomContainer() {
         val merchant = viewModel.giftCardMerchant ?: return
-        
+
         Box(
             modifier = Modifier.background(
                 color = MyTheme.Colors.backgroundSecondary,

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ctxspend/dialogs/PurchaseGiftCardConfirmDialog.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ctxspend/dialogs/PurchaseGiftCardConfirmDialog.kt
@@ -74,6 +74,11 @@ class PurchaseGiftCardConfirmDialog : OffsetDialogFragment(R.layout.dialog_confi
         super.onViewCreated(view, savedInstanceState)
 
         val merchant = viewModel.giftCardMerchant
+        if (merchant == null) {
+            log.warn("PurchaseGiftCardConfirmDialog: No merchant available, dismissing dialog")
+            dismiss()
+            return
+        }
         val paymentValue = viewModel.giftCardPaymentValue.value
         val savingsFraction = merchant.savingsFraction
         binding.merchantName.text = merchant.name
@@ -97,6 +102,13 @@ class PurchaseGiftCardConfirmDialog : OffsetDialogFragment(R.layout.dialog_confi
 
     private fun onConfirmButtonClicked() {
         lifecycleScope.launch {
+            // Double-check merchant is still available before proceeding
+            if (viewModel.giftCardMerchant == null) {
+                log.warn("PurchaseGiftCardConfirmDialog: Merchant became null during confirmation, dismissing")
+                dismiss()
+                return@launch
+            }
+
             if (authManager.authenticate(requireActivity()) == null) {
                 return@launch
             }

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ctxspend/dialogs/PurchaseGiftCardConfirmDialog.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ctxspend/dialogs/PurchaseGiftCardConfirmDialog.kt
@@ -25,6 +25,7 @@ import androidx.annotation.StyleRes
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
+import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.transition.TransitionManager
@@ -39,6 +40,7 @@ import org.dash.wallet.common.services.DirectPayException
 import org.dash.wallet.common.ui.dialogs.AdaptiveDialog
 import org.dash.wallet.common.ui.dialogs.MinimumBalanceDialog
 import org.dash.wallet.common.ui.dialogs.OffsetDialogFragment
+import org.dash.wallet.common.ui.enter_amount.EnterAmountViewModel
 import org.dash.wallet.common.ui.viewBinding
 import org.dash.wallet.common.util.GenericUtils
 import org.dash.wallet.common.util.discountBy
@@ -62,6 +64,7 @@ class PurchaseGiftCardConfirmDialog : OffsetDialogFragment(R.layout.dialog_confi
 
     private val binding by viewBinding(DialogConfirmPurchaseGiftCardBinding::bind)
     private val viewModel by exploreViewModels<CTXSpendViewModel>()
+    private val enterAmountViewModel by activityViewModels<EnterAmountViewModel>()
 
     @Inject
     lateinit var authManager: AuthenticationManager
@@ -174,6 +177,7 @@ class PurchaseGiftCardConfirmDialog : OffsetDialogFragment(R.layout.dialog_confi
 
             val transactionId = createSendingRequestFromDashUri(data.paymentUrls?.get("DASH.DASH")!!)
             transactionId?.let {
+                enterAmountViewModel.clearSavedState()
                 viewModel.saveGiftCardDummy(transactionId, data.id)
                 showGiftCardDetailsDialog(transactionId, data.id)
             }

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ctxspend/dialogs/PurchaseGiftCardConfirmDialog.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/ctxspend/dialogs/PurchaseGiftCardConfirmDialog.kt
@@ -120,6 +120,14 @@ class PurchaseGiftCardConfirmDialog : OffsetDialogFragment(R.layout.dialog_confi
             } catch (ex: CTXSpendException) {
                 hideLoading()
                 when {
+                    ex.isNetworkError -> {
+                        AdaptiveDialog.create(
+                            R.drawable.ic_error,
+                            getString(R.string.gift_card_purchase_failed),
+                            getString(R.string.gift_card_error),
+                            getString(R.string.button_close)
+                        ).show(requireActivity())
+                    }
                     ex.errorCode == 400 && ex.isLimitError -> {
                         AdaptiveDialog.create(
                             R.drawable.ic_error,

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/explore/SearchFragment.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/explore/SearchFragment.kt
@@ -296,7 +296,11 @@ class SearchFragment : Fragment(R.layout.fragment_search) {
 
     override fun onDestroy() {
         super.onDestroy()
-        viewModel.onExitSearch()
+        try {
+            viewModel.onExitSearch()
+        } catch (e: IllegalArgumentException) {
+            // Handle case where nav graph is no longer on back stack after process death
+        }
         // clear this listener
         requireActivity().window?.decorView?.let { decor ->
             ViewCompat.setOnApplyWindowInsetsListener(decor) { _, _ ->

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/ui/EnterAmountToTransferFragment.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/ui/EnterAmountToTransferFragment.kt
@@ -78,8 +78,13 @@ class EnterAmountToTransferFragment : Fragment(R.layout.enter_amount_to_transfer
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        viewModel.isFiatSelected = false
-        viewModel.isMaxAmountSelected = false
+        try {
+            viewModel.isFiatSelected = false
+            viewModel.isMaxAmountSelected = false
+        } catch (e: IllegalArgumentException) {
+            // Handle case where nav graph is no longer on back stack after process death
+            return
+        }
         pickedCurrencyIndex = 0
         binding.keyboardView.onKeyboardActionListener = keyboardActionListener
         formatTransferredAmount(CoinbaseConstants.VALUE_ZERO)

--- a/wallet/src/de/schildbach/wallet/ui/transactions/TxResourceMapper.kt
+++ b/wallet/src/de/schildbach/wallet/ui/transactions/TxResourceMapper.kt
@@ -72,11 +72,15 @@ open class TxResourceMapper {
                         val cftx = authExtension.getAssetLockTransaction(tx)
 
                         val group = authExtension.keyChainGroup as AuthenticationKeyChainGroup
-                        typeId = when (group.getKeyChainType(cftx.assetLockPublicKeyId.bytes)) {
-                            AuthenticationKeyChain.KeyChainType.INVITATION_FUNDING -> R.string.dashpay_invite_fee
-                            AuthenticationKeyChain.KeyChainType.BLOCKCHAIN_IDENTITY_FUNDING -> R.string.dashpay_upgrade_fee
-                            AuthenticationKeyChain.KeyChainType.BLOCKCHAIN_IDENTITY_TOPUP -> R.string.dashpay_topup_fee
-                            else -> R.string.transaction_row_status_sent
+                        typeId = if (cftx.assetLockPublicKeyId != null) {
+                            when (group.getKeyChainType(cftx.assetLockPublicKeyId.bytes)) {
+                                AuthenticationKeyChain.KeyChainType.INVITATION_FUNDING -> R.string.dashpay_invite_fee
+                                AuthenticationKeyChain.KeyChainType.BLOCKCHAIN_IDENTITY_FUNDING -> R.string.dashpay_upgrade_fee
+                                AuthenticationKeyChain.KeyChainType.BLOCKCHAIN_IDENTITY_TOPUP -> R.string.dashpay_topup_fee
+                                else -> R.string.transaction_row_status_sent
+                            }
+                        } else {
+                            R.string.transaction_row_status_sent
                         }
                     } else if (coinJoinType == CoinJoinTransactionType.Mixing) {
                         typeId = R.string.transaction_row_status_coinjoin_mixing


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->
A user had this crash that is reported 2 seconds after the app starts.The user was trying to purchase a gift card, but was getting SSL Handshake errors with purchaseGiftCard.  Logs report many other connection problems.7 minutes later, the app is restarted by the user. 2 seconds later the crash happenedI am wondering if this PurchaseGiftCardConfirmDialog is being recreated by Android, but this dialog was created from the right place in the app, so the giftCardMerchant value is not initialized.  My idea is based on the call stack and that 2 seconds had passed, so it would seem impossible to make an attempt to purchase a card.or is there another explanation?

```
20:07:14 [main] WalletApplication - WalletApplication.onCreate()

20:07:16 [main] CrashReporter - crashing because of uncaught exception
kotlin.UninitializedPropertyAccessException: lateinit property giftCardMerchant has not been initialized
	at org.dash.wallet.features.exploredash.ui.ctxspend.CTXSpendViewModel.getGiftCardMerchant(CTXSpendViewModel.kt:90)
	at org.dash.wallet.features.exploredash.ui.ctxspend.dialogs.PurchaseGiftCardConfirmDialog.onViewCreated(PurchaseGiftCardConfirmDialog.kt:70)
	at androidx.fragment.app.Fragment.performViewCreated(Fragment.java:3147)
	at androidx.fragment.app.FragmentStateManager.createView(FragmentStateManager.java:588)
	at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:272)
	at androidx.fragment.app.FragmentStore.moveToExpectedState(FragmentStore.java:114)
	at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1455)
	at androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:3034)
	at androidx.fragment.app.FragmentManager.dispatchActivityCreated(FragmentManager.java:2952)
	at androidx.fragment.app.FragmentController.dispatchActivityCreated(FragmentController.java:263)
	at androidx.fragment.app.FragmentActivity.onStart(FragmentActivity.java:350)
	at androidx.appcompat.app.AppCompatActivity.onStart(AppCompatActivity.java:246)
	at de.schildbach.wallet.ui.LockScreenActivity.onStart(LockScreenActivity.kt:224)
	at de.schildbach.wallet.ui.main.MainActivity.onStart(MainActivity.kt:197)
	at android.app.Instrumentation.callActivityOnStart(Instrumentation.java:1582)
	at android.app.Activity.performStart(Activity.java:9034)
	at android.app.ActivityThread.handleStartActivity(ActivityThread.java:4206)
	at android.app.servertransaction.TransactionExecutor.performLifecycleSequence(TransactionExecutor.java:225)
	at android.app.servertransaction.TransactionExecutor.cycleToPath(TransactionExecutor.java:205)
	at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:177)
	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:98)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2693)
	at android.os.Handler.dispatchMessage(Handler.java:106)
	at android.os.Looper.loopOnce(Looper.java:230)
	at android.os.Looper.loop(Looper.java:319)
	at android.app.ActivityThread.main(ActivityThread.java:9063)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:588)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1103)
20:07:16 [DefaultDispatcher-worker-13] ExchangeRatesRepository - exchange rates updated successfully with de.schildbach.wallet.rates.DashRetailClient@534c060
20:07:19 [main] WalletApplication - WalletApplication.onCreate()
 ```
The stack trace from this dialog when the user clicks on the "Continue" button on the gift card enter amount screen:

```
result = {StackTraceElement[16]@43373} 
 0 = {StackTraceElement@43385} "org.dash.wallet.features.exploredash.ui.ctxspend.dialogs.PurchaseGiftCardConfirmDialog.onViewCreated(PurchaseGiftCardConfirmDialog.kt:68)"
 1 = {StackTraceElement@43386} "androidx.fragment.app.Fragment.performViewCreated(Fragment.java:3147)"
 2 = {StackTraceElement@43387} "androidx.fragment.app.FragmentStateManager.createView(FragmentStateManager.java:588)"
 3 = {StackTraceElement@43388} "androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:272)"
 4 = {StackTraceElement@43389} "androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:1943)"
 5 = {StackTraceElement@43390} "androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:1845)"
 6 = {StackTraceElement@43391} "androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:1782)"
 7 = {StackTraceElement@43392} "androidx.fragment.app.FragmentManager$5.run(FragmentManager.java:565)"
 8 = {StackTraceElement@43393} "android.os.Handler.handleCallback(Handler.java:942)"
 9 = {StackTraceElement@43394} "android.os.Handler.dispatchMessage(Handler.java:99)"
 10 = {StackTraceElement@43395} "android.os.Looper.loopOnce(Looper.java:201)"
 11 = {StackTraceElement@43396} "android.os.Looper.loop(Looper.java:288)"
 12 = {StackTraceElement@43397} "android.app.ActivityThread.main(ActivityThread.java:7924)"
 13 = {StackTraceElement@43398} "java.lang.reflect.Method.invoke(Native Method)"
 14 = {StackTraceElement@43399} "com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)"
 15 = {StackTraceElement@43400} "com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)"
Andrei said:
PurchaseGiftCardConfirmDialog expects the merchant to be initialized, but if it's recreated for an app that comes back from background, it might not be.The quick solution would be to check if merchant is initialized in the dialog with a viewModel property
```

```
val hasMerchant: Boolean
        get() = ::giftCardMerchant.isInitialized
```
And then dismiss the dialog before going futher.This somewhat defeats the purpose of lateinit (we might as well be using a nullable here). A proper solution would be to dismiss any dialogs when the app goes into background, similar to how we do it for the lockscreen. But this might be a bit of work to get everything correct.
The problem, of course, is that even if we dismiss the dialog, the user will end up on an empty Buy screen with uninitialized merchant, this can lead to other issues if he starts pressing buttons.The REAL proper solution would be to save the state of the viewModel with SavedStateHandle and restore the state correctly when the app is restored from background. We do this in the Send screen iirk.
## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->
none
## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [x] I have added or updated relevant unit/integration/functional/e2e tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved state saving and restoration for amount entry and merchant selection, ensuring user input and selections persist across app restarts or navigation.
  * Added the ability to fetch merchant details by ID for enhanced merchant management.

* **Bug Fixes**
  * Resolved potential crashes by handling null merchant and transaction states more safely throughout gift card purchase and confirmation flows.
  * Improved error handling for network issues during gift card purchases, providing clearer feedback to users.

* **Refactor**
  * Centralized and streamlined merchant setup logic for better reliability and maintainability.
  * Enhanced UI updates to reflect accurate merchant data and prevent inconsistencies.

* **Chores**
  * Added null checks and improved LiveData handling to prevent unexpected errors and improve app stability.
  * Wrapped critical state assignments and navigation calls in try-catch blocks to handle edge cases after process death gracefully.
  * Updated fragment lifecycle and navigation handling to clear saved states appropriately and avoid stale data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->