### PR TITLE
fix(dash-dex): show the amount-too-low hint when a provider reports sellAssetAmountTooSmall

### DIFF
--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/swapkit/SwapKitApiAggregator.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/swapkit/SwapKitApiAggregator.kt
@@ -690,7 +690,9 @@ class SwapKitApiAggregator @Inject constructor(
         }
         val route = quote.routes.bestRoute()
             ?: return ResponseResource.Failure(
-                MayaException(quote.providerErrors?.firstOrNull()?.message ?: "no swapkit route"),
+                MayaException(
+                    SwapKitErrors.providerErrorMessage(quote.providerErrors?.firstOrNull()) ?: "no swapkit route"
+                ),
                 false,
                 0,
                 null
@@ -889,7 +891,9 @@ class SwapKitApiAggregator @Inject constructor(
         }
         val route = quote.routes.bestRoute()
             ?: return ResponseResource.Failure(
-                MayaException(quote.providerErrors?.firstOrNull()?.message ?: "no swapkit route"),
+                MayaException(
+                    SwapKitErrors.providerErrorMessage(quote.providerErrors?.firstOrNull()) ?: "no swapkit route"
+                ),
                 false,
                 0,
                 null
@@ -1186,9 +1190,9 @@ class SwapKitApiAggregator @Inject constructor(
     @StringRes
     override fun errorMessageRes(error: String?): Int = SwapKitErrors.messageResFor(error)
 
-    // SwapKit reports a below-minimum sell amount as `noRoutesFound` (no provider can fill it).
-    override fun isAmountTooLowError(error: String?): Boolean =
-        error?.substringBefore(':')?.trim() == "noRoutesFound"
+    // Below-minimum sell amounts arrive either as a top-level `noRoutesFound` or as a provider's
+    // `sellAssetAmountTooSmall`; SwapKitErrors owns that vocabulary.
+    override fun isAmountTooLowError(error: String?): Boolean = SwapKitErrors.isAmountTooLow(error)
 
     override fun applyPoolPrices(pools: List<PoolInfo>, usdToFiat: Fiat) {
         // usdToFiat is the wallet's "1 USD in SELECTED_CURRENCY" rate. Unlike Maya

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/swapkit/SwapKitErrors.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/swapkit/SwapKitErrors.kt
@@ -19,6 +19,7 @@ package org.dash.wallet.integrations.maya.swapkit
 
 import androidx.annotation.StringRes
 import org.dash.wallet.integrations.maya.R
+import org.dash.wallet.integrations.maya.swapkit.model.SwapKitProviderError
 
 /**
  * Maps a raw SwapKit error into a user-facing, localized message resource.
@@ -38,6 +39,15 @@ import org.dash.wallet.integrations.maya.R
  */
 object SwapKitErrors {
     /**
+     * Codes meaning "the sell amount is below what this swap can fill", which the UI surfaces as
+     * an inline hint (raise the amount and retry) rather than a blocking modal.
+     *
+     * `noRoutesFound` is the top-level form; `sellAssetAmountTooSmall` is what providers report
+     * per-provider in `providerErrors[]` when the amount is under their minimum.
+     */
+    private val AMOUNT_TOO_LOW_CODES = setOf("noRoutesFound", "sellAssetAmountTooSmall")
+
+    /**
      * Friendly message resource for [rawError] — the message carried by the failed swap's
      * exception. The leading token (before an optional `": <detail>"`) is treated as the SwapKit
      * error code; unrecognised or null values fall back to [R.string.dex_error_generic].
@@ -49,12 +59,10 @@ object SwapKitErrors {
      */
     @StringRes
     fun messageResFor(rawError: String?): Int {
-        // Match on the code prefix so both a bare "validation_error" and a
-        // "validation_error: <detail>" map to the same friendly message.
-        val code = rawError?.substringBefore(':')?.trim().orEmpty()
-        return when (code) {
+        return when (codeOf(rawError)) {
             // /v3/quote
             "noRoutesFound" -> R.string.dex_error_no_route
+            "sellAssetAmountTooSmall" -> R.string.dex_error_amount_too_small
             "blackListAsset" -> R.string.dex_error_blacklisted
             "invalidRequest", "validation_error" -> R.string.dex_error_validation
             "apiKeyInvalid", "unauthorized" -> R.string.dex_error_unavailable
@@ -70,4 +78,30 @@ object SwapKitErrors {
             else -> R.string.dex_error_generic
         }
     }
+
+    /** True when [rawError] means the sell amount is under the minimum this swap can fill. */
+    fun isAmountTooLow(rawError: String?): Boolean = codeOf(rawError) in AMOUNT_TOO_LOW_CODES
+
+    /**
+     * The failure of a quote that came back with no routes, rendered in the same
+     * `"<code>: <detail>"` shape the top-level `error` field uses. A provider reports its code in
+     * [SwapKitProviderError.errorCode] and prose in `message`; only the code is a stable
+     * identifier, so it must lead — matching on the prose would silently fall through to the
+     * generic message (the `sellAssetAmountTooSmall` case, where the user needs to be told to
+     * raise the amount). Null when there is no provider error to report.
+     */
+    fun providerErrorMessage(error: SwapKitProviderError?): String? {
+        val code = error?.errorCode?.trim()?.takeIf { it.isNotEmpty() }
+        val detail = error?.message?.trim()?.takeIf { it.isNotEmpty() }
+        return when {
+            code != null && detail != null -> "$code: $detail"
+            else -> code ?: detail
+        }
+    }
+
+    /**
+     * The SwapKit error code carried by [rawError]: the leading token before an optional
+     * `": <detail>"`, so both a bare `validation_error` and `validation_error: <detail>` match.
+     */
+    private fun codeOf(rawError: String?): String = rawError?.substringBefore(':')?.trim().orEmpty()
 }

--- a/integrations/maya/src/main/res/values/strings-maya.xml
+++ b/integrations/maya/src/main/res/values/strings-maya.xml
@@ -402,6 +402,7 @@
     <string name="dex_error_generic">Something went wrong setting up your swap. Please try again.</string>
     <string name="dex_error_missing_details">Swap details are missing. Please go back and enter an amount.</string>
     <string name="dex_error_no_route">This amount can\'t be swapped right now. Routes can be briefly unavailable — try again shortly, or try a different amount.</string>
+    <string name="dex_error_amount_too_small">This amount is below the minimum for this swap. Please enter a larger amount.</string>
     <string name="dex_error_blacklisted">%1$s can\'t be swapped at the moment.</string>
     <string name="dex_error_validation">We couldn\'t set up your swap. Please check the amount and address, then try again.</string>
     <string name="dex_error_unavailable">Swaps are temporarily unavailable. Please try again later.</string>

--- a/integrations/maya/src/test/java/org/dash/wallet/integrations/maya/swapkit/SwapKitErrorsTest.kt
+++ b/integrations/maya/src/test/java/org/dash/wallet/integrations/maya/swapkit/SwapKitErrorsTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.dash.wallet.integrations.maya.swapkit
+
+import org.dash.wallet.integrations.maya.R
+import org.dash.wallet.integrations.maya.swapkit.model.SwapKitProviderError
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SwapKitErrorsTest {
+
+    @Test
+    fun bareCodeAndCodeWithDetail_mapToTheSameMessage() {
+        assertEquals(R.string.dex_error_validation, SwapKitErrors.messageResFor("validation_error"))
+        assertEquals(
+            R.string.dex_error_validation,
+            SwapKitErrors.messageResFor("validation_error: sellAmount must be a string")
+        )
+    }
+
+    @Test
+    fun unknownAndNullErrors_fallBackToGeneric() {
+        assertEquals(R.string.dex_error_generic, SwapKitErrors.messageResFor(null))
+        assertEquals(R.string.dex_error_generic, SwapKitErrors.messageResFor("somethingBrandNew"))
+        // Prose with no leading code must not accidentally match a mapped code.
+        assertEquals(
+            R.string.dex_error_generic,
+            SwapKitErrors.messageResFor("Sell asset amount too small for provider MAYACHAIN.")
+        )
+    }
+
+    @Test
+    fun sellAssetAmountTooSmall_isAnAmountTooLowErrorWithItsOwnMessage() {
+        assertEquals(
+            R.string.dex_error_amount_too_small,
+            SwapKitErrors.messageResFor("sellAssetAmountTooSmall")
+        )
+        assertTrue(SwapKitErrors.isAmountTooLow("sellAssetAmountTooSmall"))
+        assertTrue(
+            SwapKitErrors.isAmountTooLow("sellAssetAmountTooSmall: Sell asset amount too small for provider MAYACHAIN.")
+        )
+    }
+
+    @Test
+    fun noRoutesFound_staysAnAmountTooLowError() {
+        assertEquals(R.string.dex_error_no_route, SwapKitErrors.messageResFor("noRoutesFound"))
+        assertTrue(SwapKitErrors.isAmountTooLow("noRoutesFound"))
+    }
+
+    @Test
+    fun otherErrors_areNotAmountTooLow() {
+        assertFalse(SwapKitErrors.isAmountTooLow(null))
+        assertFalse(SwapKitErrors.isAmountTooLow("isSanctionedAddress"))
+        // The prose alone must not be treated as too-low; only the code counts.
+        assertFalse(SwapKitErrors.isAmountTooLow("Sell asset amount too small for provider MAYACHAIN."))
+    }
+
+    /**
+     * The regression this guards: the aggregator used to pass a provider error's prose `message`,
+     * which never matches a code, so a below-minimum amount showed the generic "something went
+     * wrong" modal instead of the inline "enter a larger amount" hint.
+     */
+    @Test
+    fun providerErrorMessage_leadsWithTheCodeSoTheMappingMatches() {
+        val error = SwapKitProviderError(
+            provider = "MAYACHAIN_STREAMING",
+            errorCode = "sellAssetAmountTooSmall",
+            message = "Sell asset amount too small for provider MAYACHAIN."
+        )
+        val rendered = SwapKitErrors.providerErrorMessage(error)
+
+        assertEquals(
+            "sellAssetAmountTooSmall: Sell asset amount too small for provider MAYACHAIN.",
+            rendered
+        )
+        assertEquals(R.string.dex_error_amount_too_small, SwapKitErrors.messageResFor(rendered))
+        assertTrue(SwapKitErrors.isAmountTooLow(rendered))
+    }
+
+    @Test
+    fun providerErrorMessage_handlesPartialAndAbsentErrors() {
+        assertNull(SwapKitErrors.providerErrorMessage(null))
+        assertNull(SwapKitErrors.providerErrorMessage(SwapKitProviderError()))
+        assertEquals(
+            "noRoutesFound",
+            SwapKitErrors.providerErrorMessage(SwapKitProviderError(errorCode = "noRoutesFound"))
+        )
+        assertEquals(
+            "No route available",
+            SwapKitErrors.providerErrorMessage(SwapKitProviderError(message = "No route available"))
+        )
+    }
+}


### PR DESCRIPTION
## The bug

Selling an amount below MAYACHAIN's minimum shows a modal reading **"Something went wrong setting up your swap. Please try again."** instead of the inline *"enter a larger amount"* hint. Nothing tells the user the amount is the problem, so the natural response is to retry the same amount.

Found while testing the DEX sell flow on testnet against live SwapKit.

## Root cause

When a quote returns no routes, the reason is in `providerErrors[]`, where `errorCode` is the stable identifier and `message` is human prose. `SwapKitApiAggregator` passed the **prose** into `MayaException`:

```kotlin
MayaException(quote.providerErrors?.firstOrNull()?.message ?: "no swapkit route")
```

Both `SwapKitErrors.messageResFor` and `isAmountTooLowError` key off the *code* (via `substringBefore(':')`), so `"Sell asset amount too small for provider MAYACHAIN."` matched nothing — it fell through to `dex_error_generic`, and the too-low check returned false, forcing the modal path. `sellAssetAmountTooSmall` was also absent from the mapping table entirely.

Observed response (testnet, 0.0033 DASH → BTC.BTC):

```json
{"routes":[],"providerErrors":[{"provider":"MAYACHAIN_STREAMING",
  "errorCode":"sellAssetAmountTooSmall",
  "message":"Sell asset amount too small for provider MAYACHAIN."}]}
```

## The fix

- `SwapKitErrors.providerErrorMessage()` renders a provider error as `"<code>: <detail>"` — the same shape the top-level `error` field already uses — so the code leads and the existing mapping matches. Both routeless-quote sites (sell and buy) use it.
- `sellAssetAmountTooSmall` maps to a new `dex_error_amount_too_small` string and joins `noRoutesFound` as an amount-too-low code, so it surfaces as the inline red error rather than a modal.
- The code vocabulary now lives in `SwapKitErrors` (`codeOf` / `isAmountTooLow`) instead of the aggregator re-parsing the prefix independently.

## Tests

New `SwapKitErrorsTest` (7 cases) covers the mapping, the too-low classification, and the regression directly — including that prose alone must **not** match a code. All 80 maya unit tests pass and the module compiles.

Note the same defect exists on `feat/kotlin-sdk-phase1` (it inherited this code via the master merge in #1525); this fix should flow there through the next master merge rather than being duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved swap error handling with clearer provider error messages.
  - Correctly identifies insufficient swap amounts across supported error formats.
  - Displays a dedicated message when the entered amount is below the minimum required.
  - Preserves appropriate fallback messaging for unknown or incomplete errors.

- **Tests**
  - Added coverage for error mapping, amount validation, provider responses, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->