### PR TITLE
feat(payment): support BIP21 op_return and callback URI parameters

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/data/PaymentIntent.java
+++ b/common/src/main/java/org/dash/wallet/common/data/PaymentIntent.java
@@ -24,6 +24,7 @@ import android.text.TextUtils;
 import com.google.common.io.BaseEncoding;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.Locale;
 
 import javax.annotation.Nullable;
 
@@ -192,6 +193,14 @@ public final class PaymentIntent implements Parcelable {
 
     public String source = "";
 
+    /**
+     * BIP21 {@code callback=<https-url>} parameter. When set, the wallet UI opens this URL after
+     * a successful send so the merchant / payee-side service can continue its checkout flow.
+     * Validated as {@code https} at parse time; arbitrary schemes are rejected.
+     */
+    @Nullable
+    public String callback = null;
+
     private static final Logger log = LoggerFactory.getLogger(PaymentIntent.class);
 
     public PaymentIntent(@Nullable final Standard standard, @Nullable final String payeeName,
@@ -265,15 +274,75 @@ public final class PaymentIntent implements Parcelable {
 
     public static PaymentIntent fromBitcoinUri(final BitcoinURI bitcoinUri) {
         final Address address = bitcoinUri.getAddress();
-        final Output[] outputs = address != null ? buildSimplePayTo(bitcoinUri.getAmount(), address) : null;
+        final Output[] baseOutputs = address != null ? buildSimplePayTo(bitcoinUri.getAmount(), address) : null;
         final String bluetoothMac = (String) bitcoinUri.getParameterByName(Bluetooth.MAC_URI_PARAM);
         final String paymentRequestHashStr = (String) bitcoinUri.getParameterByName("h");
         final byte[] paymentRequestHash = paymentRequestHashStr != null ? base64UrlDecode(paymentRequestHashStr) : null;
         final String dashPayUsername = bitcoinUri.getUser();
 
-        return new PaymentIntent(PaymentIntent.Standard.BIP21, null, null, outputs, bitcoinUri.getLabel(),
-                bluetoothMac != null ? "bt:" + bluetoothMac : null, null, bitcoinUri.getPaymentRequestUrl(),
-                paymentRequestHash, null, dashPayUsername);
+        // BIP21 op_return=<hex>: attach the payload as a 0-value OP_RETURN output so
+        // payee-side services (e.g. THORChain swap memos) can correlate the on-chain tx
+        // with their off-chain order. Invalid payloads are silently dropped per BIP21
+        // unknown-param convention.
+        final Output opReturnOutput = parseOpReturnParam(
+                (String) bitcoinUri.getParameterByName("op_return"));
+
+        // BIP21 callback=<https-url>: URL the wallet opens after a successful send so
+        // the merchant can continue its checkout flow.
+        final String callbackUrl = parseCallbackParam(
+                (String) bitcoinUri.getParameterByName("callback"));
+
+        final Output[] outputs;
+        if (baseOutputs == null) {
+            outputs = (opReturnOutput != null) ? new Output[]{opReturnOutput} : null;
+        } else if (opReturnOutput != null) {
+            outputs = new Output[baseOutputs.length + 1];
+            System.arraycopy(baseOutputs, 0, outputs, 0, baseOutputs.length);
+            outputs[baseOutputs.length] = opReturnOutput;
+        } else {
+            outputs = baseOutputs;
+        }
+
+        final PaymentIntent intent = new PaymentIntent(PaymentIntent.Standard.BIP21, null, null,
+                outputs, bitcoinUri.getLabel(),
+                bluetoothMac != null ? "bt:" + bluetoothMac : null, null,
+                bitcoinUri.getPaymentRequestUrl(), paymentRequestHash, null, dashPayUsername);
+        intent.callback = callbackUrl;
+        return intent;
+    }
+
+    @Nullable
+    private static Output parseOpReturnParam(@Nullable final String hex) {
+        if (hex == null || hex.isEmpty()) return null;
+        // 80-byte cap = Dash standard relay policy. Even-length + hex-only required
+        // before decode; use req-op_return= to make an invalid value invalidate the
+        // whole request (handled by BitcoinURI).
+        if (hex.length() % 2 != 0 || !hex.matches("[0-9a-fA-F]+")) {
+            log.info("dropping op_return param: not valid hex");
+            return null;
+        }
+        try {
+            final byte[] payload = Constants.HEX.decode(hex.toLowerCase(Locale.ROOT));
+            if (payload.length < 1 || payload.length > 80) {
+                log.info("dropping op_return param: payload size {} out of range (1..80)", payload.length);
+                return null;
+            }
+            return new Output(Coin.ZERO, ScriptBuilder.createOpReturnScript(payload));
+        } catch (final IllegalArgumentException x) {
+            log.info("dropping op_return param: decode failed");
+            return null;
+        }
+    }
+
+    @Nullable
+    private static String parseCallbackParam(@Nullable final String raw) {
+        if (raw == null || raw.isEmpty()) return null;
+        // https only: arbitrary schemes would let a URI invoke other app handlers.
+        if (!raw.toLowerCase(Locale.ROOT).startsWith("https://")) {
+            log.info("dropping callback param: not a valid https URL");
+            return null;
+        }
+        return raw;
     }
 
     private static final BaseEncoding BASE64URL = BaseEncoding.base64Url().omitPadding();
@@ -295,8 +364,13 @@ public final class PaymentIntent implements Parcelable {
             if (mayEditAmount()) {
                 checkArgument(editedAmount != null);
 
-                // put all coins on first output, skip the others
-                outputs = new Output[]{new Output(editedAmount, this.outputs[0].script)};
+                // first output amount is editable; preserve every other output verbatim
+                // (e.g. a BIP21 op_return data output that shouldn't be dropped on amount edit)
+                outputs = new Output[this.outputs.length];
+                outputs[0] = new Output(editedAmount, this.outputs[0].script);
+                for (int i = 1; i < this.outputs.length; i++) {
+                    outputs[i] = this.outputs[i];
+                }
             } else {
                 // exact copy of outputs
                 outputs = this.outputs;
@@ -309,7 +383,9 @@ public final class PaymentIntent implements Parcelable {
             outputs = buildSimplePayTo(editedAmount, editedAddress);
         }
 
-        return new PaymentIntent(standard, payeeName, payeeVerifiedBy, outputs, memo, null, payeeData, null, null, null, null);
+        final PaymentIntent merged = new PaymentIntent(standard, payeeName, payeeVerifiedBy, outputs, memo, null, payeeData, null, null, null, null);
+        merged.callback = this.callback;
+        return merged;
     }
 
     public SendRequest toSendRequest(NetworkParameters params) {
@@ -543,6 +619,7 @@ public final class PaymentIntent implements Parcelable {
         dest.writeString(payeeUsername);
         dest.writeInt(shouldConfirmAddress ? 1 : 0);
         dest.writeString(source);
+        dest.writeString(callback);
     }
 
     public static final Parcelable.Creator<PaymentIntent> CREATOR = new Parcelable.Creator<PaymentIntent>() {
@@ -599,6 +676,7 @@ public final class PaymentIntent implements Parcelable {
         payeeUsername = in.readString();
         shouldConfirmAddress = in.readInt() == 1;
         source = in.readString();
+        callback = in.readString();
     }
 
     public boolean getExpired() {

--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.kt
@@ -56,6 +56,7 @@ import org.dash.wallet.common.ui.enter_amount.EnterAmountFragment
 import org.dash.wallet.common.ui.enter_amount.EnterAmountViewModel
 import org.dash.wallet.common.ui.viewBinding
 import org.dash.wallet.common.util.observe
+import org.dash.wallet.common.util.openCustomTab
 import org.dash.wallet.common.util.toFormattedString
 import org.slf4j.LoggerFactory
 import javax.inject.Inject
@@ -352,6 +353,13 @@ open class SendCoinsFragment: Fragment(R.layout.send_coins_fragment) {
 
         showTransactionResult(transaction, autoAcceptContactRequest)
         playSentSound()
+
+        // BIP21 callback=<https-url>: surface the merchant continuation URL after the send.
+        // Already validated as https at parse time in PaymentIntent.fromBitcoinUri.
+        args.paymentIntent.callback?.let { callbackUrl ->
+            requireActivity().openCustomTab(callbackUrl)
+        }
+
         requireActivity().finish()
     }
 


### PR DESCRIPTION
Parses two new BIP21 URI parameters and routes them through the existing payment flow:

  - `op_return=<hex>`: hex-encoded payload (up to 80 bytes) attached to the transaction as a 0-value OP_RETURN output. Used for cross-chain memos (THORChain/Maya), order IDs, and similar payee-side correlation data.

  - `callback=<https-url>`: https URL opened in a Chrome Custom Tab after a successful send so the merchant can continue its checkout flow. Only https is accepted at parse time to prevent a URI from invoking arbitrary app handlers.

The OP_RETURN payload is built via `ScriptBuilder.createOpReturnScript` and appended to the existing `outputs[]` array, so the existing broadcast path picks it up with no further changes. The dust check in bitcoinj's `TransactionOutput.isDust` already exempts 0-value OP_RETURN scripts, so no special-case handling was needed there.

`mergeWithEditedValues` now preserves auxiliary outputs (e.g. OP_RETURN) and the callback URL when the user edits the amount in the send screen — previously the non-primary outputs were dropped.

Both parameters are optional and additive — URIs that don't carry them behave identically to before.

Mirrors the corresponding iOS change in dashpay/dashsync-iOS and dashpay/dashwallet-ios.

<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for BIP21 payment links with an optional secure callback URL.
  * After a successful payment, the app can now continue to the provided callback in a browser tab.

* **Bug Fixes**
  * Improved payment editing so changing the amount keeps the rest of the original outputs intact.
  * Preserved callback details when updating an existing payment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->