### PR TITLE
fix: Dash DEX sell-swap fixes (MO-983, MO-984, MO-969)

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/payments/parsers/AddressParser.kt
+++ b/common/src/main/java/org/dash/wallet/common/payments/parsers/AddressParser.kt
@@ -21,7 +21,7 @@ import org.bitcoinj.core.Address
 import org.bitcoinj.core.Base58
 import org.bitcoinj.core.NetworkParameters
 
-open class AddressParser(pattern: String, val params: NetworkParameters?, ignoreCase: Boolean = false) {
+open class AddressParser(pattern: String, val params: NetworkParameters?, private val ignoreCase: Boolean = false) {
     companion object {
         val PATTERN_BITCOIN_ADDRESS = "[${Base58.ALPHABET.joinToString(separator = "")}]{20,40}"
         private const val PATTERN_ETHEREUM_ADDRESS = "0x[a-fA-F0-9]{40}"
@@ -70,11 +70,14 @@ open class AddressParser(pattern: String, val params: NetworkParameters?, ignore
     /**
      * Canonicalizes the case of a scanned or pasted address: bech32 QR codes commonly carry
      * the all-uppercase form (alphanumeric mode), which is lowercased when the lowercase form
-     * is a valid address. Anything containing a lowercase letter is left untouched — Base58
-     * and EIP-55 checksums are case-significant.
+     * is a valid address. Only inputs reported by [isCaseInsensitiveFormat] are ever rewritten:
+     * Base58 and EIP-55 are case-significant, and where they are validated by pattern only
+     * (no [params], so no checksum) an all-caps corrupt address could otherwise be "repaired"
+     * into a different, plausible-looking one instead of being rejected.
      */
     fun normalizeCase(input: String): String {
-        return if (input.any { it.isUpperCase() } &&
+        return if (isCaseInsensitiveFormat(input) &&
+            input.any { it.isUpperCase() } &&
             input.none { it.isLowerCase() } &&
             exactMatch(input.lowercase())
         ) {
@@ -83,6 +86,12 @@ open class AddressParser(pattern: String, val params: NetworkParameters?, ignore
             input
         }
     }
+
+    /**
+     * Whether [input] is a candidate for a case-insensitive address format. Parsers that mix
+     * case-insensitive bech32 with case-sensitive alternatives override this per input.
+     */
+    protected open fun isCaseInsensitiveFormat(input: String): Boolean = ignoreCase
 
     protected open fun verifyAddress(addressCandidate: String) {
         params?.let { Address.fromString(params, addressCandidate) }

--- a/common/src/main/java/org/dash/wallet/common/payments/parsers/AddressParser.kt
+++ b/common/src/main/java/org/dash/wallet/common/payments/parsers/AddressParser.kt
@@ -21,7 +21,7 @@ import org.bitcoinj.core.Address
 import org.bitcoinj.core.Base58
 import org.bitcoinj.core.NetworkParameters
 
-open class AddressParser(pattern: String, val params: NetworkParameters?) {
+open class AddressParser(pattern: String, val params: NetworkParameters?, ignoreCase: Boolean = false) {
     companion object {
         val PATTERN_BITCOIN_ADDRESS = "[${Base58.ALPHABET.joinToString(separator = "")}]{20,40}"
         private const val PATTERN_ETHEREUM_ADDRESS = "0x[a-fA-F0-9]{40}"
@@ -39,7 +39,7 @@ open class AddressParser(pattern: String, val params: NetworkParameters?) {
         }
     }
 
-    private val addressPattern = Regex(pattern)
+    private val addressPattern = Regex(pattern, if (ignoreCase) setOf(RegexOption.IGNORE_CASE) else emptySet())
 
     open fun exactMatch(inputText: String): Boolean {
         return addressPattern.matches(inputText) && isAddressValid(inputText)

--- a/common/src/main/java/org/dash/wallet/common/payments/parsers/AddressParser.kt
+++ b/common/src/main/java/org/dash/wallet/common/payments/parsers/AddressParser.kt
@@ -67,6 +67,23 @@ open class AddressParser(pattern: String, val params: NetworkParameters?, ignore
         return validRanges
     }
 
+    /**
+     * Canonicalizes the case of a scanned or pasted address: bech32 QR codes commonly carry
+     * the all-uppercase form (alphanumeric mode), which is lowercased when the lowercase form
+     * is a valid address. Anything containing a lowercase letter is left untouched — Base58
+     * and EIP-55 checksums are case-significant.
+     */
+    fun normalizeCase(input: String): String {
+        return if (input.any { it.isUpperCase() } &&
+            input.none { it.isLowerCase() } &&
+            exactMatch(input.lowercase())
+        ) {
+            input.lowercase()
+        } else {
+            input
+        }
+    }
+
     protected open fun verifyAddress(addressCandidate: String) {
         params?.let { Address.fromString(params, addressCandidate) }
     }

--- a/common/src/main/java/org/dash/wallet/common/payments/parsers/Bech32AddressParser.kt
+++ b/common/src/main/java/org/dash/wallet/common/payments/parsers/Bech32AddressParser.kt
@@ -17,11 +17,16 @@
 
 package org.dash.wallet.common.payments.parsers
 
+import org.bitcoinj.core.AddressFormatException
 import org.bitcoinj.core.NetworkParameters
 
+// BIP-173 allows a bech32 string to be all-lowercase or all-uppercase (QR codes use upper
+// for the denser alphanumeric mode), so match case-insensitively; mixed case is rejected
+// in verifyAddress.
 open class Bech32AddressParser(hrp: String, regex: String, params: NetworkParameters? = null) : AddressParser(
     "${hrp}$regex",
-    params
+    params,
+    ignoreCase = true
 ) {
     companion object {
         private const val BECH32_ALPHABET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
@@ -34,6 +39,11 @@ open class Bech32AddressParser(hrp: String, regex: String, params: NetworkParame
         this(params.segwitAddressHrp, "1[$BECH32_ALPHABET]{$min,$max}", params)
 
     override fun verifyAddress(addressCandidate: String) {
+        // BIP-173 forbids mixing cases; enforce it here since the chains without params
+        // never reach a decoder that would catch it
+        if (addressCandidate.any { it.isLowerCase() } && addressCandidate.any { it.isUpperCase() }) {
+            throw AddressFormatException("bech32 must not mix upper and lower case: $addressCandidate")
+        }
         params?.let { SegwitAddress.fromBech32(params, addressCandidate) }
     }
 }

--- a/common/src/main/java/org/dash/wallet/common/payments/parsers/BitcoinAddressParser.kt
+++ b/common/src/main/java/org/dash/wallet/common/payments/parsers/BitcoinAddressParser.kt
@@ -35,6 +35,12 @@ class BitcoinAddressParser(params: NetworkParameters) : AddressParser(PATTERN_BI
         return result
     }
 
+    // Only the segwit bech32 alternative is case-insensitive; legacy Base58 keeps its case.
+    override fun isCaseInsensitiveFormat(input: String): Boolean {
+        val hrp = params?.segwitAddressHrp ?: return false
+        return input.startsWith("${hrp}1", ignoreCase = true)
+    }
+
     override fun verifyAddress(addressCandidate: String) {
         params?.let {
             try {

--- a/common/src/main/java/org/dash/wallet/common/ui/address_input/AddressInputViewModel.kt
+++ b/common/src/main/java/org/dash/wallet/common/ui/address_input/AddressInputViewModel.kt
@@ -52,7 +52,7 @@ data class AddressInputResult(
             return if (separator == -1) {
                 addressInput
             } else {
-                addressInput.substring(separator)
+                addressInput.substring(separator + 1)
             }
         }
 }

--- a/common/src/test/java/org/dash/wallet/common/payments/parsers/AddressParserTest.kt
+++ b/common/src/test/java/org/dash/wallet/common/payments/parsers/AddressParserTest.kt
@@ -19,6 +19,7 @@ package org.dash.wallet.common.payments.parsers
 
 import org.bitcoinj.params.MainNetParams
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -58,14 +59,26 @@ class AddressParserTest {
         SegwitAddress.fromBech32(network, "bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297")
         SegwitAddress.fromBech32(network, "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0")
 
+        // All-uppercase bech32 is valid per BIP-173 (QR codes use it for alphanumeric mode).
+        // First one is the BIP-173 uppercase test vector.
+        assertTrue(parser.exactMatch("BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4"))
+        assertTrue(parser.exactMatch("BC1QXHGNNP745ZRYN2UD8HM6K3MYGKKPKM35020JS0"))
+        assertTrue(parser.exactMatch("BC1P5D7RJQ7G6RDK2YHZKS9SMLAQTEDR4DEKQ08GE8ZTWAC72SFR9RUSXG3297"))
+        SegwitAddress.fromBech32(network, "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4")
+
+        // Mixed case is invalid per BIP-173.
+        assertFalse(parser.exactMatch("bc1qxhgnnp745zryn2ud8hm6k3mygkkpkm35020JS0"))
+        assertFalse(parser.exactMatch("BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3t4"))
+
         assertEquals(
-            4,
+            5,
             parser.findAll(
                 """
                 Here is the first address 183axN6F7ZjwayiJPjjwJgWGas6J9mtfi
                 and the second: 34Me5SAG8W8Bf2LxGfPiqVZRKKV1VL1hmW
                 \n\n bc1qxhgnnp745zryn2ud8hm6k3mygkkpkm35020js0
                 \n bc1p5d7rjq7g6rdk2yhzks9smlaqtedr4dekq08ge8ztwac72sfr9rusxg3297
+                \n BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4
                 """
             ).size
         )
@@ -96,6 +109,10 @@ class AddressParserTest {
         assertTrue(parser.exactMatch("kujira1r8egcurpwxftegr07gjv9gwffw4fk00960dj4f"))
         assertTrue(parser.exactMatch("kujira1377jxt6t0jrkk47thc86udxfxnvqkhj7evmd99"))
 
+        // All-uppercase bech32 is valid per BIP-173; mixed case is not.
+        assertTrue(parser.exactMatch("KUJIRA1R8EGCURPWXFTEGR07GJV9GWFFW4FK00960DJ4F"))
+        assertFalse(parser.exactMatch("kujira1R8EGCURPWXFTEGR07GJV9GWFFW4FK00960DJ4F"))
+
         assertEquals(
             2,
             parser.findAll(
@@ -110,6 +127,8 @@ class AddressParserTest {
 
         assertTrue(runeParser.exactMatch("thor166n4w5039meulfa3p6ydg60ve6ueac7tlt0jws"))
         assertTrue(runeParser.exactMatch("thor1ap5vn4svwkpch2c9jm7hlpr2pj47e62xwpcvtw"))
+        assertTrue(runeParser.exactMatch("THOR166N4W5039MEULFA3P6YDG60VE6UEAC7TLT0JWS"))
+        assertFalse(runeParser.exactMatch("THOR166n4w5039meulfa3p6ydg60ve6ueac7tlt0jws"))
 
         assertEquals(
             2,

--- a/common/src/test/java/org/dash/wallet/common/payments/parsers/AddressParserTest.kt
+++ b/common/src/test/java/org/dash/wallet/common/payments/parsers/AddressParserTest.kt
@@ -135,6 +135,16 @@ class AddressParserTest {
             "thor166n4w5039meulfa3p6ydg60ve6ueac7tlt0jws",
             runeParser.normalizeCase("THOR166N4W5039MEULFA3P6YDG60VE6UEAC7TLT0JWS")
         )
+
+        // A params-less Base58 parser validates by pattern only (no checksum), so the
+        // case-sensitivity gate is what keeps an all-caps Base58 string — whose lowercase
+        // form also matches the pattern — from being rewritten into a different address.
+        val base58Parser = AddressParser.getBase58AddressParser()
+        assertTrue(base58Parser.exactMatch("3AB4ME5SAG8W8BF2XGFPQVZRKKV1V1HMW".lowercase()))
+        assertEquals(
+            "3AB4ME5SAG8W8BF2XGFPQVZRKKV1V1HMW",
+            base58Parser.normalizeCase("3AB4ME5SAG8W8BF2XGFPQVZRKKV1V1HMW")
+        )
     }
 
     @Test

--- a/common/src/test/java/org/dash/wallet/common/payments/parsers/AddressParserTest.kt
+++ b/common/src/test/java/org/dash/wallet/common/payments/parsers/AddressParserTest.kt
@@ -103,6 +103,41 @@ class AddressParserTest {
     }
 
     @Test
+    fun normalizeCaseTest() {
+        val bitcoinParser = BitcoinAddressParser(BitcoinMainNetParams())
+
+        // All-caps bech32 (QR alphanumeric mode) canonicalizes to lowercase.
+        assertEquals(
+            "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+            bitcoinParser.normalizeCase("BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4")
+        )
+        // Already lowercase, mixed case, and case-significant Base58 pass through unchanged.
+        assertEquals(
+            "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+            bitcoinParser.normalizeCase("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")
+        )
+        assertEquals(
+            "BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3t4",
+            bitcoinParser.normalizeCase("BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3t4")
+        )
+        assertEquals(
+            "34Me5SAG8W8Bf2LxGfPiqVZRKKV1VL1hmW",
+            bitcoinParser.normalizeCase("34Me5SAG8W8Bf2LxGfPiqVZRKKV1VL1hmW")
+        )
+        // Uppercased Base58 doesn't lowercase into a valid address — untouched.
+        assertEquals(
+            "34ME5SAG8W8BF2LXGFPIQVZRKKV1VL1HMW",
+            bitcoinParser.normalizeCase("34ME5SAG8W8BF2LXGFPIQVZRKKV1VL1HMW")
+        )
+
+        val runeParser = Bech32AddressParser("thor", 38, null)
+        assertEquals(
+            "thor166n4w5039meulfa3p6ydg60ve6ueac7tlt0jws",
+            runeParser.normalizeCase("THOR166N4W5039MEULFA3P6YDG60VE6UEAC7TLT0JWS")
+        )
+    }
+
+    @Test
     fun bech32AddressTest() {
         val parser = Bech32AddressParser("kujira", 38, null)
 

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/Bech32PaymentIntentParser.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/Bech32PaymentIntentParser.kt
@@ -71,7 +71,9 @@ open class Bech32PaymentIntentParser(
             }
         } else if (addressParser.exactMatch(input)) {
             try {
-                return@withContext createPaymentIntent(input)
+                // a matched bech32 address is uniformly lower or upper case (mixed is rejected);
+                // lowercase is the canonical form expected in the swap memo
+                return@withContext createPaymentIntent(input.lowercase())
             } catch (ex: AddressFormatException) {
                 log.info("got invalid address", ex)
                 throw PaymentIntentParserException(

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/Bech32PaymentIntentParser.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/Bech32PaymentIntentParser.kt
@@ -43,8 +43,8 @@ open class Bech32PaymentIntentParser(
     override suspend fun parse(input: String): PaymentIntent = withContext(Dispatchers.Default) {
         if (input.startsWith("$uriPrefix:") || input.startsWith("${uriPrefix.uppercase()}:")) {
             try {
-                val address = input.substring(uriPrefix.length + 1)
-                return@withContext createPaymentIntent(normalize(address))
+                val address = validate(input.substring(uriPrefix.length + 1))
+                return@withContext createPaymentIntent(address)
             } catch (ex: Exception) {
                 log.info("got invalid uri: '$input'", ex)
                 throw PaymentIntentParserException(
@@ -57,8 +57,8 @@ open class Bech32PaymentIntentParser(
             }
         } else if (input.startsWith("$currency:") || input.startsWith("${currency.uppercase()}:")) {
             try {
-                val address = input.substring(currency.length + 1)
-                return@withContext createPaymentIntent(normalize(address))
+                val address = validate(input.substring(currency.length + 1))
+                return@withContext createPaymentIntent(address)
             } catch (ex: Exception) {
                 log.info("got invalid uri: '$input'", ex)
                 throw PaymentIntentParserException(
@@ -71,7 +71,7 @@ open class Bech32PaymentIntentParser(
             }
         } else if (addressParser.exactMatch(input)) {
             try {
-                return@withContext createPaymentIntent(normalize(input))
+                return@withContext createPaymentIntent(input.lowercase())
             } catch (ex: AddressFormatException) {
                 log.info("got invalid address", ex)
                 throw PaymentIntentParserException(
@@ -95,10 +95,15 @@ open class Bech32PaymentIntentParser(
     }
 
     /**
-     * A valid bech32 address may be scanned all-uppercase (QR alphanumeric mode); lowercase is
-     * the canonical form expected in the swap memo. Anything that isn't a valid bech32 match is
-     * passed through unchanged.
+     * A URI scheme prefix says nothing about the payload that follows it, so the payload gets
+     * the same validation as a bare address before it can reach the swap memo. A valid bech32
+     * address may be scanned all-uppercase (QR alphanumeric mode); lowercase is the canonical
+     * form expected in the memo.
      */
-    private fun normalize(address: String) =
-        if (addressParser.exactMatch(address)) address.lowercase() else address
+    private fun validate(address: String): String {
+        if (!addressParser.exactMatch(address)) {
+            throw AddressFormatException("not a valid $currency address: $address")
+        }
+        return address.lowercase()
+    }
 }

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/Bech32PaymentIntentParser.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/Bech32PaymentIntentParser.kt
@@ -43,8 +43,8 @@ open class Bech32PaymentIntentParser(
     override suspend fun parse(input: String): PaymentIntent = withContext(Dispatchers.Default) {
         if (input.startsWith("$uriPrefix:") || input.startsWith("${uriPrefix.uppercase()}:")) {
             try {
-                val hexAddress = input.substring(uriPrefix.length)
-                return@withContext createPaymentIntent(hexAddress)
+                val address = input.substring(uriPrefix.length + 1)
+                return@withContext createPaymentIntent(normalize(address))
             } catch (ex: Exception) {
                 log.info("got invalid uri: '$input'", ex)
                 throw PaymentIntentParserException(
@@ -57,8 +57,8 @@ open class Bech32PaymentIntentParser(
             }
         } else if (input.startsWith("$currency:") || input.startsWith("${currency.uppercase()}:")) {
             try {
-                val hexAddress = input.substring(currency.length)
-                return@withContext createPaymentIntent(hexAddress)
+                val address = input.substring(currency.length + 1)
+                return@withContext createPaymentIntent(normalize(address))
             } catch (ex: Exception) {
                 log.info("got invalid uri: '$input'", ex)
                 throw PaymentIntentParserException(
@@ -71,9 +71,7 @@ open class Bech32PaymentIntentParser(
             }
         } else if (addressParser.exactMatch(input)) {
             try {
-                // a matched bech32 address is uniformly lower or upper case (mixed is rejected);
-                // lowercase is the canonical form expected in the swap memo
-                return@withContext createPaymentIntent(input.lowercase())
+                return@withContext createPaymentIntent(normalize(input))
             } catch (ex: AddressFormatException) {
                 log.info("got invalid address", ex)
                 throw PaymentIntentParserException(
@@ -95,4 +93,12 @@ open class Bech32PaymentIntentParser(
             )
         )
     }
+
+    /**
+     * A valid bech32 address may be scanned all-uppercase (QR alphanumeric mode); lowercase is
+     * the canonical form expected in the swap memo. Anything that isn't a valid bech32 match is
+     * passed through unchanged.
+     */
+    private fun normalize(address: String) =
+        if (addressParser.exactMatch(address)) address.lowercase() else address
 }

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/CardanoAddressParser.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/CardanoAddressParser.kt
@@ -40,6 +40,11 @@ class CardanoAddressParser : AddressParser(
         private const val MAX_SHELLEY_LENGTH = 110
     }
 
+    // Only the Shelley bech32 form is case-insensitive; Byron Base58 keeps its case.
+    override fun isCaseInsensitiveFormat(input: String): Boolean {
+        return input.startsWith("addr1", ignoreCase = true)
+    }
+
     override fun verifyAddress(addressCandidate: String) {
         if (addressCandidate.startsWith("addr1", ignoreCase = true)) {
             val decoded = Bech32.decode(addressCandidate, MAX_SHELLEY_LENGTH)

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/CardanoAddressParser.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/CardanoAddressParser.kt
@@ -30,7 +30,9 @@ import java.util.zip.CRC32
  * CBOR-wrapped CRC32 — so a single-character typo is rejected client-side.
  */
 class CardanoAddressParser : AddressParser(
-    "(addr1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{53,98})|((Ae2|DdzFF)[1-9A-HJ-NP-Za-km-z]{50,110})",
+    // Only the Shelley alternative is case-insensitive — bech32 may be all-caps (BIP-173),
+    // while Byron Base58 is case-sensitive. Bech32.decode rejects mixed case.
+    "((?i:addr1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{53,98}))|((Ae2|DdzFF)[1-9A-HJ-NP-Za-km-z]{50,110})",
     null
 ) {
     companion object {
@@ -39,7 +41,7 @@ class CardanoAddressParser : AddressParser(
     }
 
     override fun verifyAddress(addressCandidate: String) {
-        if (addressCandidate.startsWith("addr1")) {
+        if (addressCandidate.startsWith("addr1", ignoreCase = true)) {
             val decoded = Bech32.decode(addressCandidate, MAX_SHELLEY_LENGTH)
             require(decoded.encoding == Bech32.Encoding.BECH32 && decoded.hrp == "addr") {
                 "not a mainnet Shelley address"

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/CardanoPaymentIntentParser.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/CardanoPaymentIntentParser.kt
@@ -51,7 +51,10 @@ open class CardanoPaymentIntentParser(
             }
         } else if (addressParser.exactMatch(input)) {
             try {
-                return@withContext createPaymentIntent(input)
+                // Shelley addresses are bech32 and may be scanned all-caps; lowercase is
+                // canonical. Byron addresses are Base58 (case-sensitive) — leave untouched.
+                val address = if (input.startsWith("addr1", ignoreCase = true)) input.lowercase() else input
+                return@withContext createPaymentIntent(address)
             } catch (ex: AddressFormatException) {
                 log.info("got invalid address", ex)
                 throw PaymentIntentParserException(

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/CardanoPaymentIntentParser.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/CardanoPaymentIntentParser.kt
@@ -40,7 +40,7 @@ open class CardanoPaymentIntentParser(
     override suspend fun parse(input: String): PaymentIntent = withContext(Dispatchers.Default) {
         if (input.startsWith("$uriPrefix:") || input.startsWith("${uriPrefix.uppercase()}:")) {
             try {
-                val address = input.substring(uriPrefix.length + 1)
+                val address = validate(input.substring(uriPrefix.length + 1))
                 return@withContext createPaymentIntent(address)
             } catch (ex: Exception) {
                 log.info("got invalid uri: '$input'", ex)
@@ -51,10 +51,7 @@ open class CardanoPaymentIntentParser(
             }
         } else if (addressParser.exactMatch(input)) {
             try {
-                // Shelley addresses are bech32 and may be scanned all-caps; lowercase is
-                // canonical. Byron addresses are Base58 (case-sensitive) — leave untouched.
-                val address = if (input.startsWith("addr1", ignoreCase = true)) input.lowercase() else input
-                return@withContext createPaymentIntent(address)
+                return@withContext createPaymentIntent(normalizeShelley(input))
             } catch (ex: AddressFormatException) {
                 log.info("got invalid address", ex)
                 throw PaymentIntentParserException(
@@ -68,5 +65,20 @@ open class CardanoPaymentIntentParser(
             IllegalArgumentException(input),
             ResourceString(R.string.error, listOf(input))
         )
+    }
+
+    /**
+     * Shelley addresses are bech32 and may be scanned all-caps; lowercase is canonical.
+     * Byron addresses are Base58 (case-sensitive) — left untouched.
+     */
+    private fun normalizeShelley(address: String) =
+        if (address.startsWith("addr1", ignoreCase = true)) address.lowercase() else address
+
+    /** URI payloads get the same validation as bare addresses before reaching the swap memo. */
+    private fun validate(address: String): String {
+        if (!addressParser.exactMatch(address)) {
+            throw AddressFormatException("not a valid $currency address: $address")
+        }
+        return normalizeShelley(address)
     }
 }

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/EthereumPaymentIntentParser.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/EthereumPaymentIntentParser.kt
@@ -44,7 +44,7 @@ class EthereumPaymentIntentParser(
     override suspend fun parse(input: String): PaymentIntent = withContext(Dispatchers.Default) {
         if (input.startsWith("$uriPrefix:") || input.startsWith("${uriPrefix.uppercase()}:")) {
             try {
-                val hexAddress = input.substring(uriPrefix.length)
+                val hexAddress = input.substring(uriPrefix.length + 1)
                 return@withContext createPaymentIntent(hexAddress)
             } catch (ex: Exception) {
                 log.info("got invalid uri: '$input'", ex)
@@ -56,9 +56,9 @@ class EthereumPaymentIntentParser(
                     )
                 )
             }
-        } else if (input.startsWith(currency) || input.startsWith("${currency.uppercase()}:")) {
+        } else if (input.startsWith("$currency:") || input.startsWith("${currency.uppercase()}:")) {
             try {
-                val hexAddress = input.substring(currency.length)
+                val hexAddress = input.substring(currency.length + 1)
                 return@withContext createPaymentIntent(hexAddress)
             } catch (ex: Exception) {
                 log.info("got invalid uri: '$input'", ex)

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/SolanaAddressParser.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/SolanaAddressParser.kt
@@ -16,10 +16,23 @@
  */
 package org.dash.wallet.integrations.maya.payments.parsers
 
+import org.bitcoinj.core.Base58
 import org.dash.wallet.common.payments.parsers.AddressParser
 
 /**
  * Solana address parser — Base58 ed25519 public key, 32 to 44 characters.
- * Uses a permissive Base58 alphabet check; final validation is done by SwapKit.
  */
-class SolanaAddressParser : AddressParser("[1-9A-HJ-NP-Za-km-z]{32,44}", null)
+class SolanaAddressParser : AddressParser("[1-9A-HJ-NP-Za-km-z]{32,44}", null) {
+    /**
+     * A Solana address is the Base58 encoding of a raw 32-byte ed25519 public key. The
+     * lexical pattern alone also matches other chains' Base58 strings — notably a Dash
+     * P2PKH address (25-byte Base58Check payload, 34 chars), which then only fails at
+     * conversion time (MO-969) — so require the decoded payload to be exactly 32 bytes.
+     */
+    override fun verifyAddress(addressCandidate: String) {
+        val decoded = Base58.decode(addressCandidate)
+        require(decoded.size == 32) {
+            "not a Base58-encoded 32-byte key (${decoded.size} bytes)"
+        }
+    }
+}

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/SolanaPaymentIntentParser.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/SolanaPaymentIntentParser.kt
@@ -42,6 +42,10 @@ open class SolanaPaymentIntentParser(
         if (input.startsWith("$uriPrefix:") || input.startsWith("${uriPrefix.uppercase()}:")) {
             try {
                 val address = input.substring(uriPrefix.length + 1)
+                // The URI branch must validate the stripped address like the bare-address
+                // branch below does — createPaymentIntent encodes whatever it is given, so
+                // without this a "solana:"-prefixed non-Solana address slips through.
+                require(addressParser.exactMatch(address)) { "not a valid SOL address: '$address'" }
                 return@withContext createPaymentIntent(address)
             } catch (ex: Exception) {
                 log.info("got invalid uri: '$input'", ex)

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/XrdPaymentIntentParser.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/XrdPaymentIntentParser.kt
@@ -46,7 +46,8 @@ class XrdPaymentIntentParser : MayaPaymentIntentParser("XRD", "radix", "XRD.XRD"
                 )
             }
         } else if (addressParser.exactMatch(input)) {
-            return@withContext createPaymentIntent(input)
+            // bech32 may be scanned all-caps; lowercase is the canonical form
+            return@withContext createPaymentIntent(input.lowercase())
         }
         log.info("cannot classify: '{}'", input)
         throw PaymentIntentParserException(

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/XrdPaymentIntentParser.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/XrdPaymentIntentParser.kt
@@ -18,6 +18,7 @@ package org.dash.wallet.integrations.maya.payments.parsers
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.bitcoinj.core.AddressFormatException
 import org.dash.wallet.common.R
 import org.dash.wallet.common.data.PaymentIntent
 import org.dash.wallet.common.payments.parsers.Bech32AddressParser
@@ -36,8 +37,13 @@ class XrdPaymentIntentParser : MayaPaymentIntentParser("XRD", "radix", "XRD.XRD"
     override suspend fun parse(input: String): PaymentIntent = withContext(Dispatchers.Default) {
         if (input.startsWith("$uriPrefix:") || input.startsWith("${uriPrefix.uppercase()}:")) {
             try {
+                // A URI payload gets the same validation as a bare address before reaching
+                // the swap memo; bech32 may be scanned all-caps, lowercase is canonical.
                 val address = input.substring(uriPrefix.length + 1)
-                return@withContext createPaymentIntent(address)
+                if (!addressParser.exactMatch(address)) {
+                    throw AddressFormatException("not a valid XRD address: $address")
+                }
+                return@withContext createPaymentIntent(address.lowercase())
             } catch (ex: Exception) {
                 log.info("got invalid uri: '$input'", ex)
                 throw PaymentIntentParserException(

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/ZcashAddressParser.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/ZcashAddressParser.kt
@@ -36,6 +36,12 @@ class ZcashAddressParser : AddressParser("t[13][1-9A-HJ-NP-Za-km-z]{33}", null) 
             unifiedParser.exactMatch(inputText)
     }
 
+    // Only the bech32 forms (Sapling zs1..., unified u1...) are case-insensitive; transparent
+    // t-addresses are Base58 and keep their case.
+    override fun isCaseInsensitiveFormat(input: String): Boolean {
+        return input.startsWith("zs1", ignoreCase = true) || input.startsWith("u1", ignoreCase = true)
+    }
+
     override fun findAll(inputText: String): List<IntRange> {
         val result = arrayListOf<IntRange>()
         result.addAll(super.findAll(inputText))

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/ZcashPaymentIntentParser.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/ZcashPaymentIntentParser.kt
@@ -49,7 +49,10 @@ class ZcashPaymentIntentParser : MayaPaymentIntentParser("ZEC", "zcash", "ZEC.ZE
             }
         } else if (addressParser.exactMatch(input)) {
             try {
-                return@withContext createPaymentIntent(input)
+                // shielded/unified addresses are bech32 and may be scanned all-caps; lowercase is
+                // canonical. Transparent t-addresses are Base58 (case-sensitive) — leave untouched.
+                val address = if (input.startsWith("t")) input else input.lowercase()
+                return@withContext createPaymentIntent(address)
             } catch (ex: AddressFormatException) {
                 log.info("got invalid address", ex)
                 throw PaymentIntentParserException(

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/ZcashPaymentIntentParser.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/payments/parsers/ZcashPaymentIntentParser.kt
@@ -38,7 +38,7 @@ class ZcashPaymentIntentParser : MayaPaymentIntentParser("ZEC", "zcash", "ZEC.ZE
     override suspend fun parse(input: String): PaymentIntent = withContext(Dispatchers.Default) {
         if (input.startsWith("$uriPrefix:") || input.startsWith("${uriPrefix.uppercase()}:")) {
             try {
-                val address = input.substring(uriPrefix.length + 1)
+                val address = validate(input.substring(uriPrefix.length + 1))
                 return@withContext createPaymentIntent(address)
             } catch (ex: Exception) {
                 log.info("got invalid uri: '$input'", ex)
@@ -49,10 +49,7 @@ class ZcashPaymentIntentParser : MayaPaymentIntentParser("ZEC", "zcash", "ZEC.ZE
             }
         } else if (addressParser.exactMatch(input)) {
             try {
-                // shielded/unified addresses are bech32 and may be scanned all-caps; lowercase is
-                // canonical. Transparent t-addresses are Base58 (case-sensitive) — leave untouched.
-                val address = if (input.startsWith("t")) input else input.lowercase()
-                return@withContext createPaymentIntent(address)
+                return@withContext createPaymentIntent(normalizeShielded(input))
             } catch (ex: AddressFormatException) {
                 log.info("got invalid address", ex)
                 throw PaymentIntentParserException(
@@ -66,5 +63,20 @@ class ZcashPaymentIntentParser : MayaPaymentIntentParser("ZEC", "zcash", "ZEC.ZE
             IllegalArgumentException(input),
             ResourceString(R.string.error, listOf(input))
         )
+    }
+
+    /**
+     * Shielded/unified addresses are bech32 and may be scanned all-caps; lowercase is
+     * canonical. Transparent t-addresses are Base58 (case-sensitive) — left untouched.
+     */
+    private fun normalizeShielded(address: String) =
+        if (address.startsWith("t")) address else address.lowercase()
+
+    /** URI payloads get the same validation as bare addresses before reaching the swap memo. */
+    private fun validate(address: String): String {
+        if (!addressParser.exactMatch(address)) {
+            throw AddressFormatException("not a valid $currency address: $address")
+        }
+        return normalizeShielded(address)
     }
 }

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/swapkit/SwapKitApiAggregator.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/swapkit/SwapKitApiAggregator.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.launch
 import org.bitcoinj.core.Address
 import org.bitcoinj.core.InsufficientMoneyException
 import org.bitcoinj.utils.Fiat
+import org.bitcoinj.wallet.Wallet
 import org.dash.wallet.common.WalletDataProvider
 import org.dash.wallet.common.data.ResponseResource
 import org.dash.wallet.common.services.SendPaymentService
@@ -626,10 +627,44 @@ class SwapKitApiAggregator @Inject constructor(
     }
 
     override suspend fun getSwapInfo(swapRequest: SwapQuoteRequest): ResponseResource<SwapTradeUIModel> {
-        val sellAmount = swapRequest.amount.dash.setScale(8, RoundingMode.HALF_UP).toPlainString()
-        if (walletDataProvider.wallet == null) {
-            return ResponseResource.Failure(MayaException("wallet not loaded"), false, 0, null)
+        val wallet = walletDataProvider.wallet
+            ?: return ResponseResource.Failure(MayaException("wallet not loaded"), false, 0, null)
+        // A max ("empty wallet") sell sweeps the balance and the miner fee comes out of the
+        // sweep's single output, so the deposit delivers balance − fee. The amount quoted here
+        // is what NEAR Intents expects, and it refuses any deposit below it (auto-refunding
+        // ~1h later minus a 0.001 DASH fee — MO-984), so quote the post-fee sweep output, not
+        // the full balance. Derive it from the CURRENT balance rather than swapRequest.amount:
+        // the pre-broadcast refresh in commitSwapTransaction passes the already-reduced amount
+        // back in, and re-deriving keeps this idempotent across preview and refresh. Deposits
+        // ABOVE the quoted amount are accepted, so only a balance drop is dangerous — that is
+        // guarded again in buildAndSendDepositTx before broadcasting. The receive address is
+        // only a size stand-in for the estimate; the real deposit address is also P2PKH.
+        val effectiveAmount = if (swapRequest.maximum) {
+            val balance = wallet.getBalance(Wallet.BalanceType.ESTIMATED)
+            val sweep = try {
+                sendPaymentService.estimateNetworkFee(
+                    walletDataProvider.currentReceiveAddress(),
+                    balance,
+                    emptyWallet = true
+                )
+            } catch (e: Exception) {
+                log.error("swapkit max sell: sweep fee estimation failed", e)
+                return ResponseResource.Failure(e, false, 0, e.message)
+            }
+            log.info(
+                "swapkit max sell: quoting sweep output {} (balance {}, fee {})",
+                sweep.amountToSend.toFriendlyString(),
+                balance.toFriendlyString(),
+                sweep.fee
+            )
+            swapRequest.amount.copy().apply {
+                dash = sweep.amountToSend.toBigDecimal()
+                anchoredType = swapRequest.amount.anchoredType
+            }
+        } else {
+            swapRequest.amount
         }
+        val sellAmount = effectiveAmount.dash.setScale(8, RoundingMode.HALF_UP).toPlainString()
         // Refund / source address reported to SwapKit. Use the current receive address
         // rather than the wallet's largest-balance UTXO: SwapKit logs this value, and for
         // NEAR routes it is where refunds land, so sending the richest address would link
@@ -708,7 +743,8 @@ class SwapKitApiAggregator @Inject constructor(
             anchoredType = swapRequest.amount.anchoredType
         }
 
-        // Pass swapRequest.amount through unchanged. Mirrors MayaWebApi (which also
+        // Pass the quoted amount through unchanged (effectiveAmount: the request amount,
+        // or the post-fee sweep output for max sells). Mirrors MayaWebApi (which also
         // passes `amount = swapRequest.amount` to SwapTradeUIModel). DO NOT set
         // .crypto from swap.expectedBuyAmount here — Amount.crypto's setter flips
         // the anchor to Crypto and recomputes _dash from crypto/rate, which silently
@@ -722,7 +758,7 @@ class SwapKitApiAggregator @Inject constructor(
             .toBigDecimalOrNull() ?: BigDecimal.ZERO
 
         val result = SwapTradeUIModel(
-            amount = swapRequest.amount,
+            amount = effectiveAmount,
             outputAsset = swapRequest.target_maya_asset,
             feeAmount = feeAmount,
             vaultAddress = vault,
@@ -944,6 +980,33 @@ class SwapKitApiAggregator @Inject constructor(
             // returned one so we notice if a provider ever starts requiring it.
             if (!swapTradeUIModel.memo.isNullOrBlank()) {
                 log.warn("non-Maya deposit route returned a memo; not encoding it: {}", swapTradeUIModel.memo)
+            }
+
+            // A max sell was quoted for (balance − estimated sweep fee) in getSwapInfo. If the
+            // spendable balance dropped since, the sweep's output would come in below the quoted
+            // amount, and NEAR Intents refuses under-delivery — the deposit would sit for ~1h
+            // and refund minus a 0.001 DASH fee. Abort with a recoverable error instead of
+            // broadcasting a doomed deposit. A balance that grew simply over-delivers, which
+            // NEAR accepts.
+            if (swapTradeUIModel.maximum) {
+                val sweep = sendPaymentService.estimateNetworkFee(
+                    depositAddress,
+                    walletDataProvider.wallet!!.getBalance(Wallet.BalanceType.ESTIMATED),
+                    emptyWallet = true
+                )
+                if (sweep.amountToSend.isLessThan(amount)) {
+                    log.warn(
+                        "swapkit max sell aborted: sweep would deliver {} < quoted {}",
+                        sweep.amountToSend.toFriendlyString(),
+                        amount.toFriendlyString()
+                    )
+                    return ResponseResource.Failure(
+                        MayaException("wallet balance changed; the deposit would fall below the quoted amount"),
+                        false,
+                        0,
+                        null
+                    )
+                }
             }
 
             log.info("swapkit deposit: {} to {}", amount.toFriendlyString(), depositAddress)

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/DEXEnterAmountFragment.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/DEXEnterAmountFragment.kt
@@ -50,11 +50,6 @@ class DEXEnterAmountFragment : Fragment() {
     private val mayaViewModel by mayaViewModels<MayaViewModel>()
     private val args by navArgs<DEXEnterAmountFragmentArgs>()
 
-    // Captured while the Maya nav graph is still on the back stack (in onCreateView). onDestroy must
-    // not touch the `viewModel` lazy directly: resolving it re-runs getBackStackEntry(nav_maya), which
-    // throws once the whole flow has been popped to Home (the graph is gone by then).
-    private var resolvedViewModel: DEXEnterAmountViewModel? = null
-
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -70,7 +65,6 @@ class DEXEnterAmountFragment : Fragment() {
             ?: assetPool?.assetPriceFiat?.currencyCode
             ?: args.fiatCurrency
 
-        resolvedViewModel = viewModel
         viewModel.setArguments(
             asset = args.asset,
             assetCurrencyCode = args.currency,
@@ -112,10 +106,11 @@ class DEXEnterAmountFragment : Fragment() {
         // gesture) to the coin picker, or the receive screen's "Back home" popping the whole flow —
         // not on config changes or process death. The shared ViewModel outlives this fragment while
         // the picker is still on the stack, so without this it would restore the stale amount on
-        // the next entry into the buy flow. Use the instance captured in onCreateView rather than the
-        // lazy: re-resolving it here would throw once the whole flow has been popped to Home.
+        // the next entry into the buy flow. Resolving the navGraphViewModels lazy throws once the
+        // whole flow was popped to Home — the graph scope is gone and its state with it, so there
+        // is nothing left to clear.
         if (isRemoving) {
-            resolvedViewModel?.clearEnteredAmount()
+            runCatching { viewModel }.getOrNull()?.clearEnteredAmount()
         }
     }
 }

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/DEXRefundAddressFragment.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/DEXRefundAddressFragment.kt
@@ -64,7 +64,7 @@ class DEXRefundAddressFragment : Fragment() {
     ) { result ->
         if (result.resultCode == Activity.RESULT_OK) {
             result.data?.getStringExtra(ScanActivity.INTENT_EXTRA_RESULT)?.let { scanned ->
-                viewModel.onAddressChanged(scanned)
+                viewModel.onAddressChanged(viewModel.normalizeCase(scanned.trim()))
             }
         }
     }
@@ -116,7 +116,7 @@ class DEXRefundAddressFragment : Fragment() {
         val pasted = clipboard.primaryClip?.takeIf { it.itemCount > 0 }
             ?.getItemAt(0)?.coerceToText(requireContext())?.toString()
         if (!pasted.isNullOrBlank()) {
-            viewModel.onAddressChanged(pasted.trim())
+            viewModel.onAddressChanged(viewModel.normalizeCase(pasted.trim()))
         }
     }
 

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/DEXRefundAddressViewModel.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/DEXRefundAddressViewModel.kt
@@ -159,6 +159,15 @@ class DEXRefundAddressViewModel @Inject constructor(
         persistAddress()
     }
 
+    /**
+     * Canonicalizes a scanned/pasted address for display: the all-uppercase bech32 form QR
+     * codes use becomes lowercase; case-significant forms (Base58, EIP-55) pass through.
+     */
+    fun normalizeCase(text: String): String {
+        val parser = MayaCurrencyList[_uiState.value.asset]?.addressParser
+        return parser?.normalizeCase(text) ?: text
+    }
+
     /** Persist the entered address + its asset so it survives process death. */
     private fun persistAddress() {
         savedStateHandle[KEY_ADDRESS] = _uiState.value.address

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/MayaAddressInputFragment.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/MayaAddressInputFragment.kt
@@ -79,7 +79,7 @@ class MayaAddressInputFragment : Fragment() {
     ) { result ->
         if (result.resultCode == Activity.RESULT_OK) {
             result.data?.getStringExtra(ScanActivity.INTENT_EXTRA_RESULT)?.let { scanned ->
-                viewModel.setInput(scanned)
+                viewModel.setInput(normalizeCase(scanned.trim()))
             }
         }
     }
@@ -179,7 +179,7 @@ class MayaAddressInputFragment : Fragment() {
 
     private fun onSourceClick(source: AddressSourceUIState) {
         if (!source.address.isNullOrEmpty()) {
-            viewModel.setInput(source.address)
+            viewModel.setInput(normalizeCase(source.address))
         } else {
             // exchange login
             findNavController().navigate(DeepLinkDestination.Exchange(source.id, "login_and_close").deepLink)
@@ -187,7 +187,15 @@ class MayaAddressInputFragment : Fragment() {
     }
 
     private fun onClipboardClick() {
-        uiState.clipboardAddress?.let { viewModel.setInput(it) }
+        uiState.clipboardAddress?.let { viewModel.setInput(normalizeCase(it)) }
+    }
+
+    /**
+     * A bech32 address scanned or pasted in its all-uppercase QR form is shown and stored in
+     * canonical lowercase; anything else (Base58, URIs, mixed case) is left as entered.
+     */
+    private fun normalizeCase(text: String): String {
+        return viewModel.paymentParsers.getAddressParser(viewModel.currency)?.normalizeCase(text) ?: text
     }
 
     /**

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/MayaAddressInputFragment.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/MayaAddressInputFragment.kt
@@ -235,6 +235,15 @@ class MayaAddressInputFragment : Fragment() {
                 return@launch
             }
 
+            // A checksum-valid Dash address can pass the permissive lexical validation of some
+            // target chains (e.g. Solana's Base58 length range) and then fail only at
+            // conversion time (MO-969) — reject it explicitly before quoting.
+            if (mayaAddressInputViewModel.isDashAddress(input)) {
+                log.info("rejecting a DASH address as the swap destination for {}", viewModel.currency)
+                setInlineError(getString(CommonR.string.not_valid_address, viewModel.currency))
+                return@launch
+            }
+
             setInlineError(null)
             uiState = uiState.copy(isLoading = true)
             val quote = mayaAddressInputViewModel.getDefaultQuote(viewModel.addressResult.addressInputWithoutPrefix)

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/MayaAddressInputViewModel.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/MayaAddressInputViewModel.kt
@@ -9,8 +9,10 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import org.dash.wallet.common.WalletDataProvider
 import org.dash.wallet.common.integrations.ExchangeIntegration
 import org.dash.wallet.common.integrations.ExchangeIntegrationProvider
+import org.dash.wallet.common.payments.parsers.AddressParser
 import org.dash.wallet.common.ui.address_input.AddressSource
 import org.dash.wallet.integrations.maya.api.SwapProvider
 import org.dash.wallet.integrations.maya.model.SwapQuote
@@ -21,7 +23,8 @@ import javax.inject.Inject
 @HiltViewModel
 class MayaAddressInputViewModel @Inject constructor(
     private val exchangeIntegrationProvider: ExchangeIntegrationProvider,
-    private val swapProvider: SwapProvider
+    private val swapProvider: SwapProvider,
+    walletDataProvider: WalletDataProvider
 ) : ViewModel() {
     companion object {
         // Indicative sell amount for the bootstrap quote: 1 DASH in base units.
@@ -33,6 +36,18 @@ class MayaAddressInputViewModel @Inject constructor(
     }
 
     lateinit var asset: String
+
+    private val dashAddressParser = AddressParser.getDashAddressParser(walletDataProvider.networkParameters)
+
+    /**
+     * True when the input is a checksum-valid DASH address on this wallet's network. A Dash
+     * address is never a valid sell-swap destination (the target chain is always non-Dash),
+     * but several target chains validate with permissive lexical patterns that a Dash
+     * address also satisfies — e.g. Solana's 32-44 char Base58 range — letting the mistake
+     * through to a conversion that can only fail (MO-969). Checked as an explicit reject at
+     * the continue gate so it covers every asset's parser at once.
+     */
+    fun isDashAddress(input: String): Boolean = dashAddressParser.exactMatch(input.trim())
 
     // Source of truth for the inline validation error and the address it was shown for:
     // the Compose UIState lives in the fragment and is recreated with the view, so they

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/MayaConversionPreviewViewModel.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/MayaConversionPreviewViewModel.kt
@@ -143,13 +143,26 @@ class MayaConversionPreviewViewModel @Inject constructor(
                 if (result.value == SwapTradeResponse.EMPTY_SWAP_TRADE) {
                     commitSwapTradeFailureState.call()
                 } else {
+                    // commitSwapTransaction refreshes the route before broadcasting, and on
+                    // SwapKit/NEAR Intents routes the refreshed quote carries a NEW one-time
+                    // deposit address — the one the tx actually paid. Persist the returned
+                    // (committed) model, not the pre-refresh preview quote, or tracking and
+                    // the explorer link point at an intent that never receives funds (MO-983).
+                    val committedTrade = result.value
+                    if (committedTrade.vaultAddress != swapTradeUIModel.vaultAddress) {
+                        log.info(
+                            "deposit address changed on route refresh: {} -> {}",
+                            swapTradeUIModel.vaultAddress,
+                            committedTrade.vaultAddress
+                        )
+                    }
                     commitSwapTradeSuccessState.value = SendTransactionToWalletParams(
-                        swapTradeUIModel.amount,
-                        swapTradeUIModel.feeAmount,
-                        swapTradeUIModel.destinationAddress,
+                        committedTrade.amount,
+                        committedTrade.feeAmount,
+                        committedTrade.destinationAddress,
                         MayaConstants.TRANSACTION_TYPE_SEND,
                         txid = txId.takeIf { it != Sha256Hash.ZERO_HASH }?.toString(),
-                        depositAddress = swapTradeUIModel.vaultAddress
+                        depositAddress = committedTrade.vaultAddress
                     )
                     val service = when (dispatchingSwapProvider.currentBackend()) {
                         SwapBackend.SWAPKIT -> ServiceName.Swapkit
@@ -160,12 +173,12 @@ class MayaConversionPreviewViewModel @Inject constructor(
                             SwapOrder(
                                 txId = txId,
                                 service = service,
-                                provider = swapTradeUIModel.routeName?.takeIf { it.isNotEmpty() },
-                                fromAsset = swapTradeUIModel.inputCurrency,
-                                toAsset = swapTradeUIModel.outputCurrency,
-                                toAddress = swapTradeUIModel.destinationAddress,
-                                depositAddress = swapTradeUIModel.vaultAddress.takeIf { it.isNotEmpty() },
-                                expectedToAmount = swapTradeUIModel.expectedOutputAmount
+                                provider = committedTrade.routeName?.takeIf { it.isNotEmpty() },
+                                fromAsset = committedTrade.inputCurrency,
+                                toAsset = committedTrade.outputCurrency,
+                                toAddress = committedTrade.destinationAddress,
+                                depositAddress = committedTrade.vaultAddress.takeIf { it.isNotEmpty() },
+                                expectedToAmount = committedTrade.expectedOutputAmount
                                     .takeIf { it.signum() > 0 }?.toPlainString(),
                                 timestamp = System.currentTimeMillis()
                             )
@@ -174,7 +187,7 @@ class MayaConversionPreviewViewModel @Inject constructor(
                     }
                     // TODO add more information about the transaction to metadata.  it is a trade
                     transactionMetadataProvider.markAddressAsync(
-                        swapTradeUIModel.vaultAddress,
+                        committedTrade.vaultAddress,
                         false,
                         TaxCategory.Expense, // TODO: this should be a Trade
                         service

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/MayaConvertCryptoFragment.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/MayaConvertCryptoFragment.kt
@@ -79,11 +79,6 @@ class MayaConvertCryptoFragment : Fragment() {
 
     private var selectedCoinBaseAccount: AccountDataUIModel? = null
 
-    // The graph-scoped ViewModel captured while the nav_maya graph is guaranteed on the back
-    // stack — onDestroy also runs when the whole flow is popped to Home (after a completed
-    // swap), where resolving the navGraphViewModels lazy for the first time throws.
-    private var resolvedConvertViewModel: ConvertViewViewModel? = null
-
     private var uiState by mutableStateOf(MayaConvertCryptoUIState())
 
     private val decimalSeparator =
@@ -111,7 +106,6 @@ class MayaConvertCryptoFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        resolvedConvertViewModel = convertViewModel
         setupState()
         setupObservers()
 
@@ -721,8 +715,9 @@ class MayaConvertCryptoFragment : Fragment() {
 
     override fun onDestroy() {
         super.onDestroy()
-        // Use the instance captured in onCreateView rather than the lazy: re-resolving it
-        // here crashes once the whole flow was popped to Home.
-        resolvedConvertViewModel?.clear()
+        // Resolving the navGraphViewModels lazy throws once the whole flow was popped to
+        // Home (after a completed swap) — the graph scope is gone and its ViewModel state
+        // with it, so there is nothing left to clear.
+        runCatching { convertViewModel }.getOrNull()?.clear()
     }
 }

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/MayaConvertCryptoFragment.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/MayaConvertCryptoFragment.kt
@@ -79,6 +79,11 @@ class MayaConvertCryptoFragment : Fragment() {
 
     private var selectedCoinBaseAccount: AccountDataUIModel? = null
 
+    // The graph-scoped ViewModel captured while the nav_maya graph is guaranteed on the back
+    // stack — onDestroy also runs when the whole flow is popped to Home (after a completed
+    // swap), where resolving the navGraphViewModels lazy for the first time throws.
+    private var resolvedConvertViewModel: ConvertViewViewModel? = null
+
     private var uiState by mutableStateOf(MayaConvertCryptoUIState())
 
     private val decimalSeparator =
@@ -106,6 +111,7 @@ class MayaConvertCryptoFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
+        resolvedConvertViewModel = convertViewModel
         setupState()
         setupObservers()
 
@@ -715,6 +721,8 @@ class MayaConvertCryptoFragment : Fragment() {
 
     override fun onDestroy() {
         super.onDestroy()
-        convertViewModel.clear()
+        // Use the instance captured in onCreateView rather than the lazy: re-resolving it
+        // here crashes once the whole flow was popped to Home.
+        resolvedConvertViewModel?.clear()
     }
 }

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/MayaConvertCryptoFragment.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/MayaConvertCryptoFragment.kt
@@ -715,9 +715,14 @@ class MayaConvertCryptoFragment : Fragment() {
 
     override fun onDestroy() {
         super.onDestroy()
-        // Resolving the navGraphViewModels lazy throws once the whole flow was popped to
-        // Home (after a completed swap) — the graph scope is gone and its ViewModel state
-        // with it, so there is nothing left to clear.
-        runCatching { convertViewModel }.getOrNull()?.clear()
+        // Clear the entered amounts only when this screen is popped off the back stack:
+        // isRemoving is false on a configuration change, where clear() would wipe the
+        // saved-state amount the recreated fragment is about to restore. Resolving the
+        // navGraphViewModels lazy throws once the whole flow was popped to Home — the
+        // graph scope is gone and its ViewModel state with it, so there is nothing left
+        // to clear.
+        if (isRemoving) {
+            runCatching { convertViewModel }.getOrNull()?.clear()
+        }
     }
 }

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/MayaCryptoCurrencyPickerFragment.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/MayaCryptoCurrencyPickerFragment.kt
@@ -42,11 +42,18 @@ class MayaCryptoCurrencyPickerFragment : Fragment() {
 
     private val viewModel by mayaViewModels<MayaViewModel>()
 
+    // The graph-scoped ViewModel captured while the nav_maya graph is guaranteed on the back
+    // stack. onDestroy also runs when the whole flow is popped to Home (after a completed
+    // swap), where resolving the navGraphViewModels lazy for the first time throws — which a
+    // restored back-stack instance whose view was never recreated would otherwise do.
+    private var resolvedViewModel: MayaViewModel? = null
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
+        resolvedViewModel = viewModel
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
@@ -69,9 +76,10 @@ class MayaCryptoCurrencyPickerFragment : Fragment() {
         // when the picker is popped off the back stack (returning to the portal):
         // isRemoving is false on a configuration change and while the fragment sits on
         // the back stack after navigating forward, so the query survives rotation and a
-        // forward-then-back trip.
+        // forward-then-back trip. Use the instance captured in onCreateView rather than
+        // the lazy: re-resolving it here crashes once the whole flow was popped to Home.
         if (isRemoving) {
-            viewModel.onSearchQuery("")
+            resolvedViewModel?.onSearchQuery("")
         }
     }
 

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/MayaCryptoCurrencyPickerFragment.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/MayaCryptoCurrencyPickerFragment.kt
@@ -42,18 +42,11 @@ class MayaCryptoCurrencyPickerFragment : Fragment() {
 
     private val viewModel by mayaViewModels<MayaViewModel>()
 
-    // The graph-scoped ViewModel captured while the nav_maya graph is guaranteed on the back
-    // stack. onDestroy also runs when the whole flow is popped to Home (after a completed
-    // swap), where resolving the navGraphViewModels lazy for the first time throws — which a
-    // restored back-stack instance whose view was never recreated would otherwise do.
-    private var resolvedViewModel: MayaViewModel? = null
-
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        resolvedViewModel = viewModel
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
@@ -76,10 +69,11 @@ class MayaCryptoCurrencyPickerFragment : Fragment() {
         // when the picker is popped off the back stack (returning to the portal):
         // isRemoving is false on a configuration change and while the fragment sits on
         // the back stack after navigating forward, so the query survives rotation and a
-        // forward-then-back trip. Use the instance captured in onCreateView rather than
-        // the lazy: re-resolving it here crashes once the whole flow was popped to Home.
+        // forward-then-back trip. Resolving the navGraphViewModels lazy throws once the
+        // whole flow was popped to Home — the graph scope is gone and its state with it,
+        // so there is nothing left to clear.
         if (isRemoving) {
-            resolvedViewModel?.onSearchQuery("")
+            runCatching { viewModel }.getOrNull()?.onSearchQuery("")
         }
     }
 

--- a/integrations/maya/src/main/res/values/strings-maya.xml
+++ b/integrations/maya/src/main/res/values/strings-maya.xml
@@ -369,7 +369,7 @@
     <string name="maya_halted_label">Halted</string>
     <string name="maya_halted_coins_toast">Some coins are temporarily halted and unavailable for trading</string>
     <string name="maya_select_coin_title">Select coin</string>
-    <string name="dex_enter_amount_title">Convert Dash to %s</string>
+    <string name="dex_enter_amount_title">Convert %s to Dash</string>
     <string name="dex_enter_amount_checking">Checking amount…</string>
     <string name="dex_enter_amount_invalid">This amount can\'t be swapped right now. Try a different amount, or try again shortly.</string>
     <string name="maya_route_label_maya" translatable="false">Maya</string>

--- a/integrations/maya/src/test/java/org/dash/wallet/integrations/maya/payments/parsers/AddressParserTest.kt
+++ b/integrations/maya/src/test/java/org/dash/wallet/integrations/maya/payments/parsers/AddressParserTest.kt
@@ -346,4 +346,31 @@ class AddressParserTest {
             ).size
         )
     }
+
+    @Test
+    fun normalizeCaseTest() {
+        // Only case-insensitive (bech32) forms are canonicalized to lowercase. Case-sensitive
+        // Base58 forms must never be rewritten: where they are validated by pattern only, an
+        // all-caps corrupt address could otherwise be "repaired" into a different, plausible-
+        // looking address instead of being rejected.
+        val zcashParser = ZcashAddressParser()
+        val sapling = "zs1qpzry9x8gf2tvdw0s3jn54khce6mua7lqpzry9x8gf2tvdw0s3jn54khce6mua7lqpzry9x8gf2"
+        assertEquals(sapling, zcashParser.normalizeCase(sapling.uppercase()))
+        assertEquals(sapling, zcashParser.normalizeCase(sapling))
+        val uppercasedTransparent = "t1K79TgQbqu74d6rBmsMu2oFEXEwAmdYiT7".uppercase()
+        assertEquals(uppercasedTransparent, zcashParser.normalizeCase(uppercasedTransparent))
+
+        val cardanoParser = CardanoAddressParser()
+        val shelley = "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer" +
+            "3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x"
+        assertEquals(shelley, cardanoParser.normalizeCase(shelley.uppercase()))
+        val uppercasedByron = "Ae2tdPwUPEZ4YjgvykNpoFeYUxoyhNj2kg8KfKWN2FizsSpLUPv68MpTVDo".uppercase()
+        assertEquals(uppercasedByron, cardanoParser.normalizeCase(uppercasedByron))
+
+        // Solana is Base58 with a length-only payload check — an all-caps string whose
+        // lowercase form happens to decode to a 32-byte key must not be rewritten.
+        val solanaParser = SolanaAddressParser()
+        val uppercasedSolana = "DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK".uppercase()
+        assertEquals(uppercasedSolana, solanaParser.normalizeCase(uppercasedSolana))
+    }
 }

--- a/integrations/maya/src/test/java/org/dash/wallet/integrations/maya/payments/parsers/AddressParserTest.kt
+++ b/integrations/maya/src/test/java/org/dash/wallet/integrations/maya/payments/parsers/AddressParserTest.kt
@@ -203,6 +203,14 @@ class AddressParserTest {
         assertFalse(parser.exactMatch("0OIl000000000000000000000000000000"))
         assertFalse(parser.exactMatch(""))
 
+        // Base58 strings inside the length range that are NOT 32-byte ed25519 keys: a Dash
+        // P2PKH address (25-byte Base58Check payload) passed the old lexical check and only
+        // failed at conversion time (MO-969).
+        assertFalse(parser.exactMatch("Xh93hJroCBPn77rPGmi73p3uwfYvY96AqG"))
+        assertFalse(parser.exactMatch("XiqnCEVFCxHDkiivDNFt47mLthdnPCavDe"))
+        // A Bitcoin P2PKH address — same 25-byte Base58Check shape.
+        assertFalse(parser.exactMatch("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"))
+
         assertEquals(
             2,
             parser.findAll(

--- a/integrations/maya/src/test/java/org/dash/wallet/integrations/maya/payments/parsers/AddressParserTest.kt
+++ b/integrations/maya/src/test/java/org/dash/wallet/integrations/maya/payments/parsers/AddressParserTest.kt
@@ -109,6 +109,26 @@ class AddressParserTest {
         )
         assertTrue(parser.exactMatch("Ae2tdPwUPEZ4YjgvykNpoFeYUxoyhNj2kg8KfKWN2FizsSpLUPv68MpTVDo"))
 
+        // All-uppercase Shelley bech32 is valid per BIP-173 (QR alphanumeric mode); mixed case
+        // is not. Byron Base58 stays case-sensitive, so its uppercased form is rejected.
+        assertTrue(
+            parser.exactMatch(
+                (
+                    "addr1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer" +
+                        "3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x"
+                    ).uppercase()
+            )
+        )
+        assertFalse(
+            parser.exactMatch(
+                "ADDR1qx2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer" +
+                    "3n0d3vllmyqwsx5wktcd8cc3sq835lu7drv2xwl2wywfgse35a3x"
+            )
+        )
+        assertFalse(
+            parser.exactMatch("Ae2tdPwUPEZ4YjgvykNpoFeYUxoyhNj2kg8KfKWN2FizsSpLUPv68MpTVDo".uppercase())
+        )
+
         // Shape-valid Shelley string with an invalid bech32 checksum (the fabricated address
         // this codebase previously used as the ADA example).
         assertFalse(
@@ -294,6 +314,13 @@ class AddressParserTest {
         val unified = "u1qpzry9x8gf2tvdw0s3jn54khce6mua7lqpzry9x8gf2tvdw0s3jn54khce6mua7lqpzry9x8gf2tvdw0s3jn54kh"
         assertTrue(parser.exactMatch(sapling))
         assertTrue(parser.exactMatch(unified))
+
+        // All-uppercase bech32 forms are valid per BIP-173; mixed case is not. Transparent
+        // addresses are Base58 (case-sensitive), so the uppercased form is rejected.
+        assertTrue(parser.exactMatch(sapling.uppercase()))
+        assertTrue(parser.exactMatch(unified.uppercase()))
+        assertFalse(parser.exactMatch("zs1" + sapling.uppercase().substring(3)))
+        assertFalse(parser.exactMatch("t1K79TgQbqu74d6rBmsMu2oFEXEwAmdYiT7".uppercase()))
 
         // 't2' is not a valid transparent prefix (only t1 / t3).
         assertFalse(parser.exactMatch("t2K79TgQbqu74d6rBmsMu2oFEXEwAmdYiT7"))

--- a/integrations/maya/src/test/java/org/dash/wallet/integrations/maya/payments/parsers/Bech32PaymentIntentParserTest.kt
+++ b/integrations/maya/src/test/java/org/dash/wallet/integrations/maya/payments/parsers/Bech32PaymentIntentParserTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.dash.wallet.integrations.maya.payments.parsers
+
+import kotlinx.coroutines.runBlocking
+import org.dash.wallet.common.data.PaymentIntent
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class Bech32PaymentIntentParserTest {
+    private val parser = RunePaymentIntentProcessor() // RUNE / thor: / THOR.RUNE
+    private val address = "thor166n4w5039meulfa3p6ydg60ve6ueac7tlt0jws"
+
+    /** The swap memo carried in the intent's OP_RETURN output: `=:ASSET:destinationAddress`. */
+    private fun memoOf(intent: PaymentIntent): String {
+        val chunks = intent.outputs!![0].script.chunks
+        return String(chunks[1].data!!)
+    }
+
+    @Test
+    fun bareAddress_buildsMemo() = runBlocking {
+        assertEquals("=:THOR.RUNE:$address", memoOf(parser.parse(address)))
+    }
+
+    @Test
+    fun uriInput_stripsSchemeIncludingColon() = runBlocking {
+        assertEquals("=:THOR.RUNE:$address", memoOf(parser.parse("thor:$address")))
+        assertEquals("=:THOR.RUNE:$address", memoOf(parser.parse("THOR:$address")))
+        assertEquals("=:THOR.RUNE:$address", memoOf(parser.parse("RUNE:$address")))
+    }
+
+    @Test
+    fun uppercaseAddress_normalizedToCanonicalLowercase() = runBlocking {
+        assertEquals("=:THOR.RUNE:$address", memoOf(parser.parse(address.uppercase())))
+        assertEquals("=:THOR.RUNE:$address", memoOf(parser.parse("THOR:${address.uppercase()}")))
+    }
+}

--- a/integrations/maya/src/test/java/org/dash/wallet/integrations/maya/payments/parsers/CardanoPaymentIntentParserTest.kt
+++ b/integrations/maya/src/test/java/org/dash/wallet/integrations/maya/payments/parsers/CardanoPaymentIntentParserTest.kt
@@ -24,9 +24,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Test
 
-class Bech32PaymentIntentParserTest {
-    private val parser = RunePaymentIntentProcessor() // RUNE / thor: / THOR.RUNE
-    private val address = "thor166n4w5039meulfa3p6ydg60ve6ueac7tlt0jws"
+class CardanoPaymentIntentParserTest {
+    private val parser = CardanoPaymentIntentParser()
+    private val byron = "Ae2tdPwUPEZ4YjgvykNpoFeYUxoyhNj2kg8KfKWN2FizsSpLUPv68MpTVDo"
 
     /** The swap memo carried in the intent's OP_RETURN output: `=:ASSET:destinationAddress`. */
     private fun memoOf(intent: PaymentIntent): String {
@@ -35,35 +35,20 @@ class Bech32PaymentIntentParserTest {
     }
 
     @Test
-    fun bareAddress_buildsMemo() = runBlocking {
-        assertEquals("=:THOR.RUNE:$address", memoOf(parser.parse(address)))
-    }
-
-    @Test
-    fun uriInput_stripsSchemeIncludingColon() = runBlocking {
-        assertEquals("=:THOR.RUNE:$address", memoOf(parser.parse("thor:$address")))
-        assertEquals("=:THOR.RUNE:$address", memoOf(parser.parse("THOR:$address")))
-        assertEquals("=:THOR.RUNE:$address", memoOf(parser.parse("RUNE:$address")))
-    }
-
-    @Test
-    fun uppercaseAddress_normalizedToCanonicalLowercase() = runBlocking {
-        assertEquals("=:THOR.RUNE:$address", memoOf(parser.parse(address.uppercase())))
-        assertEquals("=:THOR.RUNE:$address", memoOf(parser.parse("THOR:${address.uppercase()}")))
+    fun uriInput_preservesByronCase() = runBlocking {
+        assertEquals("=:ADA.ADA:$byron", memoOf(parser.parse("cardano:$byron")))
+        assertEquals("=:ADA.ADA:$byron", memoOf(parser.parse("CARDANO:$byron")))
     }
 
     @Test
     fun uriWithInvalidPayload_rejected() {
         // A valid scheme prefix must not bypass address validation.
         assertThrows(PaymentIntentParserException::class.java) {
-            runBlocking { parser.parse("thor:notAnAddress") }
+            runBlocking { parser.parse("cardano:notAnAddress") }
         }
+        // An uppercased Byron address is corrupt Base58 — rejected, not "repaired".
         assertThrows(PaymentIntentParserException::class.java) {
-            runBlocking { parser.parse("RUNE:$address-junk") }
-        }
-        // Mixed case is invalid per BIP-173 even after a valid prefix.
-        assertThrows(PaymentIntentParserException::class.java) {
-            runBlocking { parser.parse("thor:thor166N4W5039MEULFA3P6YDG60VE6UEAC7TLT0JWS") }
+            runBlocking { parser.parse("cardano:${byron.uppercase()}") }
         }
     }
 }

--- a/integrations/maya/src/test/java/org/dash/wallet/integrations/maya/payments/parsers/XrdPaymentIntentParserTest.kt
+++ b/integrations/maya/src/test/java/org/dash/wallet/integrations/maya/payments/parsers/XrdPaymentIntentParserTest.kt
@@ -24,9 +24,12 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Test
 
-class Bech32PaymentIntentParserTest {
-    private val parser = RunePaymentIntentProcessor() // RUNE / thor: / THOR.RUNE
-    private val address = "thor166n4w5039meulfa3p6ydg60ve6ueac7tlt0jws"
+class XrdPaymentIntentParserTest {
+    private val parser = XrdPaymentIntentParser()
+
+    // Pattern-valid fixture (the XRD parser has no checksum validation): account_rdx1 + 54
+    // bech32-alphabet chars, within the parser's 50-65 range.
+    private val address = "account_rdx1qpzry9x8gf2tvdw0s3jn54khce6mua7lqpzry9x8gf2tvdw0s3jn54"
 
     /** The swap memo carried in the intent's OP_RETURN output: `=:ASSET:destinationAddress`. */
     private fun memoOf(intent: PaymentIntent): String {
@@ -35,35 +38,20 @@ class Bech32PaymentIntentParserTest {
     }
 
     @Test
-    fun bareAddress_buildsMemo() = runBlocking {
-        assertEquals("=:THOR.RUNE:$address", memoOf(parser.parse(address)))
-    }
-
-    @Test
-    fun uriInput_stripsSchemeIncludingColon() = runBlocking {
-        assertEquals("=:THOR.RUNE:$address", memoOf(parser.parse("thor:$address")))
-        assertEquals("=:THOR.RUNE:$address", memoOf(parser.parse("THOR:$address")))
-        assertEquals("=:THOR.RUNE:$address", memoOf(parser.parse("RUNE:$address")))
-    }
-
-    @Test
-    fun uppercaseAddress_normalizedToCanonicalLowercase() = runBlocking {
-        assertEquals("=:THOR.RUNE:$address", memoOf(parser.parse(address.uppercase())))
-        assertEquals("=:THOR.RUNE:$address", memoOf(parser.parse("THOR:${address.uppercase()}")))
+    fun uriInput_normalizedToCanonicalLowercase() = runBlocking {
+        assertEquals("=:x:$address", memoOf(parser.parse("radix:$address")))
+        assertEquals("=:x:$address", memoOf(parser.parse("RADIX:${address.uppercase()}")))
     }
 
     @Test
     fun uriWithInvalidPayload_rejected() {
         // A valid scheme prefix must not bypass address validation.
         assertThrows(PaymentIntentParserException::class.java) {
-            runBlocking { parser.parse("thor:notAnAddress") }
-        }
-        assertThrows(PaymentIntentParserException::class.java) {
-            runBlocking { parser.parse("RUNE:$address-junk") }
+            runBlocking { parser.parse("radix:notAnAddress") }
         }
         // Mixed case is invalid per BIP-173 even after a valid prefix.
         assertThrows(PaymentIntentParserException::class.java) {
-            runBlocking { parser.parse("thor:thor166N4W5039MEULFA3P6YDG60VE6UEAC7TLT0JWS") }
+            runBlocking { parser.parse("radix:account_rdx1QPZRY9x8gf2tvdw0s3jn54khce6mua7lqpzry9x8gf2tvdw0s3jn54") }
         }
     }
 }

--- a/integrations/maya/src/test/java/org/dash/wallet/integrations/maya/payments/parsers/ZcashPaymentIntentParserTest.kt
+++ b/integrations/maya/src/test/java/org/dash/wallet/integrations/maya/payments/parsers/ZcashPaymentIntentParserTest.kt
@@ -24,9 +24,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Test
 
-class Bech32PaymentIntentParserTest {
-    private val parser = RunePaymentIntentProcessor() // RUNE / thor: / THOR.RUNE
-    private val address = "thor166n4w5039meulfa3p6ydg60ve6ueac7tlt0jws"
+class ZcashPaymentIntentParserTest {
+    private val parser = ZcashPaymentIntentParser()
+    private val transparent = "t1K79TgQbqu74d6rBmsMu2oFEXEwAmdYiT7"
 
     /** The swap memo carried in the intent's OP_RETURN output: `=:ASSET:destinationAddress`. */
     private fun memoOf(intent: PaymentIntent): String {
@@ -35,35 +35,21 @@ class Bech32PaymentIntentParserTest {
     }
 
     @Test
-    fun bareAddress_buildsMemo() = runBlocking {
-        assertEquals("=:THOR.RUNE:$address", memoOf(parser.parse(address)))
-    }
-
-    @Test
-    fun uriInput_stripsSchemeIncludingColon() = runBlocking {
-        assertEquals("=:THOR.RUNE:$address", memoOf(parser.parse("thor:$address")))
-        assertEquals("=:THOR.RUNE:$address", memoOf(parser.parse("THOR:$address")))
-        assertEquals("=:THOR.RUNE:$address", memoOf(parser.parse("RUNE:$address")))
-    }
-
-    @Test
-    fun uppercaseAddress_normalizedToCanonicalLowercase() = runBlocking {
-        assertEquals("=:THOR.RUNE:$address", memoOf(parser.parse(address.uppercase())))
-        assertEquals("=:THOR.RUNE:$address", memoOf(parser.parse("THOR:${address.uppercase()}")))
+    fun uriInput_preservesTransparentCase() = runBlocking {
+        assertEquals("=:z:$transparent", memoOf(parser.parse("zcash:$transparent")))
+        assertEquals("=:z:$transparent", memoOf(parser.parse("ZCASH:$transparent")))
     }
 
     @Test
     fun uriWithInvalidPayload_rejected() {
         // A valid scheme prefix must not bypass address validation.
         assertThrows(PaymentIntentParserException::class.java) {
-            runBlocking { parser.parse("thor:notAnAddress") }
+            runBlocking { parser.parse("zcash:notAnAddress") }
         }
+        // An uppercased t-address is corrupt Base58 — rejected, not lowercased into a
+        // different address.
         assertThrows(PaymentIntentParserException::class.java) {
-            runBlocking { parser.parse("RUNE:$address-junk") }
-        }
-        // Mixed case is invalid per BIP-173 even after a valid prefix.
-        assertThrows(PaymentIntentParserException::class.java) {
-            runBlocking { parser.parse("thor:thor166N4W5039MEULFA3P6YDG60VE6UEAC7TLT0JWS") }
+            runBlocking { parser.parse("zcash:${transparent.uppercase()}") }
         }
     }
 }


### PR DESCRIPTION
## Summary

A batch of Dash DEX (SwapKit / NEAR Intents) sell-swap fixes, driven by a field report of a DASH → SOL swap whose funds went to a "different address than intended" ([MO-983](https://dashpay.atlassian.net/browse/MO-983)). Investigating that report surfaced two more defects ([MO-984](https://dashpay.atlassian.net/browse/MO-984), [MO-969](https://dashpay.atlassian.net/browse/MO-969)).

### MO-983 — persist the committed swap route, not the stale preview quote
`commitSwapTransaction` refreshes the SwapKit route before broadcasting (routeIds expire after 60s); on NEAR Intents routes the refreshed quote creates a **new** intent with a fresh one-time deposit address, which the transaction pays. The stored `SwapOrder`, the success-screen params and the marked address were still built from the pre-refresh preview model, so swap tracking and the in-app NEAR Intents explorer link followed the abandoned first intent — stuck on "Pending Deposit" forever even when the swap settled. `commitSwapTrade` now persists the model returned by the commit, and logs when the deposit address changed across the refresh.

### MO-984 — max sells always refunded on NEAR Intents routes
A max ("empty wallet") sell sweeps the balance and the miner fee comes out of the sweep's single output, so the deposit delivers `balance − fee` — but the quote was requested for the full balance, and NEAR Intents refuses any deposit below the quoted amount, auto-refunding ~1h later minus a 0.001 DASH fee. Every max sell on a NEAR route was doomed. `getSwapInfo` now quotes the post-fee sweep output (via `estimateNetworkFee(emptyWallet = true)`, derived from the current balance so preview and the pre-broadcast refresh stay idempotent), and `buildAndSendDepositTx` gains a pre-broadcast guard that aborts with a recoverable error if the balance dropped below the quoted amount. Maya vault routes execute on whatever arrives and are unchanged.

### MO-969 — Dash address accepted as sell destination → "Conversion failed"
Several target chains validate destinations with permissive lexical patterns that a Dash address also satisfies — Solana accepted any 32–44 char Base58 string, and a Dash address is 34 Base58 chars. Three layers: `SolanaAddressParser` now requires the Base58 payload to decode to a raw 32-byte ed25519 key (rejecting 25-byte Base58Check addresses in `exactMatch` and `findAll`, including the clipboard row); `SolanaPaymentIntentParser` validates the address in its URI-prefixed branch, which previously bypassed validation entirely; and the address-input continue gate explicitly rejects any checksum-valid DASH address as a sell destination, covering every target chain's parser at once.

Also included: buy enter-amount title direction fix, all-caps bech32 scan handling and lowercase display, and the URI-prefix memo colon fix.

## Test plan
- `:integrations:maya` unit tests pass; `AddressParserTest` extended with the field-report Dash addresses and a Bitcoin address as Solana-rejection regression cases
- Manual (recommended before release): small max sell DASH → SOL on a NEAR route — preview should show balance-minus-fee, the intent should complete rather than refund, and the tx details explorer link should open the funded intent
- Field-report forensics for MO-983/984 (tx `a050e551…`, refund `63857302…`) documented in the Jira tickets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consistent canonical address casing across scan, paste, and URI inputs (including uppercase Bech32 QR normalization where allowed).
  * Stricter chain-specific case rules and improved Bech32 mixed-case rejection.
* **Bug Fixes**
  * Fixed delimiter/colon handling in multiple URI address parsers so extracted addresses exclude the separator.
  * Improved address input normalization and corrected Dash address rejection in the continue flow.
  * Swap preview/commit consistency improved, with additional safety checks for maximum trades.
  * Corrected DEX conversion wording (“Convert %s to Dash”).
* **Tests**
  * Expanded address/parser and payment-intent test coverage for casing, prefixes, memo generation, and invalid payload rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->