### PR TITLE
fix: repair issue with not returning change on regular transactions

### DIFF
--- a/wallet/src/de/schildbach/wallet/payments/SendCoinsTaskRunner.kt
+++ b/wallet/src/de/schildbach/wallet/payments/SendCoinsTaskRunner.kt
@@ -411,7 +411,7 @@ class SendCoinsTaskRunner @Inject constructor(
         sendRequest.signInputs = signInputs
         val walletBalance = wallet.getBalance(getMaxOutputCoinSelector())
         sendRequest.emptyWallet = mayEditAmount && walletBalance == paymentIntent.amount
-        if (!sendRequest.emptyWallet && useCoinJoinGreedy) {
+        if (!sendRequest.emptyWallet && useCoinJoinGreedy && coinJoinMode != CoinJoinMode.NONE) {
             sendRequest.returnChange = false
         }
 
@@ -429,7 +429,7 @@ class SendCoinsTaskRunner @Inject constructor(
             paymentIntent,
             signInputs = true,
             forceEnsureMinRequiredFee,
-            useCoinJoinGreedy = true
+            useCoinJoinGreedy = coinJoinMode != CoinJoinMode.NONE
         )
         signSendRequest(firstSendRequest)
         walletData.wallet!!.completeTx(firstSendRequest)
@@ -441,7 +441,7 @@ class SendCoinsTaskRunner @Inject constructor(
                 paymentIntent,
                 signInputs = false,
                 forceEnsureMinRequiredFee = true,
-                useCoinJoinGreedy = true
+                useCoinJoinGreedy = coinJoinMode != CoinJoinMode.NONE
             )
             signSendRequest(sendRequest)
             walletData.wallet!!.completeTx(sendRequest)
@@ -466,7 +466,7 @@ class SendCoinsTaskRunner @Inject constructor(
                 paymentIntent,
                 signInputs,
                 forceEnsureMinRequiredFee,
-                useCoinJoinGreedy = true
+                useCoinJoinGreedy = coinJoinMode != CoinJoinMode.NONE
             )
         }
     }
@@ -489,7 +489,7 @@ class SendCoinsTaskRunner @Inject constructor(
         sendRequest.signInputs = signInputs
         val walletBalance = wallet.getBalance(getMaxOutputCoinSelector())
         sendRequest.emptyWallet = mayEditAmount && walletBalance == paymentIntent.amount
-        if (!sendRequest.emptyWallet && useCoinJoinGreedy) {
+        if (!sendRequest.emptyWallet && useCoinJoinGreedy && coinJoinMode != CoinJoinMode.NONE) {
             sendRequest.returnChange = false
         }
 

--- a/wallet/src/de/schildbach/wallet/payments/SendCoinsTaskRunner.kt
+++ b/wallet/src/de/schildbach/wallet/payments/SendCoinsTaskRunner.kt
@@ -509,7 +509,7 @@ class SendCoinsTaskRunner @Inject constructor(
             signInputs = true,
             forceEnsureMinRequiredFee,
             topUpKey,
-            useCoinJoinGreedy = true
+            useCoinJoinGreedy = coinJoinSend
         )
         signSendRequest(firstSendRequest)
         walletData.wallet!!.completeTx(firstSendRequest)
@@ -522,7 +522,7 @@ class SendCoinsTaskRunner @Inject constructor(
                 signInputs = false,
                 forceEnsureMinRequiredFee = true,
                 topUpKey,
-                useCoinJoinGreedy = true
+                useCoinJoinGreedy = coinJoinSend
             )
             signSendRequest(sendRequest)
             walletData.wallet!!.completeTx(sendRequest)
@@ -548,7 +548,7 @@ class SendCoinsTaskRunner @Inject constructor(
                 signInputs,
                 forceEnsureMinRequiredFee,
                 topUpKey,
-                useCoinJoinGreedy = true
+                useCoinJoinGreedy = coinJoinSend
             )
         }
     }

--- a/wallet/src/de/schildbach/wallet/payments/SendCoinsTaskRunner.kt
+++ b/wallet/src/de/schildbach/wallet/payments/SendCoinsTaskRunner.kt
@@ -411,7 +411,7 @@ class SendCoinsTaskRunner @Inject constructor(
         sendRequest.signInputs = signInputs
         val walletBalance = wallet.getBalance(getMaxOutputCoinSelector())
         sendRequest.emptyWallet = mayEditAmount && walletBalance == paymentIntent.amount
-        if (!sendRequest.emptyWallet && useCoinJoinGreedy && coinJoinMode != CoinJoinMode.NONE) {
+        if (!sendRequest.emptyWallet && useCoinJoinGreedy && coinJoinSend) {
             sendRequest.returnChange = false
         }
 
@@ -429,7 +429,7 @@ class SendCoinsTaskRunner @Inject constructor(
             paymentIntent,
             signInputs = true,
             forceEnsureMinRequiredFee,
-            useCoinJoinGreedy = coinJoinMode != CoinJoinMode.NONE
+            useCoinJoinGreedy = coinJoinSend
         )
         signSendRequest(firstSendRequest)
         walletData.wallet!!.completeTx(firstSendRequest)
@@ -441,7 +441,7 @@ class SendCoinsTaskRunner @Inject constructor(
                 paymentIntent,
                 signInputs = false,
                 forceEnsureMinRequiredFee = true,
-                useCoinJoinGreedy = coinJoinMode != CoinJoinMode.NONE
+                useCoinJoinGreedy = coinJoinSend
             )
             signSendRequest(sendRequest)
             walletData.wallet!!.completeTx(sendRequest)
@@ -466,7 +466,7 @@ class SendCoinsTaskRunner @Inject constructor(
                 paymentIntent,
                 signInputs,
                 forceEnsureMinRequiredFee,
-                useCoinJoinGreedy = coinJoinMode != CoinJoinMode.NONE
+                useCoinJoinGreedy = coinJoinSend
             )
         }
     }
@@ -489,7 +489,7 @@ class SendCoinsTaskRunner @Inject constructor(
         sendRequest.signInputs = signInputs
         val walletBalance = wallet.getBalance(getMaxOutputCoinSelector())
         sendRequest.emptyWallet = mayEditAmount && walletBalance == paymentIntent.amount
-        if (!sendRequest.emptyWallet && useCoinJoinGreedy && coinJoinMode != CoinJoinMode.NONE) {
+        if (!sendRequest.emptyWallet && useCoinJoinGreedy && coinJoinSend) {
             sendRequest.returnChange = false
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CoinJoin behavior is now consistently applied only when explicitly enabled, improving change, fee, and dust handling across all send flows.
  * Asset-lock and fallback send paths now respect the CoinJoin setting, reducing unexpected fee or change outcomes.

* **New Features**
  * Added an explicit option to control CoinJoin usage for asset-lock sends, allowing finer control over mixed vs. full selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->