### PR TITLE
fix(bip70): field-test corrections that missed the #1531 merge — dead rescue + double-pay on retry

### DIFF
--- a/wallet/src/de/schildbach/wallet/payments/SendCoinsTaskRunner.kt
+++ b/wallet/src/de/schildbach/wallet/payments/SendCoinsTaskRunner.kt
@@ -331,12 +331,13 @@ class SendCoinsTaskRunner @Inject constructor(
         private val log = LoggerFactory.getLogger(SendCoinsTaskRunner::class.java)
 
         /**
-         * Poll cadence for the BIP70 IS-lock timeout rescue (~12s total)
-         * — the successor of the dashj rescue's 0/1/3/5s loop, widened
-         * because an InstantSend lock takes a moment longer to observe
-         * than raw bloom relay did.
+         * Poll cadence for the BIP70 timeout rescue (~20s total) — the
+         * successor of the dashj rescue's 0/1/3/5s loop. Mempool arrival
+         * was observed within seconds in the field test; the extra
+         * headroom covers relay/persistence jitter on a slow network.
          */
-        private val IS_LOCK_RESCUE_DELAYS_MS = listOf(1_000L, 2_000L, 3_000L, 3_000L, 3_000L)
+        private val BROADCAST_OBSERVE_DELAYS_MS =
+            listOf(1_000L, 2_000L, 3_000L, 3_000L, 3_000L, 4_000L, 4_000L)
     }
     private val paymentIntentParser = DashPaymentIntentParser(org.dash.wallet.common.payments.parsers.AddressNetwork.fromId(NETWORK_PARAMETERS.id))
 
