### PR TITLE
chore: write SHA-256 checksum file next to each assembled APK

### DIFF
--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -530,13 +530,21 @@ apply from: file("../gradle/google-services.gradle")
 //   sha256sum -c dash-wallet-<variant>.apk.sha256
 // This runs automatically as a finalizer of each assemble<Variant> task.
 android.applicationVariants.all { variant ->
-    variant.outputs.all { output ->
-        def apkFile = output.outputFile
-        def taskName = "generate${variant.name.capitalize()}ApkSha256"
-        def sha256Task = tasks.register(taskName) {
-            description = "Writes a SHA-256 checksum file next to the ${variant.name} APK"
-            onlyIf { apkFile.exists() }
-            doLast {
+    // One task per variant covering all of its APK outputs, so ABI/density splits
+    // do not attempt to register the same task name more than once. Only plain
+    // values (variant name, File list) are captured, keeping the task closures
+    // compatible with the configuration cache.
+    def variantName = variant.name
+    def apkFiles = variant.outputs.collect { it.outputFile }
+    def sha256Task = tasks.register("generate${variantName.capitalize()}ApkSha256") {
+        description = "Writes a SHA-256 checksum file next to each ${variantName} APK"
+        onlyIf { apkFiles.any { it.exists() } }
+        doLast {
+            apkFiles.each { apkFile ->
+                if (!apkFile.exists()) {
+                    logger.warn("Skipping checksum for missing APK: ${apkFile}")
+                    return
+                }
                 def digest = java.security.MessageDigest.getInstance("SHA-256")
                 apkFile.withInputStream { stream ->
                     def buffer = new byte[8192]
@@ -552,6 +560,10 @@ android.applicationVariants.all { variant ->
                 logger.lifecycle("Wrote checksum to ${shaFile}")
             }
         }
-        variant.assembleProvider.configure { finalizedBy(sha256Task) }
     }
+    // A finalizer only runs when the finalized task actually executes, and the
+    // assemble<Variant> lifecycle task is skipped whenever one of its dependencies
+    // (e.g. package<Variant>) fails, so a stale APK left over from a failed build
+    // is never checksummed as if it were the new artifact.
+    variant.assembleProvider.configure { finalizedBy(sha256Task) }
 }

--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -523,3 +523,35 @@ dependencies {
 }
 
 apply from: file("../gradle/google-services.gradle")
+
+// Generate a SHA-256 checksum file next to each assembled APK.
+// For every APK output, a "<apk-name>.sha256" file is written in the same folder,
+// in sha256sum format ("<hex>  <apk-name>"), so it can be verified with:
+//   sha256sum -c dash-wallet-<variant>.apk.sha256
+// This runs automatically as a finalizer of each assemble<Variant> task.
+android.applicationVariants.all { variant ->
+    variant.outputs.all { output ->
+        def apkFile = output.outputFile
+        def taskName = "generate${variant.name.capitalize()}ApkSha256"
+        def sha256Task = tasks.register(taskName) {
+            description = "Writes a SHA-256 checksum file next to the ${variant.name} APK"
+            onlyIf { apkFile.exists() }
+            doLast {
+                def digest = java.security.MessageDigest.getInstance("SHA-256")
+                apkFile.withInputStream { stream ->
+                    def buffer = new byte[8192]
+                    int read
+                    while ((read = stream.read(buffer)) != -1) {
+                        digest.update(buffer, 0, read)
+                    }
+                }
+                def hex = digest.digest().encodeHex().toString()
+                def shaFile = new File(apkFile.parentFile, "${apkFile.name}.sha256")
+                shaFile.text = "${hex}  ${apkFile.name}\n"
+                logger.lifecycle("SHA-256 (${apkFile.name}): ${hex}")
+                logger.lifecycle("Wrote checksum to ${shaFile}")
+            }
+        }
+        variant.assembleProvider.configure { finalizedBy(sha256Task) }
+    }
+}


### PR DESCRIPTION
Add a finalizer to every assemble<Variant> task that computes the SHA-256 of each APK output and writes a "<apk-name>.sha256" file (sha256sum format) into the same folder, verifiable with:
  sha256sum -c <apk-name>.sha256

<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->
<!--- Add any questions or explanations that are not in the code comments -->
<!--- List related Stories: NMA-???? -->

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

## Screenshots / Videos
<!--- Include screenshots or videos here if applicable -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] QA (Mobile Team)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code and added comments where necessary
- [ ] I have added or updated relevant unit/integration/functional/e2e tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release builds now generate accompanying **SHA-256 checksum** files for each produced APK.
  * Checksums are computed automatically as part of the **release assemble** process.
  * Build output includes the **computed hash** and the **destination path** for each checksum file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->