### PR TITLE
feat(crowdnode): message signing via the platform SDK; fence the disabled on-chain send paths

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/services/AuthenticationManager.kt
+++ b/common/src/main/java/org/dash/wallet/common/services/AuthenticationManager.kt
@@ -24,6 +24,15 @@ import org.dash.wallet.common.data.SecuritySystemStatus
 interface AuthenticationManager {
     fun authenticate(activity: FragmentActivity, pinOnly: Boolean = false, callback: (String?) -> Unit)
     suspend fun authenticate(activity: FragmentActivity, pinOnly: Boolean = false): String?
+    /**
+     * Sign [message] with the private key of [address], returning the
+     * base64 signature.
+     *
+     * Throws [MessageSigningException] on every failure — implementations
+     * must NOT return an empty string when the wallet cannot sign (see that
+     * type's doc for why). [message] must contain no unpaired UTF-16
+     * surrogate.
+     */
     suspend fun signMessage(address: String, message: String): String
     fun getHealth(): SecuritySystemStatus
     fun observeHealth(): Flow<SecuritySystemStatus>

--- a/common/src/main/java/org/dash/wallet/common/services/MessageSigningException.kt
+++ b/common/src/main/java/org/dash/wallet/common/services/MessageSigningException.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.dash.wallet.common.services
+
+/**
+ * The failure contract of [AuthenticationManager.signMessage].
+ *
+ * ## Why this type exists in `:common`
+ *
+ * The signing implementation lives in the `:wallet` module and delegates to
+ * the Dash Platform Kotlin SDK, whose typed errors
+ * (`org.dashfoundation.dashsdk.errors.DashSdkError`) are NOT on the
+ * classpath of the feature modules that call [AuthenticationManager]
+ * (`:integrations:crowdnode` depends on `:common` only). A caller therefore
+ * has no way to `catch` the SDK type. Since the interface being implemented
+ * is declared here, its error contract has to be expressible here too — so
+ * the wallet-side implementation maps every signing failure onto this type
+ * and keeps the SDK error as [cause] for logging/analytics.
+ *
+ * ## Behavior change vs. the previous dashj implementation
+ *
+ * The dashj implementation returned an EMPTY STRING when the wallet did not
+ * own the requested address. That silently produced a valid-looking request
+ * carrying no signature, which the CrowdNode server then rejected with an
+ * opaque error — the real cause (wrong/foreign address) never reached the
+ * user or the logs. Signing failures are now thrown, never swallowed; there
+ * is no dashj fallback (the codebase's fail-closed cutover philosophy, cf.
+ * `cutoverSendRoute` in `SendCoinsTaskRunner`).
+ *
+ * @property reason machine-readable classification, for callers that want
+ *   to distinguish "this address isn't ours" from a generic failure.
+ */
+class MessageSigningException(
+    val reason: Reason,
+    message: String,
+    cause: Throwable? = null
+) : Exception(message, cause) {
+
+    enum class Reason {
+        /**
+         * The wallet cannot produce a signature for the requested address:
+         * it does not own the corresponding private key, or the key is not
+         * derivable/available. Maps from the SDK's
+         * `DashSdkError.PlatformWallet.SigningKeyUnavailable`.
+         *
+         * This is the case the old dashj code answered with `""`.
+         */
+        SIGNING_KEY_UNAVAILABLE,
+
+        /**
+         * The address (or message) was rejected as malformed before any key
+         * lookup happened. Maps from the SDK's platform-wallet
+         * `ErrorInvalidParameter` (native code 2, surfaced as
+         * `DashSdkError.PlatformWallet.Generic` with `nativeCode == 2`).
+         */
+        INVALID_ADDRESS,
+
+        /**
+         * Anything else: the SDK was not startable, no wallet was bound, or
+         * the signing call failed for an unclassified reason. Always carries
+         * a [cause].
+         */
+        UNAVAILABLE
+    }
+}

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/api/CrowdNodeApi.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/api/CrowdNodeApi.kt
@@ -40,6 +40,7 @@ import org.dash.wallet.common.payments.parsers.AddressNetwork
 import org.dash.wallet.common.payments.parsers.AddressUtils
 import org.dash.wallet.common.services.BlockchainStateProvider
 import org.dash.wallet.common.services.LeftoverBalanceException
+import org.dash.wallet.common.services.MessageSigningException
 import org.dash.wallet.common.services.NotificationService
 import org.dash.wallet.common.services.TransactionMetadataProvider
 import org.dash.wallet.common.services.analytics.AnalyticsConstants
@@ -345,6 +346,17 @@ class CrowdNodeApiAggregator @Inject constructor(
             handleError(ex, appContext.getString(R.string.crowdnode_withdraw_error))
         } catch (ex: UnknownHostException) {
             log.error("Withdrawal error: ${ex.message}")
+            handleError(ex, appContext.getString(R.string.crowdnode_withdraw_error))
+        } catch (ex: MessageSigningException) {
+            // The withdrawal request is signed before it is sent
+            // (CrowdNodeWebApi.requestWithdrawal). Signing now THROWS rather
+            // than yielding an empty signature, and neither the caller
+            // (TransferFragment.handleWithdraw, which only catches
+            // WithdrawalLimitsException) nor its lifecycleScope.launch would
+            // catch it — so without this arm a signing failure would crash
+            // the app instead of showing the withdrawal-error screen.
+            // Nothing was sent to CrowdNode, so failing here is safe.
+            log.error("Withdrawal signing error (${ex.reason}): ${ex.message}")
             handleError(ex, appContext.getString(R.string.crowdnode_withdraw_error))
         }
 

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/api/CrowdNodeBlockchainApi.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/api/CrowdNodeBlockchainApi.kt
@@ -28,6 +28,7 @@ import org.dash.wallet.common.transactions.TxInfo
 import org.dash.wallet.common.transactions.filters.CoinsReceivedTxFilter
 import org.dash.wallet.common.transactions.filters.TxWithinTimePeriod
 import org.dash.wallet.integrations.crowdnode.model.CrowdNodeException
+import org.dash.wallet.integrations.crowdnode.model.CrowdNodeServiceUnavailableException
 import org.dash.wallet.integrations.crowdnode.transactions.*
 import org.dash.wallet.integrations.crowdnode.utils.CrowdNodeConstants
 import org.slf4j.LoggerFactory
@@ -36,6 +37,49 @@ import java.util.*
 import javax.inject.Inject
 import kotlin.time.Duration
 
+/**
+ * On-chain side of the CrowdNode integration.
+ *
+ * ## The senders are fenced off, not removed
+ *
+ * CrowdNode has disabled account creation and deposits service-side, and the
+ * remaining users are all served by the API path ([CrowdNodeWebApi]), so the
+ * six senders here - [topUpAddress], [makeSignUpRequest], [acceptTerms],
+ * [deposit], [requestWithdrawal] and [resendConfirmationTx] - each open with
+ * a guard on
+ * [org.dash.wallet.integrations.crowdnode.utils.CrowdNodeConstants.SIGNUP_AND_DEPOSITS_ENABLED]
+ * that throws [CrowdNodeServiceUnavailableException].
+ *
+ * The guard is the FIRST statement in every one, so nothing is attempted
+ * before the refusal: no output locking, no top-up self-send, no partially
+ * executed flow. That is also what retires the partial-deposit stranding
+ * hazard. Throwing rather than returning quietly is deliberate - an
+ * operation that reports success while moving no funds is the failure mode
+ * being refused.
+ *
+ * Everything after each guard is the ORIGINAL dashj implementation, kept
+ * deliberately rather than deleted. It is the working template for a future
+ * port to the platform SDK, which is blocked on an `add_inputs_from_outpoints`
+ * JNI binding - the SDK has no equivalent of the [SpendSelection.ByAddress] /
+ * [SpendSelection.ExactOutput] input pinning these flows depend on.
+ *
+ * Two things follow from that, and neither is obvious from the flag's name:
+ * flipping [org.dash.wallet.integrations.crowdnode.utils.CrowdNodeConstants.SIGNUP_AND_DEPOSITS_ENABLED]
+ * back to `true` will NOT make these sends work, because the fail-closed
+ * cutover in `SendCoinsTaskRunner` (`cutoverSendRoute`) rejects a custom
+ * coin selection outright once the SDK cutover is committed; and re-enabling
+ * for real therefore means doing that SDK port, not just moving the boolean.
+ *
+ * ## The observers are untouched
+ *
+ * Everything that reads chain state still works and is still needed for
+ * balances, history, withdrawals and wallet restore: the `waitFor*` family,
+ * [getDeposits], [getDepositConfirmations], [getApiAddressConfirmationTx],
+ * [getFullSignUpTxSet] and [getWithdrawalsForTheLast].
+ *
+ * The user-facing gate on the same flag is what users normally meet; these
+ * throws are the backstop for any path that gate misses.
+ */
 open class CrowdNodeBlockchainApi @Inject constructor(
     private val paymentService: SendPaymentService,
     private val walletData: WalletDataProvider
@@ -47,6 +91,9 @@ open class CrowdNodeBlockchainApi @Inject constructor(
     private val networkId = walletData.networkId
 
     suspend fun topUpAddress(accountAddress: String, amount: Dash, emptyWallet: Boolean = false): TxInfo {
+        if (!CrowdNodeConstants.SIGNUP_AND_DEPOSITS_ENABLED) {
+            throw CrowdNodeServiceUnavailableException("topUpAddress")
+        }
         // lock funds in outputs to accountAddress to prevent other send operations from using these funds
         val topUpTx = paymentService.sendCoinsSelected(
             accountAddress,
@@ -59,6 +106,9 @@ open class CrowdNodeBlockchainApi @Inject constructor(
     }
 
     suspend fun makeSignUpRequest(accountAddress: String): TxInfo {
+        if (!CrowdNodeConstants.SIGNUP_AND_DEPOSITS_ENABLED) {
+            throw CrowdNodeServiceUnavailableException("makeSignUpRequest")
+        }
         val requestValue = CrowdNodeSignUpTx.SIGNUP_REQUEST_CODE
         val crowdNodeAddress = CrowdNodeConstants.getCrowdNodeAddress(networkId)
         val signUpTx = paymentService.sendCoinsSelected(
@@ -84,6 +134,9 @@ open class CrowdNodeBlockchainApi @Inject constructor(
     }
 
     suspend fun acceptTerms(accountAddress: String): TxInfo {
+        if (!CrowdNodeConstants.SIGNUP_AND_DEPOSITS_ENABLED) {
+            throw CrowdNodeServiceUnavailableException("acceptTerms")
+        }
         val requestValue = CrowdNodeAcceptTermsTx.ACCEPT_TERMS_REQUEST_CODE
         val crowdNodeAddress = CrowdNodeConstants.getCrowdNodeAddress(networkId)
         val acceptTx = paymentService.sendCoinsSelected(
@@ -115,6 +168,9 @@ open class CrowdNodeBlockchainApi @Inject constructor(
         emptyWallet: Boolean,
         checkBalanceConditions: Boolean
     ): TxInfo {
+        if (!CrowdNodeConstants.SIGNUP_AND_DEPOSITS_ENABLED) {
+            throw CrowdNodeServiceUnavailableException("deposit")
+        }
         val crowdNodeAddress = CrowdNodeConstants.getCrowdNodeAddress(networkId)
 
         return paymentService.sendCoinsSelected(
@@ -144,6 +200,9 @@ open class CrowdNodeBlockchainApi @Inject constructor(
 
     // not currently used
     suspend fun requestWithdrawal(accountAddress: String, requestValue: Dash): TxInfo {
+        if (!CrowdNodeConstants.SIGNUP_AND_DEPOSITS_ENABLED) {
+            throw CrowdNodeServiceUnavailableException("requestWithdrawal")
+        }
         val crowdNodeAddress = CrowdNodeConstants.getCrowdNodeAddress(networkId)
 
         return paymentService.sendCoinsSelected(
@@ -242,6 +301,9 @@ open class CrowdNodeBlockchainApi @Inject constructor(
     }
 
     suspend fun resendConfirmationTx(confirmationTx: TxInfo, accountAddress: String) {
+        if (!CrowdNodeConstants.SIGNUP_AND_DEPOSITS_ENABLED) {
+            throw CrowdNodeServiceUnavailableException("resendConfirmationTx")
+        }
         // lock the outputs
         walletData.lockOutputsPayingTo(confirmationTx.txId, accountAddress)
         val confirmationOutput = confirmationTx.outputs.first {

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/api/CrowdNodeConfirmationTxHandler.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/api/CrowdNodeConfirmationTxHandler.kt
@@ -27,6 +27,7 @@ import org.dash.wallet.common.transactions.TxInfo
 import org.dash.wallet.common.transactions.filters.CoinsToAddressTxFilter
 import org.dash.wallet.integrations.crowdnode.R
 import org.dash.wallet.integrations.crowdnode.model.CrowdNodeException
+import org.dash.wallet.integrations.crowdnode.model.CrowdNodeServiceUnavailableException
 import org.dash.wallet.integrations.crowdnode.model.OnlineAccountStatus
 import org.dash.wallet.integrations.crowdnode.utils.CrowdNodeConfig
 import org.dash.wallet.integrations.crowdnode.utils.CrowdNodeConstants
@@ -81,6 +82,12 @@ class CrowdNodeAPIConfirmationHandler(
 
             try {
                 blockchainApi.resendConfirmationTx(tx, primaryAddress)
+            } catch (ex: CrowdNodeServiceUnavailableException) {
+                // The resend sender is retired. Distinguished from the arm
+                // below on purpose: this is not a wrong-address situation,
+                // and reporting it as one would send the user chasing a
+                // problem with their address that does not exist.
+                log.info("Confirmation resend is retired; leaving the status unchanged")
             } catch (ex: CrowdNodeException) {
                 handleWrongAddressError()
             }

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/model/ApiStatuses.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/model/ApiStatuses.kt
@@ -53,7 +53,35 @@ open class CrowdNodeException(message: String) : Exception(message) {
         const val CONFIRMATION_ERROR = "confirmation_error"
         const val WITHDRAWAL_ERROR = "withdrawal_error"
         const val MISSING_PRIMARY = "primary_not_specified"
+        const val SERVICE_UNAVAILABLE = "service_unavailable"
     }
 }
 
 class MessageStatusException(details: String) : CrowdNodeException(details)
+
+/**
+ * A retired on-chain operation was invoked. CrowdNode has disabled account
+ * creation and deposits service-side, and the remaining users are all on the
+ * API path, so the dashj senders in
+ * [org.dash.wallet.integrations.crowdnode.api.CrowdNodeBlockchainApi] no
+ * longer build or broadcast anything — they raise this instead.
+ *
+ * Deliberately an exception rather than a silent no-op: an operation that
+ * reports success while moving no funds is the failure mode being refused
+ * here. It is raised BEFORE any side effect (no output locking, no partial
+ * flow), so nothing is left half-done for the caller to reconcile.
+ *
+ * Extends [CrowdNodeException] on purpose — the existing handlers
+ * (`CrowdNodeApi.signUp`/`deposit`'s `catch (Exception)` and
+ * `CrowdNodeConfirmationTxHandler`'s `catch (CrowdNodeException)`) then turn
+ * it into an error state rather than an uncaught crash.
+ *
+ * The UI gate ([org.dash.wallet.integrations.crowdnode.utils.CrowdNodeConstants.SIGNUP_AND_DEPOSITS_ENABLED])
+ * is what users normally meet; this is the backstop for any path the gate
+ * misses.
+ *
+ * @property operation the retired call, for logs and analytics.
+ */
+class CrowdNodeServiceUnavailableException(
+    val operation: String
+) : CrowdNodeException("$SERVICE_UNAVAILABLE: $operation is no longer available")

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/ResultFragment.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/ResultFragment.kt
@@ -100,6 +100,10 @@ class ResultFragment : Fragment(R.layout.fragment_result) {
         // when the capability is off there is nothing to retry — offering the
         // button would just reproduce the same failure
         // (CrowdNodeConstants.SIGNUP_AND_DEPOSITS_ENABLED).
+        // The MessageStatusException exclusion matters: that is an API-path
+        // failure (a rejected signed message), which is still live and worth
+        // retrying via retryOnlineSignUp. Only a non-API signup error would
+        // re-enter the fenced-off senders and re-throw immediately.
         val signUpRetryRetired = !CrowdNodeConstants.SIGNUP_AND_DEPOSITS_ENABLED &&
             viewModel.signUpStatus == SignUpStatus.Error &&
             viewModel.crowdNodeError !is MessageStatusException

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/ResultFragment.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/ResultFragment.kt
@@ -38,6 +38,7 @@ import org.dash.wallet.integrations.crowdnode.databinding.FragmentResultBinding
 import org.dash.wallet.integrations.crowdnode.model.CrowdNodeException
 import org.dash.wallet.integrations.crowdnode.model.MessageStatusException
 import org.dash.wallet.integrations.crowdnode.model.SignUpStatus
+import org.dash.wallet.integrations.crowdnode.utils.CrowdNodeConstants
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -95,7 +96,16 @@ class ResultFragment : Fragment(R.layout.fragment_result) {
             setErrorMessage(it)
         }
 
-        if (viewModel.crowdNodeError?.isInsufficientMoney == true ||
+        // Retrying a signup would re-enter the retired on-chain senders, so
+        // when the capability is off there is nothing to retry — offering the
+        // button would just reproduce the same failure
+        // (CrowdNodeConstants.SIGNUP_AND_DEPOSITS_ENABLED).
+        val signUpRetryRetired = !CrowdNodeConstants.SIGNUP_AND_DEPOSITS_ENABLED &&
+            viewModel.signUpStatus == SignUpStatus.Error &&
+            viewModel.crowdNodeError !is MessageStatusException
+
+        if (signUpRetryRetired ||
+            viewModel.crowdNodeError?.isInsufficientMoney == true ||
             viewModel.crowdNodeError?.message?.startsWith(INSUFFICIENT_MONEY_PREFIX) == true ||
             viewModel.crowdNodeError?.message == CrowdNodeException.CONFIRMATION_ERROR
         ) {

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/entry_point/EntryPointFragment.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/entry_point/EntryPointFragment.kt
@@ -57,6 +57,16 @@ class EntryPointFragment : Fragment(R.layout.fragment_entry_point) {
         // CrowdNode functionality is limited: linking an existing account isn't supported
         binding.existingAccountBtn.isVisible = false
 
+        // Account creation is retired service-side (CrowdNodeConstants.
+        // SIGNUP_AND_DEPOSITS_ENABLED). This is THE entry point to the signup
+        // flow, so hiding the button here is what stops a user reaching the
+        // retired on-chain senders; CrowdNodeBlockchainApi's throws are the
+        // backstop. Say why, rather than showing a dead-end button.
+        if (!CrowdNodeConstants.SIGNUP_AND_DEPOSITS_ENABLED) {
+            binding.newAccountBtn.isVisible = false
+            binding.requiredDashTxt.text = getString(R.string.crowdnode_signup_deposits_disabled)
+        }
+
         binding.backupPassphraseHint.setOnClickListener {
             val dialog = AdaptiveDialog.create(
                 null,

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/entry_point/EntryPointFragment.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/entry_point/EntryPointFragment.kt
@@ -57,14 +57,19 @@ class EntryPointFragment : Fragment(R.layout.fragment_entry_point) {
         // CrowdNode functionality is limited: linking an existing account isn't supported
         binding.existingAccountBtn.isVisible = false
 
-        // Account creation is retired service-side (CrowdNodeConstants.
+        // Account creation is fenced off (CrowdNodeConstants.
         // SIGNUP_AND_DEPOSITS_ENABLED). This is THE entry point to the signup
         // flow, so hiding the button here is what stops a user reaching the
-        // retired on-chain senders; CrowdNodeBlockchainApi's throws are the
-        // backstop. Say why, rather than showing a dead-end button.
+        // fenced-off on-chain senders; CrowdNodeBlockchainApi's throws are
+        // the backstop. Say why, rather than leaving an empty screen.
+        //
+        // The explanation replaces the screen's own title/hint, which sit
+        // OUTSIDE the button card — requiredDashTxt is a child of
+        // newAccountBtn and would be hidden along with it.
         if (!CrowdNodeConstants.SIGNUP_AND_DEPOSITS_ENABLED) {
             binding.newAccountBtn.isVisible = false
-            binding.requiredDashTxt.text = getString(R.string.crowdnode_signup_deposits_disabled)
+            binding.getStartedTitle.text = getString(R.string.crowdnode_signup_deposits_disabled)
+            binding.getStartedHint.text = getString(R.string.crowdnode_signup_deposits_disabled_message)
         }
 
         binding.backupPassphraseHint.setOnClickListener {

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/online/OnlineAccountEmailFragment.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/online/OnlineAccountEmailFragment.kt
@@ -25,8 +25,11 @@ import androidx.core.view.isVisible
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import org.dash.wallet.common.services.AuthenticationManager
 import org.dash.wallet.common.services.analytics.AnalyticsConstants
 import org.dash.wallet.common.ui.viewBinding
 import org.dash.wallet.common.util.KeyboardUtil
@@ -35,11 +38,15 @@ import org.dash.wallet.integrations.crowdnode.R
 import org.dash.wallet.integrations.crowdnode.databinding.FragmentOnlineAccountEmailBinding
 import org.dash.wallet.integrations.crowdnode.model.OnlineAccountStatus
 import org.dash.wallet.integrations.crowdnode.ui.CrowdNodeViewModel
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class OnlineAccountEmailFragment : Fragment(R.layout.fragment_online_account_email) {
     private val binding by viewBinding(FragmentOnlineAccountEmailBinding::bind)
     private val viewModel by activityViewModels<CrowdNodeViewModel>()
+
+    @Inject
+    lateinit var securityFunctions: AuthenticationManager
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -128,7 +135,18 @@ class OnlineAccountEmailFragment : Fragment(R.layout.fragment_online_account_ema
 
     private fun continueCreating(email: String) {
         KeyboardUtil.hideKeyboard(requireContext(), binding.emailInput)
-        viewModel.signAndSendEmail(email)
+
+        // Registering the email signs it with the account key, and CrowdNode
+        // treats that signature as authorization to bind the address to this
+        // email — the hook the account-recovery flow hangs off. Signing
+        // performs no authentication of its own (see SdkMessageSigner), so
+        // the gate belongs here. `?.let` means a cancelled or failed check
+        // simply returns without sending anything.
+        lifecycleScope.launch {
+            securityFunctions.authenticate(requireActivity())?.let {
+                viewModel.signAndSendEmail(email)
+            }
+        }
     }
 
     private fun isEmail(text: CharSequence?): Boolean {

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/portal/PortalFragment.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/portal/PortalFragment.kt
@@ -139,7 +139,10 @@ class PortalFragment : Fragment(R.layout.fragment_portal) {
         binding.walletBalanceDash.setAmount(Dash.ZERO)
 
         // CrowdNode functionality is limited: deposits aren't supported. Only withdrawals are allowed.
-        binding.depositBtn.isVisible = false
+        // The on-chain deposit senders are retired (CrowdNodeBlockchainApi);
+        // this button has no click listener at all, so hiding it is what
+        // keeps the deposit flow unreachable from the portal.
+        binding.depositBtn.isVisible = CrowdNodeConstants.SIGNUP_AND_DEPOSITS_ENABLED
         // online account isn't supported - the button is kept hidden in all states, see setOnlineAccountStatus
         binding.onlineAccountBtn.isVisible = false
 

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/portal/TransferFragment.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/ui/portal/TransferFragment.kt
@@ -227,9 +227,14 @@ class TransferFragment : Fragment(R.layout.fragment_transfer) {
                 showErrorBanner()
                 return
             }
-
-            securityFunctions.authenticate(requireActivity()) ?: return
         }
+
+        // Authenticate for BOTH directions. A withdrawal is signed with the
+        // account key and instructs CrowdNode to move real funds, so it needs
+        // the same proof-of-presence a deposit does — signing itself performs
+        // no authentication (see SdkMessageSigner). A null return means the
+        // user cancelled or failed the check: abort without transferring.
+        securityFunctions.authenticate(requireActivity()) ?: return
 
         val isSuccess = AdaptiveDialog.withProgress(getString(R.string.please_wait_title), requireActivity()) {
             if (isWithdraw) {

--- a/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/utils/CrowdNodeConstants.kt
+++ b/integrations/crowdnode/src/main/java/org/dash/wallet/integrations/crowdnode/utils/CrowdNodeConstants.kt
@@ -23,6 +23,26 @@ import org.dash.wallet.common.money.DashNetworks
 import org.dash.wallet.common.money.MoneyFormat
 
 object CrowdNodeConstants {
+    /**
+     * Master switch for the on-chain signup and deposit flows.
+     *
+     * CrowdNode has disabled account creation and deposits service-side and
+     * every remaining user is served by the API path, so the dashj senders
+     * behind these flows are retired
+     * ([org.dash.wallet.integrations.crowdnode.api.CrowdNodeBlockchainApi]).
+     * Flipping this to `true` would re-expose the UI, but the senders would
+     * still refuse — re-enabling for real means restoring those code paths
+     * as well.
+     *
+     * Withdrawals, balances, history and wallet restore are NOT affected and
+     * must keep working for existing accounts.
+     *
+     * This replaces the ad-hoc `isVisible = false` lines that previously
+     * hid these affordances one by one, so the whole capability is now
+     * flippable from a single place.
+     */
+    const val SIGNUP_AND_DEPOSITS_ENABLED = false
+
     private const val CROWDNODE_TESTNET_ADDRESS = "yMY5bqWcknGy5xYBHSsh2xvHZiJsRucjuy"
     private const val CROWDNODE_MAINNET_ADDRESS = "XjbaGWaGnvEtuQAUoBgDxJWe8ZNv45upG2"
 

--- a/integrations/crowdnode/src/main/res/layout/fragment_entry_point.xml
+++ b/integrations/crowdnode/src/main/res/layout/fragment_entry_point.xml
@@ -46,6 +46,7 @@
             android:theme="@style/CrowdNodeLogoBackground" />
 
         <TextView
+            android:id="@+id/get_started_title"
             style="@style/Headline5"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -56,6 +57,7 @@
             android:textAlignment="gravity" />
 
         <TextView
+            android:id="@+id/get_started_hint"
             style="@style/Body2"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/integrations/crowdnode/src/main/res/values/strings-crowdnode.xml
+++ b/integrations/crowdnode/src/main/res/values/strings-crowdnode.xml
@@ -45,6 +45,8 @@
     <string name="crowdnode_creating">Creating your CrowdNode account…</string>
     <string name="accepting_terms">Accepting terms of use…</string>
     <string name="crowdnode_signup_error">We couldn’t create your CrowdNode account.</string>
+    <string name="crowdnode_signup_deposits_disabled">CrowdNode is not accepting new accounts or deposits</string>
+    <string name="crowdnode_signup_deposits_disabled_message">You can still withdraw from an existing CrowdNode account and view your balance.</string>
     <string name="crowdnode_deposit_error">We couldn’t make a deposit to your CrowdNode account.</string>
     <string name="crowdnode_withdraw_error">We couldn’t withdraw from your CrowdNode account.</string>
     <string name="crowdnode_transfer_error">Your CrowdNode transfer was unsuccessful.</string>

--- a/integrations/crowdnode/src/test/java/org/dash/wallet/integrations/crowdnode/CrowdNodeBlockchainApiRetirementTest.kt
+++ b/integrations/crowdnode/src/test/java/org/dash/wallet/integrations/crowdnode/CrowdNodeBlockchainApiRetirementTest.kt
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.dash.wallet.integrations.crowdnode
+
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
+import junit.framework.TestCase.fail
+import kotlinx.coroutines.runBlocking
+import org.dash.wallet.common.WalletDataProvider
+import org.dash.wallet.common.money.Dash
+import org.dash.wallet.common.payments.parsers.AddressNetwork
+import org.dash.wallet.common.services.SendPaymentService
+import org.dash.wallet.integrations.crowdnode.api.CrowdNodeBlockchainApi
+import org.dash.wallet.integrations.crowdnode.model.CrowdNodeException
+import org.dash.wallet.integrations.crowdnode.model.CrowdNodeServiceUnavailableException
+import org.dash.wallet.integrations.crowdnode.utils.CrowdNodeConstants
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+
+/**
+ * The six on-chain senders of [CrowdNodeBlockchainApi] are fenced off behind
+ * [CrowdNodeConstants.SIGNUP_AND_DEPOSITS_ENABLED]: CrowdNode disabled
+ * account creation and deposits service-side and every remaining user is on
+ * the API path.
+ *
+ * The original dashj bodies are preserved as the template for a future SDK
+ * port, so these tests pin the two properties that make that safe:
+ *
+ * 1. Each sender THROWS [CrowdNodeServiceUnavailableException] — it must not
+ *    quietly no-op, because an operation that reports success while moving
+ *    no funds is the failure mode being refused.
+ * 2. Each throws BEFORE any side effect, proving the preserved body is
+ *    unreached. No send, no output locking, no top-up self-send, no
+ *    partially-executed flow — which is also what retires the
+ *    partial-deposit stranding hazard.
+ *
+ * The passive observers are deliberately untouched and still serve balances,
+ * history, withdrawals and restore.
+ */
+class CrowdNodeBlockchainApiRetirementTest {
+    private val accountAddress = "yihMSMoesHX1JhbntTiV5Nptf5NLrmFMCu"
+
+    // TxInfo is a final class and cannot be mocked; the module's TestTx
+    // helper builds a real one. Its contents are irrelevant here - the point
+    // is that resendConfirmationTx refuses before ever reading it.
+    private val confirmationTxData = "01000000016fdb75611fd8892d8d19707f0d0958da5b930c635750f2c8c5bf5a48458a8ffd000000006b483045022100ff77055377b33afb8fc2f622fda59816394a567c50e98569fe8ab68d797948b802204b05504b3f837e80f4d0d8c3c6d98107e770572a8eaae66ddd14a660fe9674f101210275ab1f1c864e594c5e075ac45fbd01a45285701e429b842f8d0a1c872cf3a7baffffffff0149d00000000000001976a9140d5bcbeeb459af40f97fcb4a98e9d1ed13e904c888ac00000000" // ktlint-disable max-line-length
+
+    /**
+     * Only `networkId` is stubbed — it is read once at construction. Any
+     * OTHER interaction with the wallet would be a side effect, which is
+     * exactly what the assertions below rule out.
+     */
+    private val walletData = mock<WalletDataProvider> {
+        on { networkId } doReturn AddressNetwork.ID_TESTNET
+    }
+
+    /**
+     * The real send service. Left completely unstubbed on purpose: every
+     * assertion below requires that it is never called at all.
+     */
+    private val paymentService = mock<SendPaymentService>()
+
+    private val api = CrowdNodeBlockchainApi(paymentService, walletData)
+
+    /** Runs [block], returning the typed exception or failing the test. */
+    private fun assertRetired(operation: String, block: suspend () -> Unit) {
+        val ex = try {
+            runBlocking { block() }
+            fail("$operation must throw CrowdNodeServiceUnavailableException, not succeed silently")
+            return
+        } catch (ex: CrowdNodeServiceUnavailableException) {
+            ex
+        }
+
+        assertEquals("wrong operation tag", operation, ex.operation)
+        // The existing handlers (CrowdNodeApi's catch(Exception) and
+        // CrowdNodeConfirmationTxHandler's catch(CrowdNodeException)) must be
+        // able to turn this into an error state rather than an uncaught crash.
+        assertTrue("must remain a CrowdNodeException", ex is CrowdNodeException)
+    }
+
+    /**
+     * No sender may do anything before refusing: no send, no output locking,
+     * no observing. The guard is the first statement in each method, so the
+     * original dashj body below it must be provably unreached.
+     */
+    private fun assertNoSideEffects() {
+        runBlocking { verifyNoInteractions(paymentService) }
+        verify(walletData, never()).lockOutputsPayingTo(any(), any())
+        runBlocking { verify(walletData, never()).waitUntilLocked(any()) }
+        verify(walletData, never()).observeTransactions(any(), any())
+        verify(walletData, never()).getTransactions(any())
+    }
+
+    // ── Each sender throws, with no side effect ───────────────────────
+
+    @Test
+    fun topUpAddress_isRetired() {
+        assertRetired("topUpAddress") { api.topUpAddress(accountAddress, Dash.COIN) }
+        assertNoSideEffects()
+    }
+
+    @Test
+    fun makeSignUpRequest_isRetired() {
+        assertRetired("makeSignUpRequest") { api.makeSignUpRequest(accountAddress) }
+        assertNoSideEffects()
+    }
+
+    @Test
+    fun acceptTerms_isRetired() {
+        assertRetired("acceptTerms") { api.acceptTerms(accountAddress) }
+        assertNoSideEffects()
+    }
+
+    @Test
+    fun deposit_isRetired() {
+        assertRetired("deposit") {
+            api.deposit(accountAddress, Dash.COIN, emptyWallet = false, checkBalanceConditions = true)
+        }
+        assertNoSideEffects()
+    }
+
+    @Test
+    fun requestWithdrawal_isRetired() {
+        assertRetired("requestWithdrawal") { api.requestWithdrawal(accountAddress, Dash.COIN) }
+        assertNoSideEffects()
+    }
+
+    @Test
+    fun resendConfirmationTx_isRetired_withoutLockingOutputsFirst() {
+        // This one used to call lockOutputsPayingTo as its FIRST statement,
+        // before sending — so it is the sharpest test of "throw before any
+        // side effect".
+        val confirmationTx = TestTx(confirmationTxData).toTxInfo()
+        assertRetired("resendConfirmationTx") { api.resendConfirmationTx(confirmationTx, accountAddress) }
+        assertNoSideEffects()
+    }
+
+    // ── The gate ──────────────────────────────────────────────────────
+
+    @Test
+    fun signupAndDepositsAreGatedOff() {
+        // The UI gate is what users meet; the throws above are the backstop.
+        // If this is ever flipped back on, the senders still refuse — see the
+        // constant's doc.
+        assertFalse(
+            "signup/deposit UI must stay gated while the senders are retired",
+            CrowdNodeConstants.SIGNUP_AND_DEPOSITS_ENABLED
+        )
+    }
+
+    // ── Observers stay alive ──────────────────────────────────────────
+
+    @Test
+    fun passiveObserversStillReadTheWallet() {
+        // Balance/history/restore must keep working: getDeposits is a pure
+        // read and must still reach the wallet rather than throw.
+        val deposits = api.getDeposits(accountAddress)
+        assertTrue("observer should return the wallet's (empty) result", deposits.isEmpty())
+        verify(walletData).getTransactions(any())
+    }
+}

--- a/wallet/src/de/schildbach/wallet/di/PlatformSdkModule.kt
+++ b/wallet/src/de/schildbach/wallet/di/PlatformSdkModule.kt
@@ -23,9 +23,11 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import de.schildbach.wallet.service.platform.sdk.DashPayBackfillGate
 import de.schildbach.wallet.service.platform.sdk.DashPayBackfillGateImpl
+import de.schildbach.wallet.service.platform.sdk.DashSdkMessageSigner
 import de.schildbach.wallet.service.platform.sdk.DashSdkService
 import de.schildbach.wallet.service.platform.sdk.DashSdkServiceImpl
 import de.schildbach.wallet.service.platform.sdk.PlatformMnemonicProvider
+import de.schildbach.wallet.service.platform.sdk.SdkMessageSigner
 import de.schildbach.wallet.service.platform.sdk.SecurityGuardMnemonicProvider
 import de.schildbach.wallet.service.platform.sdk.ShieldedBalanceService
 import de.schildbach.wallet.service.platform.sdk.ShieldedBalanceServiceImpl
@@ -81,4 +83,17 @@ abstract class PlatformSdkModule {
     abstract fun bindShieldedBalanceService(
         service: ShieldedBalanceServiceImpl
     ): ShieldedBalanceService
+
+    /**
+     * The SDK message-signing seam behind
+     * [de.schildbach.wallet.security.SecurityFunctions.signMessage] (the
+     * CrowdNode `RegisterEmail` / `Withdrawal` request signatures). Lazy
+     * like the rest: the SDK only boots if a signature is actually
+     * requested.
+     */
+    @Singleton
+    @Binds
+    abstract fun bindSdkMessageSigner(
+        signer: DashSdkMessageSigner
+    ): SdkMessageSigner
 }

--- a/wallet/src/de/schildbach/wallet/security/SecurityFunctions.kt
+++ b/wallet/src/de/schildbach/wallet/security/SecurityFunctions.kt
@@ -287,6 +287,17 @@ internal suspend fun signMessageViaSdk(
         // FFI code 31: the bound wallet holds no private key for this
         // address. The one case the dashj implementation answered with an
         // empty string.
+        //
+        // TODO(signing): this may be TRANSIENT after a wallet restore. The
+        //  SDK wallet derives its own address set as it syncs, so until that
+        //  catches up with dashj's discovery an address dashj already knows
+        //  can be genuinely absent SDK-side, and a CrowdNode signature for it
+        //  fails until the sync completes. A widen-the-lookahead-and-retry
+        //  heal is under consideration on the integration line; whether this
+        //  is a real limitation at all is still disputed. Deliberately NOT
+        //  worked around here — a retry or fallback added at this layer would
+        //  mask the distinction between "not ours yet" and "not ours", which
+        //  is exactly the distinction the fail-closed contract depends on.
         signingLog.error("signMessage: no signing key for address", ex)
         throw MessageSigningException(
             MessageSigningException.Reason.SIGNING_KEY_UNAVAILABLE,

--- a/wallet/src/de/schildbach/wallet/security/SecurityFunctions.kt
+++ b/wallet/src/de/schildbach/wallet/security/SecurityFunctions.kt
@@ -23,14 +23,16 @@ import android.os.Build
 import androidx.fragment.app.FragmentActivity
 import de.schildbach.wallet.Constants
 import de.schildbach.wallet.payments.SendCoinsTaskRunner
+import de.schildbach.wallet.service.platform.sdk.PWFFI_ERROR_INVALID_PARAMETER
+import de.schildbach.wallet.service.platform.sdk.SdkMessageSigner
 import de.schildbach.wallet.ui.CheckPinDialog
 import de.schildbach.wallet_test.R
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
-import org.bitcoinj.core.Address
 import org.bitcoinj.crypto.KeyCrypterException
 import org.bitcoinj.crypto.KeyCrypterScrypt
 import org.bitcoinj.wallet.DeterministicSeed
@@ -39,6 +41,8 @@ import org.bouncycastle.crypto.params.KeyParameter
 import de.schildbach.wallet.data.WalletData
 import org.dash.wallet.common.data.SecuritySystemStatus
 import org.dash.wallet.common.services.AuthenticationManager
+import org.dash.wallet.common.services.MessageSigningException
+import org.dashfoundation.dashsdk.errors.DashSdkError
 import org.dash.wallet.common.services.analytics.AnalyticsService
 import org.dash.wallet.common.ui.dialogs.AdaptiveDialog
 import org.slf4j.LoggerFactory
@@ -51,7 +55,13 @@ class SecurityFunctions @Inject constructor(
     private val context: Context,
     private val biometricHelper: BiometricHelper,
     private val pinRetryController: PinRetryController,
-    private val analyticsService: AnalyticsService
+    private val analyticsService: AnalyticsService,
+    /**
+     * The Kotlin SDK's message-signing surface, behind a seam so
+     * [signMessage]'s error mapping is host-JVM testable (the real call
+     * needs `libdash_sdk`).
+     */
+    private val messageSigner: SdkMessageSigner
 ): AuthenticationManager {
     private val log = LoggerFactory.getLogger(SendCoinsTaskRunner::class.java)
     private val status = MutableStateFlow(SecuritySystemStatus.HEALTHY)
@@ -149,14 +159,39 @@ class SecurityFunctions @Inject constructor(
         return@withContext deterministicSeed
     }
 
-    override suspend fun signMessage(address: String, message: String): String {
-        val securityGuard = SecurityGuard.getInstance()
-        val password = securityGuard.retrievePassword()
-        val keyParameter = deriveKey(walletData.wallet!!, password)
-        val dashjAddress = Address.fromBase58(walletData.networkParameters, address)
-        val key = walletData.wallet?.findKeyFromAddress(dashjAddress)
-        return key?.signMessage(message, keyParameter) ?: ""
-    }
+    /**
+     * Sign [message] with the private key of [address], returning the
+     * base64 signature. Backed by the Dash Platform Kotlin SDK
+     * (`ManagedPlatformWallet.signMessage` via [SdkMessageSigner]); the
+     * dashj key lookup this replaced is gone, with no fallback — the
+     * codebase's fail-closed cutover philosophy (cf. `cutoverSendRoute` in
+     * [SendCoinsTaskRunner]).
+     *
+     * No PIN prompt: the SDK's mnemonic resolver reads the seed Rust-side
+     * from its own Keystore-backed storage, so unlike the dashj path this
+     * neither retrieves the password nor derives the wallet encryption key.
+     *
+     * ## Failure contract
+     *
+     * Throws [MessageSigningException] on EVERY failure — in particular it
+     * no longer returns `""` when the wallet does not own [address]. That
+     * old silent-empty behavior made CrowdNode POST an unsigned request and
+     * fail server-side with an opaque message; the caller now gets
+     * [MessageSigningException.Reason.SIGNING_KEY_UNAVAILABLE] instead.
+     *
+     * ## Message contract
+     *
+     * [message] must be well-formed text: the SDK `require()`s that it
+     * contain no unpaired UTF-16 surrogate, since a lone surrogate cannot
+     * be encoded to the UTF-8 bytes that get hashed, and silently
+     * substituting U+FFFD would sign something other than what the caller
+     * passed. The only production callers are CrowdNode's `RegisterEmail`
+     * (an email address) and `Withdrawal` (a decimal duffs string), so
+     * neither can trip it. A violation surfaces as
+     * [MessageSigningException.Reason.UNAVAILABLE].
+     */
+    override suspend fun signMessage(address: String, message: String): String =
+        signMessageViaSdk(messageSigner, address, message)
 
     override fun getHealth(): SecuritySystemStatus {
         val securityGuard = SecurityGuard.getInstance()
@@ -218,5 +253,68 @@ class SecurityFunctions @Inject constructor(
 
         // Hand back the (possibly changed) encryption key.
         return key
+    }
+}
+
+// ── Message signing (host-testable) ───────────────────────────────────
+
+private val signingLog = LoggerFactory.getLogger("de.schildbach.wallet.security.signMessage")
+
+/**
+ * The whole of [SecurityFunctions.signMessage], lifted out of the class so
+ * it is host-JVM testable: [SecurityFunctions] itself cannot be constructed
+ * in a unit test, because [PinRetryController]'s static initializer builds
+ * an Android-dependent singleton that fails to initialize off-device. Same
+ * "pure logic as a top-level `internal fun`" convention as
+ * `classifyCoreSendFailure` in
+ * [de.schildbach.wallet.service.platform.sdk.SdkL1SendService]; the class
+ * method is a one-line delegation.
+ *
+ * Maps every SDK failure onto [MessageSigningException] — see
+ * [SecurityFunctions.signMessage] for the full contract.
+ */
+internal suspend fun signMessageViaSdk(
+    signer: SdkMessageSigner,
+    address: String,
+    message: String
+): String {
+    return try {
+        signer.signMessage(address, message)
+    } catch (ex: CancellationException) {
+        // Never wrap cancellation — a cancelled scope must stay cancelled.
+        throw ex
+    } catch (ex: DashSdkError.PlatformWallet.SigningKeyUnavailable) {
+        // FFI code 31: the bound wallet holds no private key for this
+        // address. The one case the dashj implementation answered with an
+        // empty string.
+        signingLog.error("signMessage: no signing key for address", ex)
+        throw MessageSigningException(
+            MessageSigningException.Reason.SIGNING_KEY_UNAVAILABLE,
+            "the wallet cannot sign for this address",
+            ex
+        )
+    } catch (ex: DashSdkError.PlatformWallet.Generic) {
+        // Platform-wallet native code 2 (`ErrorInvalidParameter`) has no
+        // dedicated Kotlin type — DashSdkError's code mapping falls through
+        // to Generic(2, …) — and is how a malformed address is rejected
+        // Rust-side. Any other Generic code is an unclassified SDK failure.
+        val reason = if (ex.nativeCode == PWFFI_ERROR_INVALID_PARAMETER) {
+            MessageSigningException.Reason.INVALID_ADDRESS
+        } else {
+            MessageSigningException.Reason.UNAVAILABLE
+        }
+        signingLog.error("signMessage: SDK rejected the request (code ${ex.nativeCode})", ex)
+        throw MessageSigningException(reason, "message signing failed", ex)
+    } catch (ex: Exception) {
+        // SDK not startable, no single bound wallet, an EMPTY address or a
+        // message with an unpaired surrogate (both caught by the SDK's own
+        // client-side `require`s, which raise IllegalArgumentException
+        // rather than an FFI code), or any other signing failure.
+        signingLog.error("signMessage: signing unavailable", ex)
+        throw MessageSigningException(
+            MessageSigningException.Reason.UNAVAILABLE,
+            "message signing is unavailable",
+            ex
+        )
     }
 }

--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/SdkMessageSigner.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/SdkMessageSigner.kt
@@ -25,6 +25,25 @@ import javax.inject.Inject
  * [de.schildbach.wallet.security.SecurityFunctions.signMessage] and its
  * error mapping stay host-JVM unit-testable — the real call needs
  * `libdash_sdk`. Same shape as [SdkL1SendSource].
+ *
+ * ## Signing performs NO user authentication
+ *
+ * There is no PIN or biometric prompt anywhere on this path. The SDK's
+ * mnemonic resolver reads the seed Rust-side from its own Keystore-backed
+ * storage, so a signature is produced silently from whatever code path asks
+ * for one. This is a real change from the dashj implementation that
+ * preceded it, which had to retrieve the PIN-derived password and derive
+ * the wallet's encryption key on every call and therefore could not run
+ * without the user having authenticated at some point.
+ *
+ * A signature is an authorization token to the server that verifies it, so
+ * **callers whose signatures authorize sensitive server-side actions own the
+ * authentication gate.** Today that means CrowdNode's two call sites, both
+ * gated in the UI ahead of the call: the withdrawal request
+ * (`TransferFragment.continueTransfer`) and the email registration
+ * (`OnlineAccountEmailFragment.continueCreating`). Any new caller must make
+ * the same decision deliberately rather than inheriting a prompt that no
+ * longer exists.
  */
 interface SdkMessageSigner {
     /**

--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/SdkMessageSigner.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/SdkMessageSigner.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.wallet.service.platform.sdk
+
+import javax.inject.Inject
+
+/**
+ * Seam over the Kotlin SDK's message-signing surface
+ * (`ManagedPlatformWallet.signMessage`), so
+ * [de.schildbach.wallet.security.SecurityFunctions.signMessage] and its
+ * error mapping stay host-JVM unit-testable — the real call needs
+ * `libdash_sdk`. Same shape as [SdkL1SendSource].
+ */
+interface SdkMessageSigner {
+    /**
+     * Sign [message] with the private key of [address] (Dash "magic
+     * message" signing — the same scheme CrowdNode verifies), returning the
+     * base64 signature.
+     *
+     * Throws on every failure; notably
+     * `DashSdkError.PlatformWallet.SigningKeyUnavailable` when the bound
+     * wallet does not own [address], and
+     * `DashSdkError.PlatformWallet.Generic` with `nativeCode == 2`
+     * (`ErrorInvalidParameter`) when [address] is malformed. Callers map
+     * these onto
+     * [org.dash.wallet.common.services.MessageSigningException].
+     */
+    suspend fun signMessage(address: String, message: String): String
+}
+
+/**
+ * Production [SdkMessageSigner]: boots the SDK on demand and signs with the
+ * single bound wallet.
+ *
+ * The signer handle is the manager's `mnemonicResolverHandle` — the same
+ * handle every SDK write path uses ([DashSdkL1SendSource.sendToAddress],
+ * [SdkL1InviteCreation], …). The seed never crosses the FFI boundary: the
+ * resolver reads it Rust-side from the SDK's Keystore-backed
+ * `WalletStorage`, which [DashSdkService.bindAppWallet] populated at bind
+ * time. That is why signing needs NO PIN prompt here — unlike the dashj
+ * implementation this replaces, which had to retrieve the password and
+ * derive the wallet's encryption key on every call.
+ */
+class DashSdkMessageSigner @Inject constructor(
+    private val service: DashSdkService
+) : SdkMessageSigner {
+
+    private suspend fun manager(): org.dashfoundation.dashsdk.wallet.PlatformWalletManager {
+        service.ensureStarted()
+        return checkNotNull(service.walletManagerOrNull()) {
+            "SDK wallet manager missing after ensureStarted()"
+        }
+    }
+
+    override suspend fun signMessage(address: String, message: String): String {
+        val manager = manager()
+        // ONE app wallet by construction; more than one entry means stale
+        // leftovers of a reset/wiped wallet, which `singleOrNull()` refuses
+        // rather than signing with an arbitrary one (the established
+        // bound-wallet lookup — see [DashSdkService.loadedWalletIds]).
+        val walletIdHex = checkNotNull(manager.wallets.value.keys.singleOrNull()) {
+            "no single bound SDK wallet to sign with"
+        }
+        val wallet = checkNotNull(manager.wallets.value[walletIdHex]) { "SDK wallet not loaded" }
+
+        return wallet.signMessage(
+            address = address,
+            message = message,
+            coreSignerHandle = manager.mnemonicResolverHandle
+        )
+    }
+}

--- a/wallet/test/de/schildbach/wallet/security/SecurityFunctionsSignMessageTest.kt
+++ b/wallet/test/de/schildbach/wallet/security/SecurityFunctionsSignMessageTest.kt
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.wallet.security
+
+import de.schildbach.wallet.service.platform.sdk.PWFFI_ERROR_INVALID_PARAMETER
+import de.schildbach.wallet.service.platform.sdk.SdkMessageSigner
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.dash.wallet.common.services.MessageSigningException
+import org.dashfoundation.dashsdk.errors.DashSdkError
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * Host-JVM tests for [SecurityFunctions.signMessage] after the dashj →
+ * Kotlin SDK swap. No native calls: the SDK signing surface is faked via
+ * [SdkMessageSigner], the same seam convention
+ * `SdkL1SendServiceTest`/`SdkL1SendSource` use.
+ *
+ * The invariant these lock down: signing NEVER answers a failure with an
+ * empty string. The dashj implementation returned `""` when the wallet did
+ * not own the address, which made CrowdNode POST an unsigned request and
+ * fail server-side with an opaque message. Every failure is now a typed
+ * [MessageSigningException].
+ */
+class SecurityFunctionsSignMessageTest {
+
+    private val address = "yTsGq4wV8WF5GKLaYV2C43zrkr2sfTtysT"
+    private val email = "someone@example.com"
+
+    /** Fake SDK signing seam — records the call, replays a scripted outcome. */
+    private class FakeSigner(
+        var onSign: (String, String) -> String = { _, _ -> "IIfakebase64signature==" }
+    ) : SdkMessageSigner {
+        var calls = 0
+        var lastAddress: String? = null
+        var lastMessage: String? = null
+
+        override suspend fun signMessage(address: String, message: String): String {
+            calls++
+            lastAddress = address
+            lastMessage = message
+            return onSign(address, message)
+        }
+    }
+
+    /**
+     * The production signing logic under test. [SecurityFunctions] itself
+     * cannot be constructed here — `PinRetryController`'s static
+     * initializer builds an Android-dependent singleton that fails to
+     * initialize on the host JVM — so `SecurityFunctions.signMessage` is a
+     * one-line delegation to [signMessageViaSdk] and this exercises that
+     * function directly. Same convention as `classifyCoreSendFailure` in
+     * `SdkL1SendService`.
+     */
+    private suspend fun sign(signer: SdkMessageSigner, address: String, message: String): String =
+        signMessageViaSdk(signer, address, message)
+
+    // ── Happy path ────────────────────────────────────────────────────
+
+    @Test
+    fun `returns the SDK signature verbatim`() = runBlocking {
+        val signer = FakeSigner(onSign = { _, _ -> "H9base64signature==" })
+
+        val result = sign(signer, address, email)
+
+        assertEquals("H9base64signature==", result)
+        assertEquals(1, signer.calls)
+    }
+
+    @Test
+    fun `passes address and message through unmodified`() = runBlocking {
+        val signer = FakeSigner()
+        // CrowdNode's two real messages: an email (RegisterEmail) and a
+        // decimal duffs string (Withdrawal).
+        sign(signer, address, "100000000")
+
+        assertEquals(address, signer.lastAddress)
+        assertEquals("100000000", signer.lastMessage)
+    }
+
+    // ── The regression guard: no empty string on failure ──────────────
+
+    @Test
+    fun `throws instead of returning empty string when the key is unavailable`() = runBlocking {
+        val signer = FakeSigner(onSign = { _, _ ->
+            throw DashSdkError.PlatformWallet.SigningKeyUnavailable("no signing key for address")
+        })
+
+        try {
+            val result = sign(signer, address, email)
+            fail(
+                "expected MessageSigningException; the dashj implementation's silent " +
+                    "empty-signature behavior must NOT be preserved (got: '$result')"
+            )
+        } catch (ex: MessageSigningException) {
+            assertEquals(MessageSigningException.Reason.SIGNING_KEY_UNAVAILABLE, ex.reason)
+        }
+    }
+
+    @Test
+    fun `no failure mode answers with an empty or blank signature`() = runBlocking {
+        val failures = listOf(
+            DashSdkError.PlatformWallet.SigningKeyUnavailable("no signing key"),
+            DashSdkError.PlatformWallet.Generic(PWFFI_ERROR_INVALID_PARAMETER, "bad address"),
+            DashSdkError.PlatformWallet.Generic(99, "unknown"),
+            IllegalStateException("no single bound SDK wallet to sign with"),
+            IllegalArgumentException("message contains an unpaired surrogate")
+        )
+
+        failures.forEach { failure ->
+            val signer = FakeSigner(onSign = { _, _ -> throw failure })
+            try {
+                val result = sign(signer, address, email)
+                fail("expected a throw for $failure, got '$result'")
+            } catch (ex: MessageSigningException) {
+                assertNotEquals("", ex.message)
+                assertSame("the original SDK error must survive as the cause", failure, ex.cause)
+            }
+        }
+    }
+
+    // ── Typed error mapping ───────────────────────────────────────────
+
+    @Test
+    fun `SigningKeyUnavailable maps to SIGNING_KEY_UNAVAILABLE and keeps the cause`() = runBlocking {
+        val sdkError = DashSdkError.PlatformWallet.SigningKeyUnavailable("wallet owns no key for yTsG…")
+        val signer = FakeSigner(onSign = { _, _ -> throw sdkError })
+
+        try {
+            sign(signer, address, email)
+            fail("expected MessageSigningException")
+        } catch (ex: MessageSigningException) {
+            assertEquals(MessageSigningException.Reason.SIGNING_KEY_UNAVAILABLE, ex.reason)
+            assertSame(sdkError, ex.cause)
+        }
+    }
+
+    @Test
+    fun `platform-wallet code 2 maps to INVALID_ADDRESS`() = runBlocking {
+        // ErrorInvalidParameter has no dedicated Kotlin type: DashSdkError's
+        // code mapping falls through to Generic(2, …).
+        val sdkError = DashSdkError.PlatformWallet.Generic(
+            PWFFI_ERROR_INVALID_PARAMETER,
+            "invalid address"
+        )
+        val signer = FakeSigner(onSign = { _, _ -> throw sdkError })
+
+        try {
+            sign(signer, "not-an-address", email)
+            fail("expected MessageSigningException")
+        } catch (ex: MessageSigningException) {
+            assertEquals(MessageSigningException.Reason.INVALID_ADDRESS, ex.reason)
+            assertSame(sdkError, ex.cause)
+        }
+    }
+
+    @Test
+    fun `other generic native codes map to UNAVAILABLE`() = runBlocking {
+        val sdkError = DashSdkError.PlatformWallet.Generic(99, "unknown failure")
+        val signer = FakeSigner(onSign = { _, _ -> throw sdkError })
+
+        try {
+            sign(signer, address, email)
+            fail("expected MessageSigningException")
+        } catch (ex: MessageSigningException) {
+            assertEquals(MessageSigningException.Reason.UNAVAILABLE, ex.reason)
+        }
+    }
+
+    @Test
+    fun `an unbootable SDK maps to UNAVAILABLE`() = runBlocking {
+        // What DashSdkMessageSigner raises when ensureStarted() fails or no
+        // single wallet is bound.
+        val boom = IllegalStateException("SDK wallet manager missing after ensureStarted()")
+        val signer = FakeSigner(onSign = { _, _ -> throw boom })
+
+        try {
+            sign(signer, address, email)
+            fail("expected MessageSigningException")
+        } catch (ex: MessageSigningException) {
+            assertEquals(MessageSigningException.Reason.UNAVAILABLE, ex.reason)
+            assertSame(boom, ex.cause)
+        }
+    }
+
+    @Test
+    fun `the surrogate guard surfaces as UNAVAILABLE rather than crashing`() = runBlocking {
+        // The SDK require()s a well-formed message. CrowdNode's messages
+        // (emails, decimal amounts) can never trip this, but the mapping
+        // must still be a typed failure and not an escaping IllegalArgument.
+        val signer = FakeSigner(onSign = { _, _ ->
+            throw IllegalArgumentException("message contains an unpaired surrogate")
+        })
+
+        try {
+            sign(signer, address, "\uD800")
+            fail("expected MessageSigningException")
+        } catch (ex: MessageSigningException) {
+            assertEquals(MessageSigningException.Reason.UNAVAILABLE, ex.reason)
+            assertTrue(ex.cause is IllegalArgumentException)
+        }
+    }
+
+    // ── Structured concurrency ────────────────────────────────────────
+
+    @Test
+    fun `cancellation propagates unwrapped`() {
+        val signer = FakeSigner(onSign = { _, _ -> throw CancellationException("scope cancelled") })
+
+        try {
+            runBlocking { sign(signer, address, email) }
+            fail("expected CancellationException")
+        } catch (ex: CancellationException) {
+            // Wrapping cancellation into MessageSigningException would break
+            // structured concurrency (a cancelled scope must stay cancelled).
+            assertEquals("scope cancelled", ex.message)
+        }
+    }
+}


### PR DESCRIPTION
## What this does

Completes the CrowdNode item of #1520: the integration's one functional dashj
dependency — classic Dash message signing for API withdrawals and email
registration — now routes through the platform Kotlin SDK, and the dormant
on-chain send paths are typed-fenced rather than ported, since CrowdNode has
disabled account creation and deposits service-side and every remaining user
is served by the API path.

Two commits:

**1. `feat(crowdnode): route message signing through the platform SDK`**
- `SecurityFunctions.signMessage` delegates to
  `ManagedPlatformWallet.signMessage(address, message, coreSignerHandle)`
  via a new `SdkMessageSigner` seam (same DI pattern as `SdkL1SendSource`).
  The dashj `ECKey` path, keystore password retrieval, and Kotlin-side key
  derivation are gone from signing; signing authority is the SDK's mnemonic
  resolver, same as SDK sends.
- The old silent `""`-on-missing-key return is replaced by a typed
  `MessageSigningException` (in `:common`, because
  `:integrations:crowdnode` cannot see SDK types) with
  `SIGNING_KEY_UNAVAILABLE` / `INVALID_ADDRESS` / `UNAVAILABLE` reasons and
  the SDK error preserved as cause. A regression test asserts no failure
  mode can ever return an empty string again.
- Fixes a latent crash found while tracing callers: a signing failure during
  withdrawal propagated uncaught (`CrowdNodeApi.withdraw` handled only
  `HttpException`/`UnknownHostException`). One catch arm added, mirroring
  the existing error handling.

**2. `feat(crowdnode): fence the on-chain senders behind a service-status flag`**
- All six senders in `CrowdNodeBlockchainApi` (`topUpAddress`,
  `makeSignUpRequest`, `acceptTerms`, `deposit`, `requestWithdrawal`,
  `resendConfirmationTx`) throw `CrowdNodeServiceUnavailableException`
  before any side effect when `CrowdNodeConstants.SIGNUP_AND_DEPOSITS_ENABLED`
  is false (it is). Original bodies are preserved byte-for-byte below the
  guards — the file's diff is +62/−0 — as the template for a future SDK port.
- The exception extends `CrowdNodeException` deliberately:
  `CrowdNodeConfirmationTxHandler` catches only that type inside a bare
  `handlerScope.launch`, and its existing catch would otherwise misreport a
  "wrong address" error. It gets a dedicated arm.
- UI entry points gated with an honest "CrowdNode is not accepting new
  accounts or deposits" notice (new strings in `strings-crowdnode.xml`),
  consolidating the ad-hoc `isVisible = false` hides that already existed.
- Passive observation (`waitFor*`, deposit/withdrawal history, signup-tx
  restore) is untouched — balance, history, and account restore keep
  working for existing users.

The CrowdNode module now has zero bitcoinj/dashj imports (it was already
insulated behind the `:common` abstractions; this PR removes its last
functional reliance on dashj-backed services).

## Testing

- 32/32 crowdnode module unit tests (10 new signing tests incl. the
  no-empty-string regression guard; 8 new fencing tests incl.
  `verifyNoInteractions(paymentService)` proving the fenced bodies are
  unreached); ktlint clean; `prod` and `_testNet3` flavors compile.
- Checked by hand on **mainnet**: the app signed a withdrawal request with
  the SDK, and CrowdNode's live server accepted the signed message — it
  replied `Received` and gave the message an id. The signature is 65 bytes
  in the same format the old dashj code produced, so CrowdNode cannot tell
  the two apart.
- To get that far, we ran a temporary local build that points the app at a
  wallet address it already owns, standing in for a CrowdNode account,
  because restored wallets do not detect their CrowdNode account on this
  branch (see the comment below). No money moved and no real CrowdNode
  account took part.
- **Nothing further can be tested.** CrowdNode has turned off new signups,
  so we cannot create an account to test against, and email registration
  cannot be reached without a detected account. That leaves the withdrawal
  signature above as the end-to-end evidence.
- **The new withdrawal PIN/biometric prompt is code-verified, not
  field-verified**, for the same reason — it needs an explicit manual check
  on a build where a CrowdNode account is detectable.
- SDK-side: the signing primitive has byte-for-byte dashj parity goldens
  (RFC6979) and landed upstream in dashpay/platform as 92f94526ef + #4321.

## Known limitations

1. **~~The SDK artifact this PR needs is not published yet.~~ RESOLVED.**
   The PR does not change `dashSdkVersion`; the base branch has since moved
   to `0.1.0-v42int4`, which carries the signMessage surface (confirmed in
   the AAR: `ManagedPlatformWallet.signMessage` and `core_wallet_sign_message`
   in `libdash_sdk_jni.so`). No publishing step is outstanding, and the
   earlier pin-requirements comment on this PR is historical.
2. **Signup, deposits, and on-chain withdrawal signals are fenced, not
   ported.** CrowdNode disabled these service-side. Flipping
   `SIGNUP_AND_DEPOSITS_ENABLED` alone will NOT restore them: the send
   cutover fail-closes custom coin selections, and the SDK has no
   `ByAddress`/`ExactOutput` input-pinning surface yet (needs the
   `add_inputs_from_outpoints` JNI binding in dashpay/platform, for which a
   design sketch exists). The preserved bodies are the port template.
3. **`requestWithdrawal` (on-chain signal) had no callers even before this
   PR** — it is fenced like the rest but was already dead code.
4. **Restored wallets do not detect their CrowdNode account on this branch,
   so the signing paths cannot be reached from the UI.** Detection reads the
   dashj transaction store, which no longer receives blocks after the sync
   cutover, so a restored wallet's store stays empty (details in the comment
   below). This is pre-existing and not introduced here, and we are not
   fixing it in this PR. It goes away in the SDK-only end state. A
   `SIGNING_KEY_UNAVAILABLE` TODO in `SecurityFunctions` records the related
   key-derivation window without working around it.
   *(An earlier revision of this entry argued the restore case could not be
   stranded; device testing disproved that, and this text replaces it.)*
5. **Pre-existing bugs observed but out of scope** (unreachable while the
   gate is closed): `TransferFragment.handleDeposit` shows the success
   screen regardless of the deposit result, and `BlockchainServiceImpl`
   injects `CrowdNodeBlockchainApi` without using it. Also,
   `SecurityFunctions` logs under `SendCoinsTaskRunner`'s logger category.
6. **No automated test runs against CrowdNode's API.** The server accepting
   our signature was checked by hand on mainnet (see Testing). The automated
   tests stop at the edge of the module, with the network calls mocked, and
   for the reasons above they cannot go further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