@@ -984,11 +985,11 @@ class SendCoinsTaskRunner @Inject constructor(
             // old dashj isTransactionOnNetwork rescue, on a stronger
             // signal than bloom relay).
             if (t !is DirectPayException && t !is CancellationException &&
-                awaitServerBroadcastByInstantSendLock(payment)
+                awaitServerBroadcastObserved(payment)
             ) {
                 log.warn(
-                    "Payment POST for {} failed but the tx is IS-locked on the network — " +
-                        "the BIP70 server broadcast it; completing as paid",
+                    "Payment POST for {} failed but the engine has OBSERVED the tx on the " +
+                        "network — the BIP70 server broadcast it; completing as paid",
                     payment.txidHex, t
                 )
                 return completeAckedPayment(payment)
@@ -1005,22 +1006,36 @@ class SendCoinsTaskRunner @Inject constructor(
     }
 
     /**
-     * The bounded IS-lock watch behind the timeout rescue: poll the SDK
-     * Room row's `TransactionContext` for [payment]'s txid on the old
-     * dashj rescue's cadence (~12s total). True only once the engine has
-     * observed the tx at [de.schildbach.wallet.service.platform.sdk.TX_CONTEXT_INSTANT_SEND]
-     * or beyond — mempool-only (context 0) deliberately does NOT count,
-     * because a build-time row could exist without any broadcast.
+     * The bounded network-observation watch behind the timeout rescue:
+     * poll for an SDK store row for [payment]'s txid (~20s total). The
+     * EXISTENCE of a row is the proof — the engine only records a
+     * transaction it has observed on the network (dash-spv's mempool sync
+     * persists an unmined wallet-relevant tx at context 0 within seconds
+     * of it being relayed, then advances it to in-block). We have not
+     * broadcast at this point, so an observed tx can only have been
+     * broadcast by the BIP70 server.
+     *
+     * Field-verified on testnet (2026-08-03) rather than assumed:
+     * - built-but-never-sent payments (`a6cc9ead`, `ed08074b`) have NO
+     *   row — so row existence cannot false-positive on our own build;
+     * - a server-broadcast payment (`2c3be7d8`) HAS one;
+     * - an externally broadcast wallet-relevant tx went context 0 → 2 in
+     *   under a minute, and NEVER surfaced an InstantSend context or
+     *   `isInstantLocked` flag on the pinned engine — which is why this
+     *   keys on observation, not on IS-lock (the earlier IS-lock-only
+     *   version could never fire).
      */
-    private suspend fun awaitServerBroadcastByInstantSendLock(
+    private suspend fun awaitServerBroadcastObserved(
         payment: de.schildbach.wallet.service.platform.sdk.SdkDeferredPayment
     ): Boolean {
-        for (delayMs in IS_LOCK_RESCUE_DELAYS_MS) {
+        for (delayMs in BROADCAST_OBSERVE_DELAYS_MS) {
             delay(delayMs)
             val context = l1SendProbeService.observedTxContext(payment.txidHex)
-            if (context != null &&
-                context >= de.schildbach.wallet.service.platform.sdk.TX_CONTEXT_INSTANT_SEND
-            ) {
+            if (context != null) {
+                log.info(
+                    "BIP70 tx {} observed by the engine at context {} — on the network",
+                    payment.txidHex, context
+                )
                 return true
             }
         }

--- a/wallet/src/de/schildbach/wallet/ui/send/PaymentProtocolViewModel.kt
+++ b/wallet/src/de/schildbach/wallet/ui/send/PaymentProtocolViewModel.kt
@@ -226,12 +226,24 @@ class PaymentProtocolViewModel @Inject constructor(
                     try {
                         sendCoinsTaskRunner.sendPrebuiltDirectPayment(prebuilt, finalPaymentIntent!!)
                     } catch (ex: Exception) {
-                        // Pre-ack failures are retryable — rebuild the
-                        // preview so a retry submits a fresh reservation.
-                        // NEVER rebuild after Bip70AckedDisplayException:
-                        // the merchant holds the acked tx and a rebuilt
-                        // retry could double-pay.
-                        if (ex !is SendCoinsTaskRunner.Bip70AckedDisplayException) {
+                        // Re-arm ONLY on a definitive refusal (nack): the
+                        // server said no, nothing is on the network, and a
+                        // fresh reservation is safe.
+                        //
+                        // NEVER re-arm on an AMBIGUOUS failure (transport
+                        // error that the network-observation rescue could
+                        // not resolve): the engine cannot see the mempool
+                        // spend of the released inputs, so a rebuilt retry
+                        // may select DIFFERENT inputs and pay the merchant
+                        // twice if the server did broadcast after all.
+                        // Observed in the field test (2026-08-03): the
+                        // rebuild produced a different tx (ed08074b) for
+                        // an invoice whose original (2c3be7d8) was already
+                        // on-chain. The user must restart the payment.
+                        //
+                        // Also never re-arm after Bip70AckedDisplayException
+                        // — the merchant holds an ACKED tx.
+                        if (ex is org.dash.wallet.common.services.DirectPayException) {
                             runCatching { createBaseSendRequest(finalPaymentIntent!!) }
                         }
                         throw ex

--- a/wallet/test/de/schildbach/wallet/payments/SendCoinsTaskRunnerBIP70Test.kt
+++ b/wallet/test/de/schildbach/wallet/payments/SendCoinsTaskRunnerBIP70Test.kt
@@ -702,7 +702,7 @@ class SendCoinsTaskRunnerBIP70Test {
     }
 
     @Test
-    fun `directPay releases the reservation on transport failure when no IS-lock appears`() = runTest {
+    fun `directPay releases the reservation on transport failure when the tx is never observed`() = runTest {
         val testAddress = Address.fromString(networkParams, "yWdXnYxGbouNoo8yMvcbZmZ3Gdp6BpySxL")
         val testAmount = Coin.parseCoin("1.0")
         val paymentIntent =
@@ -725,7 +725,7 @@ class SendCoinsTaskRunnerBIP70Test {
     }
 
     @Test
-    fun `directPay completes as paid when the server broadcast the tx (IS-lock rescue)`() = runTest {
+    fun `directPay completes as paid when the engine observes the server broadcast`() = runTest {
         val testAddress = Address.fromString(networkParams, "yWdXnYxGbouNoo8yMvcbZmZ3Gdp6BpySxL")
         val testAmount = Coin.parseCoin("1.0")
         val paymentIntent =
@@ -736,9 +736,13 @@ class SendCoinsTaskRunnerBIP70Test {
         coEvery { sdkL1SendService.buildDeferredPayment(any()) } returns payment
         // The POST fails at the transport layer…
         mockWebServer.enqueue(MockResponse().setResponseCode(HttpURLConnection.HTTP_INTERNAL_ERROR))
-        // …but the engine then observes the tx IS-LOCKED on the network —
-        // the BIP70 server broadcast it despite the failed response.
-        coEvery { l1SendProbeService.observedTxContext(deferredTxidHex) } returns 1
+        // …but the engine then OBSERVES the tx on the network at mempool
+        // context — the BIP70 server broadcast it despite the failed
+        // response. Context 0 is the field-observed arrival state (the
+        // pinned engine never surfaces an InstantSend context), and a row
+        // can only exist for a tx that reached the network: our own build
+        // persists nothing.
+        coEvery { l1SendProbeService.observedTxContext(deferredTxidHex) } returns 0
         coEvery { sdkL1SendService.broadcastDeferredPayment(payment) } returns
             de.schildbach.wallet.service.platform.sdk.SdkWriteResult.Broadcast(deferredTxidHex)
         coEvery { bridgedTransactionFactory.bridge(deferredTxidHex, payment.rawTxBytes) } returns

--- a/wallet/test/de/schildbach/wallet/ui/send/PaymentProtocolViewModelRaceTest.kt
+++ b/wallet/test/de/schildbach/wallet/ui/send/PaymentProtocolViewModelRaceTest.kt
@@ -139,16 +139,18 @@ class PaymentProtocolViewModelRaceTest {
     }
 
     @Test
-    fun `retryable failure releases the guard and rebuilds the preview for a clean retry`() {
+    fun `definitive nack releases the guard and rebuilds the preview for a clean retry`() {
         val runner = mockk<SendCoinsTaskRunner>(relaxed = true)
         val payment = SdkDeferredPayment(deferredTxid, byteArrayOf(1, 2, 3), 260L, null)
         val viewModel = buildViewModel(runner)
         armDeferredPreview(viewModel, runner, payment)
 
-        // First submission fails pre-ack (retryable). The rebuild returns a
-        // fresh reservation.
+        // A definitive nack (server refused; nothing on the network) is
+        // the ONE failure that re-arms the preview — an ambiguous
+        // transport failure must not, or a retry could double-pay.
         val retryPayment = SdkDeferredPayment("cc".repeat(32), byteArrayOf(4, 5), 300L, null)
-        coEvery { runner.sendPrebuiltDirectPayment(any(), any()) } throws okio.IOException("transport down")
+        coEvery { runner.sendPrebuiltDirectPayment(any(), any()) } throws
+            org.dash.wallet.common.services.DirectPayException("Payment was not acknowledged by the server")
         coEvery { runner.buildDeferredBip70Payment(any()) } returns retryPayment
 
         viewModel.sendPayment()
@@ -168,5 +170,28 @@ class PaymentProtocolViewModelRaceTest {
             coVerify(exactly = 1) { runner.sendPrebuiltDirectPayment(retryPayment, any()) }
         }
         assertTrue(viewModel.deferredPayment == null)
+    }
+
+    @Test
+    fun `ambiguous transport failure does NOT re-arm the preview`() {
+        val runner = mockk<SendCoinsTaskRunner>(relaxed = true)
+        val payment = SdkDeferredPayment(deferredTxid, byteArrayOf(1, 2, 3), 260L, null)
+        val viewModel = buildViewModel(runner)
+        armDeferredPreview(viewModel, runner, payment)
+
+        // The runner already ran (and lost) its network-observation
+        // rescue; the outcome is genuinely unknown, so the flow must NOT
+        // hand the user a fresh reservation to retry with.
+        coEvery { runner.sendPrebuiltDirectPayment(any(), any()) } throws okio.IOException("transport down")
+
+        viewModel.sendPayment()
+        awaitCondition("failure surfaced") { viewModel.directPaymentAckLiveData.value?.exception != null }
+
+        assertTrue("preview must stay un-armed", viewModel.deferredPayment == null)
+        assertTrue("send must be gated off", !viewModel.canSendPayment)
+        runBlocking {
+            // Exactly the preview build — no rebuild after the ambiguity.
+            coVerify(exactly = 1) { runner.buildDeferredBip70Payment(any()) }
+        }
     }
 }


### PR DESCRIPTION
Follow-up to #1531. This is the **field-test correction commit that missed that merge by five minutes** — #1531 was merged at head `437cf5ffa` (17:35 EDT); this fix was pushed at 17:40. It cherry-picks cleanly onto the merged line.

The on-device test (Pixel 8, testnet, real broadcasts) found two defects in what was merged. One is a funds hazard.

## 1. Double-pay on retry after an ambiguous failure 🔴

`PaymentProtocolViewModel` re-arms the preview after **any** non-acked failure, including an ambiguous transport failure. The SDK engine cannot see the mempool spend of the just-released inputs, so the rebuild selects **different** inputs — a second, independently-valid payment for the same invoice.

Reproduced on testnet, not theorised:
- original `2c3be7d8…` — broadcast by the merchant, later mined;
- post-failure rebuild `ed08074b…` — a *different* tx. A retry tap would have paid the merchant twice.
- Independently confirmed: a fresh preview build for the same invoice after `2c3be7d8` mined produced `ed08074b` again, i.e. that rebuild really was a distinct payment, not a re-serialisation.

**Fix:** re-arm only on a definitive nack (server refused; nothing on the network). An unresolved transport failure leaves the flow un-armed (`canSendPayment == false`) so no blind retry is possible; the user restarts the payment.

## 2. The timeout rescue as merged can never fire

It keys on `TransactionContext >= instantSend`. Measured on the pinned engine: an externally broadcast wallet-relevant tx goes `context 0 (mempool) → 2 (inBlock)` and **never** surfaces an InstantSend context or `isInstantLocked`, even when the network has IS-locked it (`txlock: true` on the explorer). Net effect as merged: the rescue never rescues and adds ~12 s to every failure.

**Fix:** key on the row's **existence**, which is safe here because the engine only records transactions it has observed and a built-but-unbroadcast payment has no row — verified against real txids (`a6cc9ead`, `ed08074b` absent while never sent; server-broadcast `2c3be7d8` present). We have not broadcast at that point in the flow, so an observed tx was broadcast by the BIP70 server. Window widened to ~20 s.

**Verified working after the fix:** server broadcast the payment then returned HTTP 500 → engine observed it at context 0 in **1.3 s** → `completing as paid` → reservation kept → bridged; tx `ed08074b…` on-chain with `txlock: true`.

## Tests

Four arms in `SendCoinsTaskRunnerBIP70Test` / `PaymentProtocolViewModelRaceTest`: observed → paid; never observed → release; nack → re-arm; ambiguous → stays un-armed.

## Verification status — please read

These suites are green **on the pre-merge base** (int11). I could not compile or run them against this branch's merged base locally: it pins `0.1.0-v41int13-SNAPSHOT`, which is not in local Maven, and the pin cannot be downgraded — the merged shielded-invite path requires int13's typed `ShieldedInviteAlreadyClaimed`. The int13 source is not pushed to any branch I can reach on dashpay/bfoss765/HashEngineering, so I can't build it either. Happy to re-run everything the moment the int13 AAR (or its source branch) is available — flagging it rather than implying verification I don't have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment recovery after network timeouts by detecting transactions observed in the mempool or wallet engine.
  * Prevented ambiguous transport failures from automatically rebuilding or retrying payments.
  * Limited automatic retry preparation to definitive payment rejections, reducing duplicate payment attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->