### PR TITLE
fix (maya): clone the TX to clear the TX confidence object

### DIFF
--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/api/MayaBlockchainApi.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/api/MayaBlockchainApi.kt
@@ -185,6 +185,20 @@ class MayaBlockchainApiImpl @Inject constructor(
                     return ResponseResource.Failure(MayaException("swap transaction fee too small"), false, 0, null)
                 }
 
+                // Replace sendRequest.tx with a fresh Transaction before committing.
+                // wallet.completeTx() caches a TransactionConfidence (keyed to the txid at
+                // that moment) in Transaction.confidence.  After we modify outputs and re-sign,
+                // the txid changes but the cached field is not updated — it still points to the
+                // stale confidence.  Creating a new Transaction and moving the same input/output
+                // objects into it leaves confidence == null, so wallet.commitTx() will create
+                // the correct confidence for the final txid, keeping the TxConfidenceTable and
+                // any confidence listeners in sync.  All transient state (connectedOutput,
+                // input.value, signatures) is preserved because we reuse the same objects.
+                val freshTx = Transaction(params)
+                sendRequest.tx.outputs.forEach { freshTx.addOutput(it) }
+                sendRequest.tx.inputs.forEach { freshTx.addInput(it) }
+                sendRequest.tx = freshTx
+
                 // send the transaction
                 log.info("maya swap transaction: {}", sendRequest.tx.toStringHex())
                 val sentTransaction = sendPaymentService.sendTransaction(sendRequest)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
