### PR TITLE
fix(coinbase): prevent crash and show error if no USD account

### DIFF
--- a/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/model/CoinbaseErrorResponse.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/model/CoinbaseErrorResponse.kt
@@ -30,7 +30,8 @@ enum class CoinbaseErrorType {
     INSUFFICIENT_BALANCE,
     NO_BANK_ACCOUNT,
     NO_EXCHANGE_RATE,
-    DEPOSIT_FAILED
+    DEPOSIT_FAILED,
+    NO_USD_ACCOUNT
 }
 
 class CoinbaseException(val errorType: CoinbaseErrorType, message: String?) : Exception(message)

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/ui/CoinbaseBuyDashFragment.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/ui/CoinbaseBuyDashFragment.kt
@@ -140,6 +140,11 @@ class CoinbaseBuyDashFragment : Fragment(R.layout.fragment_coinbase_buy_dash) {
                 showNoPaymentMethodsError()
                 false
             }
+
+            CoinbaseErrorType.NO_USD_ACCOUNT -> {
+                showNoUSDAccountError()
+                false
+            }
             else -> false
         }
     }
@@ -162,6 +167,21 @@ class CoinbaseBuyDashFragment : Fragment(R.layout.fragment_coinbase_buy_dash) {
             getString(R.string.close),
             getString(R.string.add_payment_method),
         ).show(requireActivity()) { addMethod ->
+            if (addMethod == true) {
+                viewModel.logEvent(AnalyticsConstants.Coinbase.BUY_ADD_PAYMENT_METHOD)
+                openCoinbaseWebsite()
+            }
+        }
+    }
+
+    private fun showNoUSDAccountError() {
+        AdaptiveDialog.create(
+            R.drawable.ic_error,
+            getString(R.string.coinbase),
+            getString(R.string.coinbase_usd_wallet_error_message),
+            getString(R.string.close),
+            getString(R.string.add_payment_method),
+            ).show(requireActivity()) { addMethod ->
             if (addMethod == true) {
                 viewModel.logEvent(AnalyticsConstants.Coinbase.BUY_ADD_PAYMENT_METHOD)
                 openCoinbaseWebsite()

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/viewmodels/CoinbaseBuyDashViewModel.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/viewmodels/CoinbaseBuyDashViewModel.kt
@@ -68,7 +68,11 @@ class CoinbaseBuyDashViewModel @Inject constructor(
         previewBuyOrder(amount)
 
         val fiatAmount = uiState.value.order ?: return CoinbaseErrorType.NO_EXCHANGE_RATE
-        val fiatAccount = coinBaseRepository.getFiatAccount()
+        val fiatAccount = try {
+            coinBaseRepository.getFiatAccount()
+        } catch (_: Exception) {
+            return CoinbaseErrorType.NO_USD_ACCOUNT
+        }
         val balance = Fiat.parseFiatInexact(
             CoinbaseConstants.DEFAULT_CURRENCY_USD,
             fiatAccount.availableBalance.value

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/viewmodels/CoinbaseBuyDashViewModel.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/viewmodels/CoinbaseBuyDashViewModel.kt
@@ -70,7 +70,7 @@ class CoinbaseBuyDashViewModel @Inject constructor(
         val fiatAmount = uiState.value.order ?: return CoinbaseErrorType.NO_EXCHANGE_RATE
         val fiatAccount = try {
             coinBaseRepository.getFiatAccount()
-        } catch (_: Exception) {
+        } catch (_: NoSuchElementException) {
             return CoinbaseErrorType.NO_USD_ACCOUNT
         }
         val balance = Fiat.parseFiatInexact(

--- a/integrations/coinbase/src/main/res/values/strings.xml
+++ b/integrations/coinbase/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="coinbase_transfer_details">Between Dash Wallet and your Coinbase account</string>
     <string name="coinbase_dash_wallet_error_title">We didn\'t find a Dash Wallet on your Coinbase account.</string>
     <string name="coinbase_dash_wallet_error_message"> Please create a Dash Wallet on Coinbase to proceed.</string>
+    <string name="coinbase_usd_wallet_error_message"> Your Coinbase account does not support USD.</string>
     <string name="create_dash_account">Create Dash Account</string>
     <string name="close">Close</string>
     <string name="retry">Retry</string>

--- a/integrations/coinbase/src/main/res/values/strings.xml
+++ b/integrations/coinbase/src/main/res/values/strings.xml
@@ -21,7 +21,7 @@
     <string name="coinbase_transfer_details">Between Dash Wallet and your Coinbase account</string>
     <string name="coinbase_dash_wallet_error_title">We didn\'t find a Dash Wallet on your Coinbase account.</string>
     <string name="coinbase_dash_wallet_error_message"> Please create a Dash Wallet on Coinbase to proceed.</string>
-    <string name="coinbase_usd_wallet_error_message"> Your Coinbase account does not support USD.</string>
+    <string name="coinbase_usd_wallet_error_message">Your Coinbase account does not support USD.</string>
     <string name="create_dash_account">Create Dash Account</string>
     <string name="close">Close</string>
     <string name="retry">Retry</string>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect and notify users when their Coinbase account does not support USD, showing a clear error dialog with guidance and an option to open Coinbase to add a payment method.

* **Bug Fixes**
  * Improved validation and error handling for Coinbase purchases to gracefully handle missing USD accounts and prevent unintended fall-through behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->