### PR TITLE
fix: re-sweep and durably invalidate DashPay backfill coverage when contact accounts register after the scan

### DIFF
--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/DashPayBackfillGate.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/DashPayBackfillGate.kt
@@ -830,8 +830,24 @@ interface DashPayBackfillGate {
      * accounts. Any positive count means the last sweep reconciled the rewind
      * before those accounts existed, so another sweep is owed; see
      * [decideDashPayBackfill]. Zero is ignored. Never throws.
+     *
+     * Accepting the registrations also DURABLY invalidates any persisted
+     * coverage — the same four-key removal the address-window heal performs
+     * ([SdkWalletBinder.maybeWidenAddressWindows]). The in-memory re-provision
+     * signal dies with the process, and a recorded coverage describes a scan
+     * that ran WITHOUT the just-registered accounts' addresses in the watched
+     * script set: surviving a crash between the drain and the follow-up
+     * sweep, it would suppress the backfill those accounts are owed on every
+     * later launch. The clear lands BEFORE this call returns — i.e. before
+     * any follow-up sweep the caller runs on the verdict — so a process death
+     * in between self-heals on the next launch.
+     *
+     * @return true when the registrations were accepted as NEW — a follow-up
+     *   sweep is owed for them and the caller may run one now; false for
+     *   zero/negative counts and for re-builds muted by the per-process loop
+     *   guard (see [DashPayBackfillGateImpl.buildsNotedThisProcess]).
      */
-    fun noteAccountBuildsRegistered(built: Int)
+    suspend fun noteAccountBuildsRegistered(built: Int): Boolean
 
     /**
      * The persisted bookkeeping, for consumers that must not treat a
@@ -855,7 +871,9 @@ interface DashPayBackfillGate {
      * anything IS accounted for, so still being unaccounted-for after several
      * minutes of polling is itself the evidence that no rewind is coming.
      * Re-checks the height and fingerprint itself and refuses if a rewind did
-     * land. Returns whether coverage was recorded. Never throws.
+     * land — or if account builds were registered since the last sweep (a
+     * sweep is then still OWED, so quiet is not evidence of anything).
+     * Returns whether coverage was recorded. Never throws.
      */
     suspend fun concludeNoRewindObserved(
         walletIdHex: String,
@@ -885,7 +903,8 @@ interface DashPayBackfillGate {
             // Nothing is ever armed, so there is never anything to watch for.
             override suspend fun isRewindAccountedFor() = true
 
-            override fun noteAccountBuildsRegistered(built: Int) = Unit
+            // Nothing is recorded, so nothing is owed a follow-up sweep.
+            override suspend fun noteAccountBuildsRegistered(built: Int) = false
 
             // Nothing is ever recorded, so nothing is ever owed.
             override suspend fun readBackfillStatus() = DashPayBackfillStatus.SETTLED
@@ -960,8 +979,8 @@ class DashPayBackfillGateImpl @Inject constructor(
      */
     private val buildsNotedThisProcess = java.util.concurrent.atomic.AtomicInteger(0)
 
-    override fun noteAccountBuildsRegistered(built: Int) {
-        if (built <= 0) return
+    override suspend fun noteAccountBuildsRegistered(built: Int): Boolean {
+        if (built <= 0) return false
         val cap = lastObservation.sdkContactCount
         if (cap > 0 && buildsNotedThisProcess.get() >= cap) {
             log.info(
@@ -970,7 +989,7 @@ class DashPayBackfillGateImpl @Inject constructor(
                     "already-swept accounts, NOT raising the re-provision signal (loop guard)",
                 built, buildsNotedThisProcess.get(), cap
             )
-            return
+            return false
         }
         buildsNotedThisProcess.addAndGet(built)
         if (accountsRegisteredSincePass.compareAndSet(false, true)) {
@@ -982,6 +1001,34 @@ class DashPayBackfillGateImpl @Inject constructor(
                 built
             )
         }
+        // The DURABLE half (see the interface KDoc): the flag above dies with
+        // the process, so a persisted coverage record — written over a scan
+        // that never watched these accounts' addresses — must be invalidated
+        // in the store NOW, before the caller's follow-up sweep gets a chance
+        // to run. A crash between this drain and that sweep then self-heals:
+        // the next launch finds no coverage and provisions again. Same
+        // four-key removal as the address-window heal's invalidation.
+        try {
+            if (readCoverage() != null) {
+                clearCoverage()
+                log.info(
+                    "DashPay coreHeight backfill coverage invalidated — receival account(s) " +
+                        "registered after it was recorded; the next gate pass rewinds with " +
+                        "the enlarged script set"
+                )
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // The in-memory signal still forces the next in-process
+            // consultation; only crash-durability is degraded. Never throw —
+            // the drain path must survive a store hiccup.
+            log.warn(
+                "failed to durably invalidate the DashPay backfill coverage; the in-memory " +
+                    "registration signal still forces a re-sweep this process", e
+            )
+        }
+        return true
     }
 
     /**
@@ -1141,6 +1188,21 @@ class DashPayBackfillGateImpl @Inject constructor(
             armed == null -> false
             // Something already accounted for the pass; leave it alone.
             readInProgress() != null || readCoverage() != null -> false
+            // A receival account registered since the last sweep is POSITIVE
+            // evidence a sweep is still owed — "no rewind observed" cannot
+            // mean "none was needed" while the sweep that would fire it has
+            // not run. Recording coverage here would suppress exactly the
+            // backfill that account needs (forever, if a crash then loses
+            // the in-memory signal before the owed sweep runs). Refusing
+            // leaves the armed marker, so the next consultation provisions.
+            accountsRegisteredSincePass.get() -> {
+                log.info(
+                    "DashPay coreHeight backfill: NOT concluding no-rewind — account build(s) " +
+                        "were registered since the last sweep, so a sweep (and possibly its " +
+                        "rewind) is still owed; leaving the armed marker in place"
+                )
+                false
+            }
             else -> {
                 val signals = sdkService.readDashPayBackfillSignals(walletIdHex, ownerIdentityId)
                 val height = signals.syncedHeight

--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/DashPayBackfillGate.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/DashPayBackfillGate.kt
@@ -20,6 +20,8 @@ package de.schildbach.wallet.service.platform.sdk
 import de.schildbach.wallet.database.dao.DashPayContactRequestDao
 import de.schildbach.wallet.ui.dashpay.utils.DashPayConfig
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.slf4j.LoggerFactory
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
@@ -842,6 +844,14 @@ interface DashPayBackfillGate {
      * any follow-up sweep the caller runs on the verdict — so a process death
      * in between self-heals on the next launch.
      *
+     * Raising the signal and invalidating the coverage are ONE atomic step
+     * against every coverage write this gate makes (see
+     * [DashPayBackfillGateImpl.coverageMutex]), so a concurrent conclusion
+     * cannot slip a coverage record between them. A store failure degrades
+     * the durable half to in-memory only — logged, and re-attempted by the
+     * follow-up sweep an accepted verdict buys, whose [evaluate] discards
+     * coverage on the registration signal.
+     *
      * @return true when the registrations were accepted as NEW — a follow-up
      *   sweep is owed for them and the caller may run one now; false for
      *   zero/negative counts and for re-builds muted by the per-process loop
@@ -979,8 +989,37 @@ class DashPayBackfillGateImpl @Inject constructor(
      */
     private val buildsNotedThisProcess = java.util.concurrent.atomic.AtomicInteger(0)
 
+    /**
+     * Serializes the registration signal against every persisted-coverage
+     * mutation this gate makes ([evaluate]'s decision, [recordPassOutcome]'s
+     * pass outcome and [concludeNoRewindObserved]'s conclusion).
+     *
+     * Without it the two halves of [noteAccountBuildsRegistered] — raise the
+     * in-memory signal, invalidate the durable coverage — can interleave with
+     * a conclusion that has ALREADY read the signal as clear: the
+     * registration finds no coverage to invalidate, and the conclusion then
+     * writes coverage over a scan that never watched the just-registered
+     * accounts' addresses. In-process the signal still forces the re-sweep,
+     * but a process death loses it and leaves exactly the stale coverage this
+     * class exists to prevent — permanently suppressing the backfill those
+     * accounts are owed.
+     *
+     * Under the lock that interleaving cannot exist: a registration landing
+     * BEFORE a write is seen by the writer's own re-check (which then
+     * refuses), and one landing AFTER it sees the record and clears it.
+     *
+     * Held over the persistence steps only — never over the native signal
+     * read or the contact-table read — so a drain never waits on the SDK.
+     */
+    private val coverageMutex = Mutex()
+
     override suspend fun noteAccountBuildsRegistered(built: Int): Boolean {
         if (built <= 0) return false
+        return coverageMutex.withLock { noteAccountBuildsRegisteredLocked(built) }
+    }
+
+    /** [noteAccountBuildsRegistered]'s body, under [coverageMutex]. */
+    private suspend fun noteAccountBuildsRegisteredLocked(built: Int): Boolean {
         val cap = lastObservation.sdkContactCount
         if (cap > 0 && buildsNotedThisProcess.get() >= cap) {
             log.info(
@@ -1007,7 +1046,9 @@ class DashPayBackfillGateImpl @Inject constructor(
         // in the store NOW, before the caller's follow-up sweep gets a chance
         // to run. A crash between this drain and that sweep then self-heals:
         // the next launch finds no coverage and provisions again. Same
-        // four-key removal as the address-window heal's invalidation.
+        // four-key removal as the address-window heal's invalidation. Atomic
+        // with the signal above ([coverageMutex]), so a conclusion racing
+        // this drain cannot write its coverage into the gap between them.
         try {
             if (readCoverage() != null) {
                 clearCoverage()
@@ -1094,40 +1135,47 @@ class DashPayBackfillGateImpl @Inject constructor(
             )
             lastObservation = observation
 
-            val coverage = readCoverage()
-            val inProgress = readInProgress()
-            val armed = readArmed()
-            val decision = decideDashPayBackfill(
-                observation, coverage, inProgress, armed, hasProvisionedInProcess.get(),
-                accountsRegisteredSincePass.get()
-            )
-            // Persist the bookkeeping — including the armed marker on a
-            // shouldRun=true decision — BEFORE returning, so the pass this
-            // decision permits is on record even if the process dies mid-pass.
-            applyDecision(decision)
+            // Read → decide → persist as ONE step against the registration
+            // signal (see [coverageMutex]): the "backfill COMPLETE" branch
+            // WRITES coverage, so a registration interleaving here would
+            // invalidate a record this decision immediately rewrites, leaving
+            // coverage for a scan the new accounts' addresses were absent from.
+            coverageMutex.withLock {
+                val coverage = readCoverage()
+                val inProgress = readInProgress()
+                val armed = readArmed()
+                val decision = decideDashPayBackfill(
+                    observation, coverage, inProgress, armed, hasProvisionedInProcess.get(),
+                    accountsRegisteredSincePass.get()
+                )
+                // Persist the bookkeeping — including the armed marker on a
+                // shouldRun=true decision — BEFORE returning, so the pass this
+                // decision permits is on record even if the process dies mid-pass.
+                applyDecision(decision)
 
-            // The per-launch line the next tester log has to be unambiguous
-            // about: the floor, what was persisted, and what we did about it.
-            log.info(
-                "DashPay coreHeight backfill gate: floor(min coreHeightCreatedAt over {} SDK " +
-                    "contact request(s))={} (received-only floor={}), syncedHeight={}, " +
-                    "persistedCoverage={}, persistedInProgress={}, persistedArmed={}, " +
-                    "appContactSet={} -> {} ({})",
-                observation.sdkContactCount,
-                observation.sdkContactFloor ?: "unknown",
-                observation.sdkReceivedContactFloor ?: "unknown",
-                observation.syncedHeight ?: "unknown",
-                coverage?.let {
-                    "floor=${it.floor}(${if (it.observedFloor) "observed" else "assumed"})" +
-                        "/completedThrough=${it.completedThroughHeight}"
-                } ?: "none",
-                inProgress?.let { "floor=${it.floor}/target=${it.targetHeight}" } ?: "none",
-                armed?.let { "target=${it.targetHeight}" } ?: "none",
-                observation.contactFingerprint ?: "unknown",
-                if (decision.shouldRun) "FORCING REWIND" else "SKIPPING REWIND",
-                decision.reason
-            )
-            decision
+                // The per-launch line the next tester log has to be unambiguous
+                // about: the floor, what was persisted, and what we did about it.
+                log.info(
+                    "DashPay coreHeight backfill gate: floor(min coreHeightCreatedAt over {} SDK " +
+                        "contact request(s))={} (received-only floor={}), syncedHeight={}, " +
+                        "persistedCoverage={}, persistedInProgress={}, persistedArmed={}, " +
+                        "appContactSet={} -> {} ({})",
+                    observation.sdkContactCount,
+                    observation.sdkContactFloor ?: "unknown",
+                    observation.sdkReceivedContactFloor ?: "unknown",
+                    observation.syncedHeight ?: "unknown",
+                    coverage?.let {
+                        "floor=${it.floor}(${if (it.observedFloor) "observed" else "assumed"})" +
+                            "/completedThrough=${it.completedThroughHeight}"
+                    } ?: "none",
+                    inProgress?.let { "floor=${it.floor}/target=${it.targetHeight}" } ?: "none",
+                    armed?.let { "target=${it.targetHeight}" } ?: "none",
+                    observation.contactFingerprint ?: "unknown",
+                    if (decision.shouldRun) "FORCING REWIND" else "SKIPPING REWIND",
+                    decision.reason
+                )
+                decision
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -1157,15 +1205,24 @@ class DashPayBackfillGateImpl @Inject constructor(
                 .syncedHeight
             val outcome = decideDashPayBackfillPassOutcome(before, after, report, firstPass)
 
-            outcome.inProgressToWrite?.let { writeInProgress(it) }
-            outcome.coverageToWrite?.let {
-                writeCoverage(it)
-                clearInProgress()
+            // Under the same lock as the registration signal (see
+            // [coverageMutex]) so a concurrent drain's invalidation cannot
+            // land in the middle of this record. No registration re-check
+            // here, deliberately: the note above is this pass's OWN drain,
+            // and the coverage branch is reachable only for a settled sweep
+            // (pendingBefore == 0 && !drainScheduled) that built nothing —
+            // re-checking would make it unreachable instead.
+            coverageMutex.withLock {
+                outcome.inProgressToWrite?.let { writeInProgress(it) }
+                outcome.coverageToWrite?.let {
+                    writeCoverage(it)
+                    clearInProgress()
+                }
+                // AFTER the latch/coverage write: a crash in between leaves
+                // both the marker and the watch behind, which the decision
+                // core resolves toward re-running — never a silent skip.
+                if (outcome.clearArmed) clearArmed()
             }
-            // AFTER the latch/coverage write: a crash in between leaves both
-            // the marker and the watch behind, which the decision core
-            // resolves toward re-running — never toward a silent skip.
-            if (outcome.clearArmed) clearArmed()
             log.info("DashPay coreHeight backfill pass outcome: {}", outcome.reason)
         } catch (e: CancellationException) {
             throw e
@@ -1242,26 +1299,7 @@ class DashPayBackfillGateImpl @Inject constructor(
                             )
                             false
                         } else {
-                            writeCoverage(
-                                BackfillCoverage(
-                                    floor = height,
-                                    completedThroughHeight = height,
-                                    contactFingerprint = fingerprint,
-                                    // ASSUMED: no rewind was ever observed.
-                                    observedFloor = false
-                                )
-                            )
-                            clearArmed()
-                            log.info(
-                                "DashPay coreHeight backfill: armed pass (target {}) produced " +
-                                    "no rewind across the whole observation window and the " +
-                                    "contact set is unchanged — nothing needed backfilling; " +
-                                    "recording coverage at height {} so later launches stop " +
-                                    "re-provisioning",
-                                armed.targetHeight,
-                                height
-                            )
-                            true
+                            recordNoRewindCoverage(armed.targetHeight, height, fingerprint)
                         }
                     }
                 }
@@ -1272,6 +1310,66 @@ class DashPayBackfillGateImpl @Inject constructor(
     } catch (e: Exception) {
         log.warn("failed to conclude the no-rewind outcome; the next launch will re-provision", e)
         false
+    }
+
+    /**
+     * [concludeNoRewindObserved]'s persisting tail: record ASSUMED coverage at
+     * [height], drop the armed marker — under [coverageMutex] and behind a
+     * final re-check of everything the conclusion rests on.
+     *
+     * The re-check is the point. The reads the conclusion reasoned over are
+     * unlocked and include a native signal read, so a drain can register
+     * receival accounts — or a pass can latch a real rewind — while it is
+     * being reasoned out. The registration case is the dangerous one:
+     * coverage written then describes a scan those accounts' addresses were
+     * never matched against, and once the process dies with the in-memory
+     * signal it suppresses their backfill on every later launch. Refusing
+     * leaves the armed marker, so the next consultation provisions again.
+     *
+     * @return whether coverage was recorded.
+     */
+    private suspend fun recordNoRewindCoverage(
+        armedTarget: Long,
+        height: Long,
+        fingerprint: String
+    ): Boolean = coverageMutex.withLock {
+        if (accountsRegisteredSincePass.get()) {
+            log.info(
+                "DashPay coreHeight backfill: NOT concluding no-rewind for the armed pass " +
+                    "(target {}) after all — account build(s) registered while the conclusion " +
+                    "was being reasoned out, so a sweep is still owed; leaving the armed marker",
+                armedTarget
+            )
+            return@withLock false
+        }
+        if (readInProgress() != null || readCoverage() != null) {
+            log.info(
+                "DashPay coreHeight backfill: NOT concluding no-rewind for the armed pass " +
+                    "(target {}) after all — the pass was accounted for while the conclusion " +
+                    "was being reasoned out",
+                armedTarget
+            )
+            return@withLock false
+        }
+        writeCoverage(
+            BackfillCoverage(
+                floor = height,
+                completedThroughHeight = height,
+                contactFingerprint = fingerprint,
+                // ASSUMED: no rewind was ever observed.
+                observedFloor = false
+            )
+        )
+        clearArmed()
+        log.info(
+            "DashPay coreHeight backfill: armed pass (target {}) produced no rewind across the " +
+                "whole observation window and the contact set is unchanged — nothing needed " +
+                "backfilling; recording coverage at height {} so later launches stop " +
+                "re-provisioning",
+            armedTarget,
+            height
+        )
+        true
     }
 
     override suspend fun isRewindAccountedFor(): Boolean = try {

--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/DashSdkService.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/DashSdkService.kt
@@ -163,6 +163,35 @@ data class DashPayContactDrainReport(
 }
 
 /**
+ * How completely the bound SDK wallet's DIP-15 receival accounts cover its
+ * established (RECEIVED-request) DashPay contacts — the drain-time
+ * diagnostic that names the DARK contacts: an established contact with NO
+ * `dashpayReceivingFunds` account has its receiving addresses in no watched
+ * script set, so its payments can never match a filter. Under the SDK's
+ * known re-enqueue asymmetry such a contact can stay dark PERMANENTLY (the
+ * sweep re-enqueues builds per contact, but a build that keeps failing is
+ * indistinguishable from one that merely has not run yet), and this report
+ * is what lets a field log say exactly which contact is stuck.
+ *
+ * Pure Room reads, diagnostics only — never load-bearing for the gate.
+ */
+data class DashPayReceivalCoverage(
+    /** Distinct contact identities with a RECEIVED contact request (the receival-account universe). */
+    val establishedContacts: Int,
+    /** Registered `dashpayReceivingFunds` accounts on the bound wallet. */
+    val receivalAccounts: Int,
+    /** Established contacts with NO receival account — the permanently-dark candidates. */
+    val darkContacts: Int,
+    /** Up to [DARK_CONTACT_SAMPLE_LIMIT] dark contact identity ids (base58, untruncated). */
+    val darkContactIdSample: List<String>
+) {
+    companion object {
+        /** Sample size for [darkContactIdSample] — enough to name the stuck contacts, bounded for one log line. */
+        const val DARK_CONTACT_SAMPLE_LIMIT = 5
+    }
+}
+
+/**
  * The two read-only signals the app-side DIP-15 backfill gate
  * ([DashPayBackfillGate]) needs to tell "the coreHeight backfill is still
  * running" from "it has provably finished", WITHOUT any SDK change.
@@ -632,6 +661,23 @@ interface DashSdkService {
      * "none queued".
      */
     suspend fun dashPayPendingAccountBuilds(walletIdHex: String): Int?
+
+    /**
+     * Read-only receival-account coverage of the wallet's established
+     * DashPay contacts — see [DashPayReceivalCoverage] for what it names and
+     * why. Pure Room reads through [databaseOrNull] (no [ensureStarted], no
+     * native call, no sweep — the same posture as
+     * [readDashPayBackfillSignals]); null when the SDK is down, the wallet id
+     * is malformed, or the read failed. Never throws. Default null so
+     * read-only fakes stay source-compatible.
+     *
+     * @param walletIdHex the bound wallet id ([bindAppWallet]'s return).
+     * @param ownerIdentityId our 32-byte platform identity id.
+     */
+    suspend fun readDashPayReceivalCoverage(
+        walletIdHex: String,
+        ownerIdentityId: ByteArray
+    ): DashPayReceivalCoverage? = null
 
     /**
      * Read-only snapshot of the two signals the app-side DIP-15 backfill

--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/DashSdkServiceImpl.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/DashSdkServiceImpl.kt
@@ -310,6 +310,40 @@ internal suspend fun healIdentityKeys(
 }
 
 /**
+ * Fold the SDK's persisted DashPay rows into a [DashPayReceivalCoverage] —
+ * pure (no Room, no native, no I/O) so the dark-contact set logic is
+ * host-testable on the plain JVM.
+ *
+ * [receivedContactIds] are the contact identity ids of the owner's RECEIVED
+ * contact requests (the receival-account universe; duplicates collapse), and
+ * [receivalAccountFriendIds] the `friendIdentityId`s of the wallet's
+ * registered `dashpayReceivingFunds` accounts. A contact with no matching
+ * account is DARK: its receiving addresses are in no watched script set, so
+ * its payments can never match a filter. Ids compare byte-wise; the sample
+ * is base58 (the same encoding the app's userId and the SDK's identity row
+ * keys use), in the order the contact rows were supplied — deterministic, so
+ * consecutive drains name the same stuck contacts.
+ */
+internal fun computeDashPayReceivalCoverage(
+    receivedContactIds: List<ByteArray>,
+    receivalAccountFriendIds: List<ByteArray>,
+    sampleLimit: Int = DashPayReceivalCoverage.DARK_CONTACT_SAMPLE_LIMIT
+): DashPayReceivalCoverage {
+    val covered = receivalAccountFriendIds.mapTo(HashSet()) { it.toList() }
+    val contacts = LinkedHashSet<List<Byte>>()
+    receivedContactIds.forEach { contacts.add(it.toList()) }
+    val dark = contacts.filter { it !in covered }
+    return DashPayReceivalCoverage(
+        establishedContacts = contacts.size,
+        receivalAccounts = receivalAccountFriendIds.size,
+        darkContacts = dark.size,
+        darkContactIdSample = dark.take(sampleLimit).map {
+            org.bitcoinj.core.Base58.encode(it.toByteArray())
+        }
+    )
+}
+
+/**
  * Default [DashSdkService] implementation — the Phase 3 bootstrap scaffold
  * (`docs/kotlin-sdk-migration-plan.md`).
  *
@@ -994,6 +1028,42 @@ class DashSdkServiceImpl @Inject constructor(
                 walletIdHex.take(8), e
             )
             DashPayBackfillSignals.UNKNOWN
+        }
+    }
+
+    /**
+     * See [DashSdkService.readDashPayReceivalCoverage]. Pure Room reads via
+     * [databaseOrNull] — the same posture as [readDashPayBackfillSignals]:
+     * no [ensureStarted], no native call, no sweep. Established contacts =
+     * distinct RECEIVED (`isOutgoing == false`) contact-request senders;
+     * receival accounts = the wallet's `dashpayReceivingFunds` rows
+     * ([ACCOUNT_TYPE_TAG_DASHPAY_RECEIVING_FUNDS]), matched by their
+     * `friendIdentityId`. Never throws — null means "unavailable".
+     */
+    override suspend fun readDashPayReceivalCoverage(
+        walletIdHex: String,
+        ownerIdentityId: ByteArray
+    ): DashPayReceivalCoverage? {
+        return try {
+            val database = databaseOrNull() ?: return null
+            val walletId = walletIdFromHex(walletIdHex) ?: return null
+            val receivedContactIds = database.dashpayDao()
+                .getContactRequestsByOwner(ownerIdentityId)
+                .filterNot { it.isOutgoing }
+                .map { it.contactIdentityId }
+            val receivalFriendIds = database.accountDao()
+                .observeByWallet(walletId).first()
+                .filter { it.accountType == ACCOUNT_TYPE_TAG_DASHPAY_RECEIVING_FUNDS }
+                .mapNotNull { it.friendIdentityId }
+            computeDashPayReceivalCoverage(receivedContactIds, receivalFriendIds)
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.debug(
+                "failed to read DashPay receival coverage for {}…: {}",
+                walletIdHex.take(8), e.message
+            )
+            null
         }
     }
 

--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/SdkWalletBinder.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/SdkWalletBinder.kt
@@ -594,14 +594,69 @@ class SdkWalletBinder internal constructor(
                         // short — and before this, the queue was only ever
                         // drained on a pass the gate allowed through, i.e. on
                         // almost no launch after the first.
-                        drainDeferredAccountBuilds(walletId)
+                        val registeredNew = drainDeferredAccountBuilds(walletId, identityId)
+                        // Post-drain follow-up sweep, at most ONE per cycle:
+                        // accounts this drain just REGISTERED were not there
+                        // when any sweep's rescan reconcile ran, so the SDK's
+                        // per-contact rescan guard has never fired for them.
+                        // The gate's registration signal is set (and its
+                        // coverage durably invalidated) by the note inside
+                        // the drain — consult it again and give the reconcile
+                        // its second look NOW, in this same cycle, instead of
+                        // leaving the money invisible until a relaunch.
+                        if (registeredNew) {
+                            val followUp = backfillGate.evaluate(walletId, identityId, userId)
+                            if (followUp.shouldRun) {
+                                if (followUp.armedToWrite != null) armedRewind = true
+                                log.info(
+                                    "DashPay follow-up sweep on {}…: the drain registered " +
+                                        "receival account(s) no sweep's rescan reconcile has " +
+                                        "seen — sweeping again in this cycle",
+                                    walletId.take(8)
+                                )
+                                runProvisioningSweep(walletId, identityId)
+                            } else {
+                                // e.g. a backfill replay in flight, which a
+                                // registration must never interrupt. The debt
+                                // is recorded (durably invalidated coverage +
+                                // the in-memory signal) for a later pass.
+                                log.info(
+                                    "DashPay follow-up sweep withheld on {}…: {} — the " +
+                                        "registration debt stays recorded for a later pass",
+                                    walletId.take(8), followUp.reason
+                                )
+                            }
+                        }
+                        if (armedRewind) {
+                            watchArmedBackfillRewind(walletId, identityId, userId)
+                        }
                         return
                     }
                     armedRewind = decision.armedToWrite != null
                 }
 
-                val report = sdkService.provisionDashPayContactAccounts(walletId)
-                identityId?.let { backfillGate.recordPassOutcome(walletId, it, report) }
+                val registrationOutstanding = runProvisioningSweep(walletId, identityId)
+                // Post-drain follow-up sweep (run path), at most ONE per
+                // cycle: this pass's own step-2 drain registered receival
+                // accounts AFTER its sweep reconciled the rewind — the exact
+                // ordering defect behind the restored-wallet dark contacts
+                // (sweep at 17:20:08 against zero accounts, 29 registered
+                // 17:20:11–31, no rewind until a manual restart). The gate's
+                // registration branches turn the signal recordPassOutcome
+                // re-raised into a permitted, re-armed pass.
+                if (registrationOutstanding && identityId != null) {
+                    val followUp = backfillGate.evaluate(walletId, identityId, userId)
+                    if (followUp.shouldRun) {
+                        if (followUp.armedToWrite != null) armedRewind = true
+                        log.info(
+                            "DashPay follow-up sweep on {}…: this pass's drain registered " +
+                                "receival account(s) after its sweep reconciled — sweeping " +
+                                "again in this cycle",
+                            walletId.take(8)
+                        )
+                        runProvisioningSweep(walletId, identityId)
+                    }
+                }
                 // The pass we just armed rewinds the SPV synced height, but the
                 // drop only becomes DURABLE ~9-60 s later, and it stays visible
                 // only until the scan climbs back out of it. recordPassOutcome
@@ -612,30 +667,6 @@ class SdkWalletBinder internal constructor(
                 // launch re-ran the whole rewind, forever. Poll for it instead.
                 if (armedRewind && identityId != null) {
                     watchArmedBackfillRewind(walletId, identityId, userId)
-                }
-                // The sweep is a long native op: its SDK lines sat in the
-                // logcat buffer until the bridge's next 30 s / 5 min poll and
-                // were routinely rolled over before then. Pull them into
-                // wallet.log NOW, while they are still there — cheap,
-                // bounded, never throws, and we are on a background
-                // coroutine, not the main thread.
-                NativeLogBridge.drainNow()
-                when {
-                    !report.bound -> log.debug(
-                        "DashPay friend-chain provisioning: SDK wallet {}… not loaded yet",
-                        walletId.take(8)
-                    )
-                    report.pendingBefore > 0 || report.drainScheduled -> log.info(
-                        "DashPay friend-chain provisioning on {}…: sweep ok={}/err={}, " +
-                            "{} account build(s) queued, drainScheduled={}",
-                        walletId.take(8), report.syncSuccess, report.syncErrors,
-                        report.pendingBefore, report.drainScheduled
-                    )
-                    else -> log.debug(
-                        "DashPay friend-chain provisioning on {}…: steady " +
-                            "(sweep ok={}/err={}, nothing queued)",
-                        walletId.take(8), report.syncSuccess, report.syncErrors
-                    )
                 }
             } finally {
                 provisioning.set(false)
@@ -648,6 +679,87 @@ class SdkWalletBinder internal constructor(
                     "discovery may lag until the next pass",
                 t
             )
+        }
+    }
+
+    /**
+     * One provisioning pass — the SDK sweep + drain
+     * ([DashSdkService.provisionDashPayContactAccounts]) with its gate
+     * accounting, wallet.log lines and post-drain receival-coverage
+     * diagnostics. Throws freely; the caller
+     * ([provisionContactAccountsIfEnabled]) contains the fallout.
+     *
+     * @return whether the pass's own drain left a registration OUTSTANDING —
+     *   the gate's signal, consumed and then re-raised from the pass's built
+     *   count by [DashPayBackfillGate.recordPassOutcome] — i.e. whether a
+     *   follow-up sweep is owed. Always false without an identity, and with
+     *   a gate that records nothing ([DashPayBackfillGate.ALWAYS_RUN]).
+     */
+    private suspend fun runProvisioningSweep(walletId: String, identityId: ByteArray?): Boolean {
+        val report = sdkService.provisionDashPayContactAccounts(walletId)
+        identityId?.let { backfillGate.recordPassOutcome(walletId, it, report) }
+        // The sweep is a long native op: its SDK lines sat in the
+        // logcat buffer until the bridge's next 30 s / 5 min poll and
+        // were routinely rolled over before then. Pull them into
+        // wallet.log NOW, while they are still there — cheap,
+        // bounded, never throws, and we are on a background
+        // coroutine, not the main thread.
+        NativeLogBridge.drainNow()
+        when {
+            !report.bound -> log.debug(
+                "DashPay friend-chain provisioning: SDK wallet {}… not loaded yet",
+                walletId.take(8)
+            )
+            report.pendingBefore > 0 || report.drainScheduled -> log.info(
+                "DashPay friend-chain provisioning on {}…: sweep ok={}/err={}, " +
+                    "{} account build(s) queued, drainScheduled={}",
+                walletId.take(8), report.syncSuccess, report.syncErrors,
+                report.pendingBefore, report.drainScheduled
+            )
+            else -> log.debug(
+                "DashPay friend-chain provisioning on {}…: steady " +
+                    "(sweep ok={}/err={}, nothing queued)",
+                walletId.take(8), report.syncSuccess, report.syncErrors
+            )
+        }
+        if (identityId != null && report.bound) {
+            logReceivalCoverageDiagnostics(walletId, identityId)
+        }
+        return identityId != null && backfillGate.readBackfillStatus().registrationOutstanding
+    }
+
+    /**
+     * The dark-contact diagnostic, one line per drain: how many established
+     * contacts have NO receival account. Such a contact's receiving addresses
+     * are in no watched script set, and under the SDK's re-enqueue asymmetry
+     * a build that keeps failing is re-enqueued forever without ever
+     * registering — so a delta that persists across drains is the fingerprint
+     * of a PERMANENTLY dark contact, and the sampled ids let a field log name
+     * exactly which one is stuck. Never throws; an unavailable read logs
+     * nothing (the drain line above it already proves the pass ran).
+     */
+    private suspend fun logReceivalCoverageDiagnostics(walletId: String, identityId: ByteArray) {
+        try {
+            val coverage = sdkService.readDashPayReceivalCoverage(walletId, identityId) ?: return
+            val sample = if (coverage.darkContactIdSample.isEmpty()) {
+                ""
+            } else {
+                coverage.darkContactIdSample.joinToString(
+                    prefix = " [", separator = ", ",
+                    postfix = if (coverage.darkContacts > coverage.darkContactIdSample.size) ", …]" else "]"
+                ) { "${it.take(8)}…" }
+            }
+            log.info(
+                "DashPay receival-account coverage on {}…: establishedContacts={}, " +
+                    "receivalAccounts={}, dark={}{} — a dark contact's receiving addresses " +
+                    "are in no watched script set (permanently-dark candidate under the SDK's " +
+                    "re-enqueue asymmetry)",
+                walletId.take(8), coverage.establishedContacts, coverage.receivalAccounts,
+                coverage.darkContacts, sample
+            )
+        } catch (t: Throwable) {
+            if (t is CancellationException) throw t
+            log.debug("receival-coverage diagnostics unavailable: {}", t.message)
         }
     }
 
@@ -667,9 +779,15 @@ class SdkWalletBinder internal constructor(
      *
      * Never throws: an unavailable drain (locked device, seed verify) is a
      * normal state and the queue survives for the next pass.
+     *
+     * @return whether the drain's registrations were accepted as NEW by the
+     *   gate ([DashPayBackfillGate.noteAccountBuildsRegistered] — which has
+     *   also durably invalidated any recorded coverage by the time it
+     *   answers), i.e. whether a follow-up sweep is owed in THIS cycle.
+     *   False for an empty/muted/failed drain.
      */
-    private suspend fun drainDeferredAccountBuilds(walletId: String) {
-        try {
+    private suspend fun drainDeferredAccountBuilds(walletId: String, identityId: ByteArray): Boolean {
+        return try {
             val report = sdkService.drainDashPayContactAccountBuilds(walletId)
             log.info(
                 "DashPay account-build drain on {}…: {}",
@@ -677,9 +795,14 @@ class SdkWalletBinder internal constructor(
             )
             // Accounts that only exist NOW were not there when the last sweep
             // reconciled the DIP-15 rewind, so a sweep is owed for them; the
-            // gate turns this into a re-provision on its next consultation
-            // instead of leaving the money invisible until a relaunch.
-            backfillGate.noteAccountBuildsRegistered(report.built)
+            // gate records that debt durably (coverage invalidation) and its
+            // verdict lets THIS cycle pay it with a follow-up sweep instead
+            // of leaving the money invisible until a relaunch.
+            val registeredNew = backfillGate.noteAccountBuildsRegistered(report.built)
+            if (report.bound) {
+                logReceivalCoverageDiagnostics(walletId, identityId)
+            }
+            registeredNew
         } catch (t: Throwable) {
             if (t is CancellationException) throw t
             log.warn(
@@ -687,6 +810,7 @@ class SdkWalletBinder internal constructor(
                     "unwatched until the next pass",
                 t
             )
+            false
         }
     }
 

--- a/wallet/test/de/schildbach/wallet/service/platform/sdk/DashPayBackfillGateTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/platform/sdk/DashPayBackfillGateTest.kt
@@ -22,6 +22,9 @@ import de.schildbach.wallet.database.dao.DashPayContactRequestDao
 import de.schildbach.wallet.ui.dashpay.utils.DashPayConfig
 import io.mockk.coEvery
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -1308,6 +1311,102 @@ class DashPayBackfillGateTest {
         assertFalse(gate.concludeNoRewindObserved(walletId, identityId, userId))
         assertNull(store.values[DashPayConfig.DASHPAY_BACKFILL_COVERED_FLOOR])
         // The marker survives, so the next launch provisions again.
+        assertEquals(1_000_000L, store.values[DashPayConfig.DASHPAY_BACKFILL_ARMED_TARGET])
+    }
+
+    // ── registration racing the conclusion (the barrier cases) ───────────
+
+    /**
+     * An SDK fake whose signal read parks on [reached]/[resume] — the seam
+     * inside [DashPayBackfillGateImpl.concludeNoRewindObserved] between its
+     * registration check and its coverage write, where a concurrent drain
+     * lands in the field.
+     */
+    private fun barrierSdk(
+        signals: DashPayBackfillSignals,
+        reached: CompletableDeferred<Unit>,
+        resume: CompletableDeferred<Unit>
+    ): DashSdkService = mockk {
+        coEvery { readDashPayBackfillSignals(any(), any()) } coAnswers {
+            reached.complete(Unit)
+            resume.await()
+            signals
+        }
+    }
+
+    @Test
+    fun registrationDuringAConclusion_refusesToRecordCoverage() = runBlocking {
+        // The interleaving the gate mutex exists for: the conclusion passes
+        // its registration check, THEN a drain registers receival accounts
+        // and finds no coverage to invalidate, and the conclusion writes
+        // coverage anyway. The in-memory signal covers this process; a death
+        // right after leaves coverage for a scan those accounts' addresses
+        // were never watched during, suppressing their backfill forever.
+        val outgoingOnly = contactSetFingerprint(0, 140, 1_700_000_000_000L, 1_699_000_000_000L)
+        val store = FakeStore()
+        store.values[DashPayConfig.DASHPAY_BACKFILL_ARMED_TARGET] = 1_000_000L
+        store.values[DashPayConfig.DASHPAY_BACKFILL_ARMED_FINGERPRINT] = outgoingOnly
+
+        val conclusionReachedTheSdk = CompletableDeferred<Unit>()
+        val registrationLanded = CompletableDeferred<Unit>()
+        val gate = DashPayBackfillGateImpl(
+            sdkService = barrierSdk(
+                DashPayBackfillSignals(1_000_042L, 790_000L, 140, null),
+                reached = conclusionReachedTheSdk,
+                resume = registrationLanded
+            ),
+            dashPayConfig = store.config(),
+            contactRequestDao = dao(toUs = 0, fromUs = 140)
+        )
+
+        val conclusion = async(Dispatchers.Default) {
+            gate.concludeNoRewindObserved(walletId, identityId, userId)
+        }
+        conclusionReachedTheSdk.await()
+        // …the drain, mid-conclusion.
+        assertTrue(gate.noteAccountBuildsRegistered(3))
+        registrationLanded.complete(Unit)
+
+        assertFalse(conclusion.await())
+        assertNull(store.values[DashPayConfig.DASHPAY_BACKFILL_COVERED_FLOOR])
+        // The marker survives, so the owed sweep still happens.
+        assertEquals(1_000_000L, store.values[DashPayConfig.DASHPAY_BACKFILL_ARMED_TARGET])
+    }
+
+    @Test
+    fun latchedRewindDuringAConclusion_refusesToRecordCoverage() = runBlocking {
+        // The same seam, other cause: a pass latches the REAL rewind while
+        // the conclusion is being reasoned out. Concluding "nothing needed
+        // backfilling" over an in-flight replay would clear the armed marker
+        // and record an assumed floor for a range still being re-scanned.
+        val outgoingOnly = contactSetFingerprint(0, 140, 1_700_000_000_000L, 1_699_000_000_000L)
+        val store = FakeStore()
+        store.values[DashPayConfig.DASHPAY_BACKFILL_ARMED_TARGET] = 1_000_000L
+        store.values[DashPayConfig.DASHPAY_BACKFILL_ARMED_FINGERPRINT] = outgoingOnly
+
+        val conclusionReachedTheSdk = CompletableDeferred<Unit>()
+        val replayLatched = CompletableDeferred<Unit>()
+        val gate = DashPayBackfillGateImpl(
+            sdkService = barrierSdk(
+                DashPayBackfillSignals(1_000_042L, 790_000L, 140, null),
+                reached = conclusionReachedTheSdk,
+                resume = replayLatched
+            ),
+            dashPayConfig = store.config(),
+            contactRequestDao = dao(toUs = 0, fromUs = 140)
+        )
+
+        val conclusion = async(Dispatchers.Default) {
+            gate.concludeNoRewindObserved(walletId, identityId, userId)
+        }
+        conclusionReachedTheSdk.await()
+        store.values[DashPayConfig.DASHPAY_BACKFILL_PENDING_FLOOR] = 790_000L
+        store.values[DashPayConfig.DASHPAY_BACKFILL_PENDING_TARGET] = 1_000_000L
+        store.values[DashPayConfig.DASHPAY_BACKFILL_PENDING_FINGERPRINT] = outgoingOnly
+        replayLatched.complete(Unit)
+
+        assertFalse(conclusion.await())
+        assertNull(store.values[DashPayConfig.DASHPAY_BACKFILL_COVERED_FLOOR])
         assertEquals(1_000_000L, store.values[DashPayConfig.DASHPAY_BACKFILL_ARMED_TARGET])
     }
 }

--- a/wallet/test/de/schildbach/wallet/service/platform/sdk/DashPayBackfillGateTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/platform/sdk/DashPayBackfillGateTest.kt
@@ -1183,4 +1183,131 @@ class DashPayBackfillGateTest {
         assertNull(store.values[DashPayConfig.DASHPAY_BACKFILL_COVERED_FLOOR])
         assertEquals(2_518_646L, store.values[DashPayConfig.DASHPAY_BACKFILL_ARMED_TARGET])
     }
+
+    // ── durable coverage invalidation on new registrations (the crash-safe
+    //    half of the post-drain follow-up sweep) ──────────────────────────
+
+    @Test
+    fun noteAccountBuildsRegistered_clearsPersistedCoverageDurably_andReportsAccepted() = runBlocking {
+        // The in-memory re-provision signal dies with the process; the
+        // persisted coverage does not. Accepted registrations must therefore
+        // clear the coverage IN THE STORE — the same four-key removal the
+        // address-window heal performs — before the note returns.
+        val store = FakeStore()
+        store.values[DashPayConfig.DASHPAY_BACKFILL_COVERED_FLOOR] = 2_237_130L
+        store.values[DashPayConfig.DASHPAY_BACKFILL_COMPLETED_THROUGH] = 2_521_270L
+        store.values[DashPayConfig.DASHPAY_BACKFILL_CONTACT_FINGERPRINT] = fingerprintA
+        store.values[DashPayConfig.DASHPAY_BACKFILL_COVERAGE_OBSERVED] = true
+        val gate = DashPayBackfillGateImpl(
+            sdkService = sdk(DashPayBackfillSignals(2_521_270L, 2_167_130L, 61, 2_167_130L)),
+            dashPayConfig = store.config(),
+            contactRequestDao = dao(toUs = 145, fromUs = 140)
+        )
+
+        assertTrue(gate.noteAccountBuildsRegistered(29))
+
+        assertNull(store.values[DashPayConfig.DASHPAY_BACKFILL_COVERED_FLOOR])
+        assertNull(store.values[DashPayConfig.DASHPAY_BACKFILL_COMPLETED_THROUGH])
+        assertNull(store.values[DashPayConfig.DASHPAY_BACKFILL_CONTACT_FINGERPRINT])
+        assertNull(store.values[DashPayConfig.DASHPAY_BACKFILL_COVERAGE_OBSERVED])
+    }
+
+    @Test
+    fun noteThenProcessDeath_nextLaunchProvisionsAgain() = runBlocking {
+        // The crash-between-drain-and-sweep case the durable half exists for:
+        // launch A's drain registers accounts, the process dies before the
+        // follow-up sweep, and the in-memory signal is gone. Without the
+        // durable invalidation, the untouched coverage + unchanged contact
+        // set would skip the sweep on every later launch — those contacts'
+        // historical payments would never be backfilled.
+        val store = FakeStore()
+        store.values[DashPayConfig.DASHPAY_BACKFILL_COVERED_FLOOR] = 2_237_130L
+        store.values[DashPayConfig.DASHPAY_BACKFILL_COMPLETED_THROUGH] = 2_521_270L
+        store.values[DashPayConfig.DASHPAY_BACKFILL_CONTACT_FINGERPRINT] = fingerprintA
+        store.values[DashPayConfig.DASHPAY_BACKFILL_COVERAGE_OBSERVED] = true
+
+        val launchA = DashPayBackfillGateImpl(
+            sdkService = sdk(DashPayBackfillSignals(2_521_270L, 2_167_130L, 61, 2_167_130L)),
+            dashPayConfig = store.config(),
+            contactRequestDao = dao(toUs = 145, fromUs = 140)
+        )
+        launchA.noteAccountBuildsRegistered(29)
+        // …process death before the follow-up sweep…
+
+        val launchB = DashPayBackfillGateImpl(
+            sdkService = sdk(DashPayBackfillSignals(2_521_270L, 2_167_130L, 61, 2_167_130L)),
+            dashPayConfig = store.config(),
+            contactRequestDao = dao(toUs = 145, fromUs = 140) // contact set UNCHANGED
+        )
+        assertTrue(launchB.evaluate(walletId, identityId, userId).shouldRun)
+    }
+
+    @Test
+    fun noteOfZeroBuilds_keepsCoverageAndReportsNothingOwed() = runBlocking {
+        val store = FakeStore()
+        store.values[DashPayConfig.DASHPAY_BACKFILL_COVERED_FLOOR] = 2_237_130L
+        store.values[DashPayConfig.DASHPAY_BACKFILL_COMPLETED_THROUGH] = 2_521_270L
+        store.values[DashPayConfig.DASHPAY_BACKFILL_CONTACT_FINGERPRINT] = fingerprintA
+        store.values[DashPayConfig.DASHPAY_BACKFILL_COVERAGE_OBSERVED] = true
+        val gate = DashPayBackfillGateImpl(
+            sdkService = sdk(DashPayBackfillSignals(2_521_270L, 2_167_130L, 61, 2_167_130L)),
+            dashPayConfig = store.config(),
+            contactRequestDao = dao(toUs = 145, fromUs = 140)
+        )
+
+        assertFalse(gate.noteAccountBuildsRegistered(0))
+
+        assertEquals(2_237_130L, store.values[DashPayConfig.DASHPAY_BACKFILL_COVERED_FLOOR])
+    }
+
+    @Test
+    fun noteMutedByTheLoopGuard_keepsCoverageAndReportsNothingOwed() = runBlocking {
+        // Re-builds of already-swept accounts (the S22 loop) must invalidate
+        // nothing: clearing coverage for them would re-scan on every launch.
+        val store = FakeStore()
+        val gate = DashPayBackfillGateImpl(
+            sdkService = sdk(DashPayBackfillSignals(2_521_270L, 2_167_130L, 61, 2_167_130L)),
+            dashPayConfig = store.config(),
+            contactRequestDao = dao(toUs = 145, fromUs = 140)
+        )
+        // Set the cap (an evaluate records the observation: 61 SDK contact
+        // requests) and exhaust it with the first, genuinely-new batch.
+        gate.evaluate(walletId, identityId, userId)
+        assertTrue(gate.noteAccountBuildsRegistered(61))
+
+        // Coverage recorded afterwards…
+        store.values[DashPayConfig.DASHPAY_BACKFILL_COVERED_FLOOR] = 2_237_130L
+        store.values[DashPayConfig.DASHPAY_BACKFILL_COMPLETED_THROUGH] = 2_521_270L
+        store.values[DashPayConfig.DASHPAY_BACKFILL_CONTACT_FINGERPRINT] = fingerprintA
+        store.values[DashPayConfig.DASHPAY_BACKFILL_COVERAGE_OBSERVED] = true
+
+        // …survives the capped re-build note.
+        assertFalse(gate.noteAccountBuildsRegistered(5))
+        assertEquals(2_237_130L, store.values[DashPayConfig.DASHPAY_BACKFILL_COVERED_FLOOR])
+    }
+
+    @Test
+    fun gate_concludeNoRewind_refusesWhileARegistrationIsOutstanding() = runBlocking {
+        // The quiet-window conclusion says "nothing needed backfilling" — but
+        // a receival account registered since the sweep is POSITIVE evidence
+        // a sweep is still owed, and coverage recorded under it would
+        // suppress exactly the backfill that account needs (forever, after a
+        // crash that loses the in-memory signal).
+        val outgoingOnly = contactSetFingerprint(0, 140, 1_700_000_000_000L, 1_699_000_000_000L)
+        val store = FakeStore()
+        store.values[DashPayConfig.DASHPAY_BACKFILL_ARMED_TARGET] = 1_000_000L
+        store.values[DashPayConfig.DASHPAY_BACKFILL_ARMED_FINGERPRINT] = outgoingOnly
+
+        val gate = DashPayBackfillGateImpl(
+            sdkService = sdk(DashPayBackfillSignals(1_000_042L, 790_000L, 140, null)),
+            dashPayConfig = store.config(),
+            contactRequestDao = dao(toUs = 0, fromUs = 140)
+        )
+        gate.noteAccountBuildsRegistered(3)
+
+        assertFalse(gate.concludeNoRewindObserved(walletId, identityId, userId))
+        assertNull(store.values[DashPayConfig.DASHPAY_BACKFILL_COVERED_FLOOR])
+        // The marker survives, so the next launch provisions again.
+        assertEquals(1_000_000L, store.values[DashPayConfig.DASHPAY_BACKFILL_ARMED_TARGET])
+    }
 }

--- a/wallet/test/de/schildbach/wallet/service/platform/sdk/DashSdkServiceImplTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/platform/sdk/DashSdkServiceImplTest.kt
@@ -411,4 +411,76 @@ class DashSdkServiceImplTest {
         assertFalse(report.allSignable)
         assertFalse(report.settled)
     }
+
+    // ── computeDashPayReceivalCoverage (dark-contact drain diagnostics) ──
+
+    private fun contactId(seed: Int) = ByteArray(32) { seed.toByte() }
+
+    @Test
+    fun receivalCoverage_contactsWithoutAccounts_areDark_andSampled() {
+        val coverage = computeDashPayReceivalCoverage(
+            receivedContactIds = listOf(contactId(1), contactId(2), contactId(3)),
+            receivalAccountFriendIds = listOf(contactId(2))
+        )
+
+        assertEquals(3, coverage.establishedContacts)
+        assertEquals(1, coverage.receivalAccounts)
+        assertEquals(2, coverage.darkContacts)
+        // Byte-equality match, base58 sample, contact order preserved.
+        assertEquals(
+            listOf(
+                org.bitcoinj.core.Base58.encode(contactId(1)),
+                org.bitcoinj.core.Base58.encode(contactId(3))
+            ),
+            coverage.darkContactIdSample
+        )
+    }
+
+    @Test
+    fun receivalCoverage_fullyCovered_hasNoDarkContacts() {
+        val coverage = computeDashPayReceivalCoverage(
+            receivedContactIds = listOf(contactId(1), contactId(2)),
+            receivalAccountFriendIds = listOf(contactId(1), contactId(2))
+        )
+
+        assertEquals(0, coverage.darkContacts)
+        assertTrue(coverage.darkContactIdSample.isEmpty())
+    }
+
+    @Test
+    fun receivalCoverage_duplicateContactRows_collapse() {
+        // The SDK can hold several request rows per contact pair; the
+        // receival-account universe is DISTINCT contact identities.
+        val coverage = computeDashPayReceivalCoverage(
+            receivedContactIds = listOf(contactId(1), contactId(1), contactId(2)),
+            receivalAccountFriendIds = emptyList()
+        )
+
+        assertEquals(2, coverage.establishedContacts)
+        assertEquals(2, coverage.darkContacts)
+    }
+
+    @Test
+    fun receivalCoverage_sampleIsCappedAtFive_countStaysComplete() {
+        val coverage = computeDashPayReceivalCoverage(
+            receivedContactIds = (1..9).map { contactId(it) },
+            receivalAccountFriendIds = listOf(contactId(9))
+        )
+
+        assertEquals(8, coverage.darkContacts) // the full delta…
+        assertEquals(5, coverage.darkContactIdSample.size) // …named up to the cap
+    }
+
+    @Test
+    fun receivalCoverage_accountForAnUnknownFriend_doesNotHideAnyContact() {
+        // A receival account whose friend id matches no received request
+        // (stale row, direction quirk) must not mask a genuinely dark one.
+        val coverage = computeDashPayReceivalCoverage(
+            receivedContactIds = listOf(contactId(1)),
+            receivalAccountFriendIds = listOf(contactId(7))
+        )
+
+        assertEquals(1, coverage.darkContacts)
+        assertEquals(1, coverage.receivalAccounts)
+    }
 }

--- a/wallet/test/de/schildbach/wallet/service/platform/sdk/SdkWalletBinderTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/platform/sdk/SdkWalletBinderTest.kt
@@ -172,6 +172,17 @@ class SdkWalletBinderTest {
         override suspend fun dashPayPendingAccountBuilds(walletIdHex: String): Int? =
             pendingAccountBuilds
 
+        /** Receival-coverage diagnostics served to the post-drain log line. */
+        var receivalCoverage: DashPayReceivalCoverage? = null
+        var receivalCoverageReads = 0
+        override suspend fun readDashPayReceivalCoverage(
+            walletIdHex: String,
+            ownerIdentityId: ByteArray
+        ): DashPayReceivalCoverage? {
+            receivalCoverageReads++
+            return receivalCoverage
+        }
+
         /**
          * Backfill signals the gate reads. Default UNKNOWN → the gate can
          * prove nothing and always forces the pass, so every pre-existing
@@ -328,6 +339,26 @@ class SdkWalletBinderTest {
         var lastIdentityId: ByteArray? = null
         var lastUserId: String? = null
 
+        /**
+         * Whether a note of registered builds is accepted as NEW (false
+         * models the real gate's per-process loop guard muting re-builds).
+         */
+        var acceptRegistrations = true
+
+        /**
+         * Whether an outstanding registration flips the next [evaluate] to
+         * shouldRun — the real decision core's registration branches. False
+         * models the states where the gate still refuses (a watch in flight).
+         */
+        var reprovisionOnRegistration = true
+
+        /** The re-sweep debt: raised by an accepted note, consumed by [recordPassOutcome]. */
+        var registrationOutstanding = false
+
+        /** Durable-coverage stand-in: true while a coverage record is "persisted". */
+        var persistedCoverage = false
+        var coverageInvalidations = 0
+
         override suspend fun evaluate(
             walletIdHex: String,
             ownerIdentityId: ByteArray,
@@ -337,8 +368,9 @@ class SdkWalletBinderTest {
             lastWalletId = walletIdHex
             lastIdentityId = ownerIdentityId
             lastUserId = ownerUserId
+            val run = shouldRun || (reprovisionOnRegistration && registrationOutstanding)
             return BackfillDecision(
-                shouldRun = shouldRun,
+                shouldRun = run,
                 reason = "test",
                 armedToWrite = armed
             )
@@ -350,6 +382,10 @@ class SdkWalletBinderTest {
             report: DashPayContactProvisionReport
         ) {
             recordCalls++
+            // Mirror the real gate: the sweep this pass just ran consumes the
+            // outstanding debt, then the pass's OWN drain may re-raise it.
+            registrationOutstanding = false
+            noteAccountBuildsRegistered(report.built)
         }
 
         override suspend fun isRewindAccountedFor(): Boolean {
@@ -360,11 +396,25 @@ class SdkWalletBinderTest {
         /** Account builds the binder reported as REGISTERED (drain path). */
         var registeredBuilds = 0
 
-        override fun noteAccountBuildsRegistered(built: Int) {
+        override suspend fun noteAccountBuildsRegistered(built: Int): Boolean {
             registeredBuilds += built
+            if (built <= 0 || !acceptRegistrations) return false
+            registrationOutstanding = true
+            // Mirror DashPayBackfillGateImpl's contract (proven by its own
+            // tests): accepting registrations durably invalidates any
+            // persisted coverage BEFORE returning.
+            if (persistedCoverage) {
+                persistedCoverage = false
+                coverageInvalidations++
+            }
+            return true
         }
 
-        override suspend fun readBackfillStatus() = DashPayBackfillStatus.SETTLED
+        override suspend fun readBackfillStatus() = DashPayBackfillStatus(
+            armed = false,
+            replaying = false,
+            registrationOutstanding = registrationOutstanding
+        )
 
         /** Set true to have the no-rewind conclusion succeed when the watch reaches it. */
         var concludesNoRewind: Boolean = false
@@ -1339,9 +1389,11 @@ class SdkWalletBinderTest {
 
         binder.provisionContactAccountsIfEnabled(force = true)
 
-        assertEquals(0, sdk.provisionCalls)
         assertEquals(1, sdk.drainCalls)
         assertEquals(walletId, sdk.lastDrainWalletId)
+        // The 176 registrations owe the SDK's rescan reconcile a second look
+        // IN THIS CYCLE (the restored-wallet fix): exactly one follow-up sweep.
+        assertEquals(1, sdk.provisionCalls)
     }
 
     @Test
@@ -1405,6 +1457,243 @@ class SdkWalletBinderTest {
         binder.provisionContactAccountsIfEnabled(force = true)
 
         assertEquals(1, sdk.drainCalls)
+    }
+
+    // ── post-drain follow-up sweep + durable invalidation (restored-wallet
+    //    dark-contact fix) ─────────────────────────────────────────────────
+    //
+    // Field root cause: provisionDashPayContactAccounts runs the SDK sweep
+    // (whose rescan reconcile rewinds for the receival accounts that exist AT
+    // THAT MOMENT) and only THEN the drain that REGISTERS those accounts. On
+    // the first post-restore pass the reconcile sees zero accounts and
+    // backfills nothing; the accounts appear seconds later on a path that
+    // never rewinds — and on gate-skip launches the standalone drain
+    // registered accounts nothing ever swept for. The fix: a drain that
+    // registered NEW accounts durably invalidates the gate's coverage (so a
+    // crash self-heals next launch) and buys AT MOST ONE follow-up sweep in
+    // the same provisioning cycle.
+
+    @Test
+    fun gateSkip_drainRegistersAccounts_runsExactlyOneFollowUpSweep() = runBlocking {
+        val sdk = readySdk()
+        sdk.onDrain = { _ ->
+            DashPayContactDrainReport(bound = true, queuedBefore = 29, drainScheduled = true, queuedAfter = 0)
+        }
+        // The follow-up pass's own drain "builds" again (the SDK re-enqueues
+        // per sweep) — the cycle must STILL stop after one follow-up.
+        sdk.onProvision = { _ ->
+            DashPayContactProvisionReport(
+                bound = true, syncSuccess = 1, syncErrors = 0,
+                pendingBefore = 29, drainScheduled = true, pendingAfter = 0
+            )
+        }
+        val gate = FakeBackfillGate(shouldRun = false)
+        val binder = binder(sdk, backfillGate = gate, scope = this)
+        binder.bindIfEnabled(unlock)
+
+        binder.provisionContactAccountsIfEnabled(force = true)
+
+        assertEquals(1, sdk.drainCalls)
+        assertEquals(1, sdk.provisionCalls) // the follow-up sweep — and ONLY one
+        assertEquals(1, gate.recordCalls) // accounted to the gate like any pass
+    }
+
+    @Test
+    fun gateSkip_drainRegistersNothing_noFollowUpSweep() = runBlocking {
+        val sdk = readySdk() // default onDrain: queued=0, built=0
+        val gate = FakeBackfillGate(shouldRun = false)
+        val binder = binder(sdk, backfillGate = gate, scope = this)
+        binder.bindIfEnabled(unlock)
+
+        binder.provisionContactAccountsIfEnabled(force = true)
+
+        assertEquals(1, sdk.drainCalls)
+        assertEquals(0, sdk.provisionCalls)
+        assertEquals(1, gate.evaluateCalls) // not even a follow-up consultation
+    }
+
+    @Test
+    fun gateSkip_reBuildsMutedByTheLoopGuard_noFollowUpSweep() = runBlocking {
+        // The gate's per-process cap says these 29 "builds" are RE-builds of
+        // already-swept accounts. A follow-up sweep for them would be the
+        // rewind→sweep→re-build livelock the cap exists to end.
+        val sdk = readySdk()
+        sdk.onDrain = { _ ->
+            DashPayContactDrainReport(bound = true, queuedBefore = 29, drainScheduled = true, queuedAfter = 0)
+        }
+        val gate = FakeBackfillGate(shouldRun = false)
+        gate.acceptRegistrations = false
+        val binder = binder(sdk, backfillGate = gate, scope = this)
+        binder.bindIfEnabled(unlock)
+
+        binder.provisionContactAccountsIfEnabled(force = true)
+
+        assertEquals(1, sdk.drainCalls)
+        assertEquals(0, sdk.provisionCalls)
+    }
+
+    @Test
+    fun gateSkip_gateStillRefusesAfterTheDrain_noSweep_debtStaysRecorded() = runBlocking {
+        // A watch in flight must not be interrupted even by fresh
+        // registrations (re-lowering the floor mid-climb is the livelock the
+        // gate exists to prevent). The binder asks the gate again and accepts
+        // the refusal — the debt survives (durably + in-memory) for a later
+        // consultation.
+        val sdk = readySdk()
+        sdk.onDrain = { _ ->
+            DashPayContactDrainReport(bound = true, queuedBefore = 29, drainScheduled = true, queuedAfter = 0)
+        }
+        val gate = FakeBackfillGate(shouldRun = false)
+        gate.reprovisionOnRegistration = false
+        val binder = binder(sdk, backfillGate = gate, scope = this)
+        binder.bindIfEnabled(unlock)
+
+        binder.provisionContactAccountsIfEnabled(force = true)
+
+        assertEquals(2, gate.evaluateCalls) // the follow-up WAS offered to the gate
+        assertEquals(0, sdk.provisionCalls) // …and its refusal respected
+        assertTrue(gate.registrationOutstanding) // the debt is still on record
+    }
+
+    @Test
+    fun runPath_passDrainRegistersAccounts_runsOneFollowUpSweepSameCycle() = runBlocking {
+        // The first-post-restore pass: the sweep reconciles against ZERO
+        // receival accounts; its own step-2 drain registers 29 seconds later.
+        // The same cycle must sweep once more so the rescan reconcile sees
+        // them — the field wallet instead needed a manual restart.
+        val sdk = readySdk()
+        sdk.onProvision = { _ ->
+            if (sdk.provisionCalls == 1) {
+                DashPayContactProvisionReport(
+                    bound = true, syncSuccess = 1, syncErrors = 0,
+                    pendingBefore = 29, drainScheduled = true, pendingAfter = 0 // built 29
+                )
+            } else {
+                DashPayContactProvisionReport(
+                    bound = true, syncSuccess = 1, syncErrors = 0,
+                    pendingBefore = 0, drainScheduled = false // follow-up: steady
+                )
+            }
+        }
+        val gate = FakeBackfillGate(shouldRun = true)
+        val binder = binder(sdk, backfillGate = gate, scope = this)
+        binder.bindIfEnabled(unlock)
+
+        binder.provisionContactAccountsIfEnabled(force = true)
+
+        assertEquals(2, sdk.provisionCalls) // primary + exactly one follow-up
+        assertEquals(2, gate.recordCalls) // both passes accounted to the gate
+    }
+
+    @Test
+    fun runPath_everyPassBuilds_atMostOneFollowUpPerCycle() = runBlocking {
+        val sdk = readySdk()
+        sdk.onProvision = { _ ->
+            DashPayContactProvisionReport(
+                bound = true, syncSuccess = 1, syncErrors = 0,
+                pendingBefore = 29, drainScheduled = true, pendingAfter = 0
+            )
+        }
+        val gate = FakeBackfillGate(shouldRun = true)
+        val binder = binder(sdk, backfillGate = gate, scope = this)
+        binder.bindIfEnabled(unlock)
+
+        binder.provisionContactAccountsIfEnabled(force = true)
+
+        assertEquals(2, sdk.provisionCalls) // never a third in one cycle
+    }
+
+    @Test
+    fun gateSkip_invalidationLandsBeforeTheFollowUpSweep() = runBlocking {
+        // Requirement: the durable coverage invalidation must be ON RECORD
+        // BEFORE the follow-up sweep runs, so a crash between drain and sweep
+        // self-heals on the next launch. The fake gate invalidates inside
+        // noteAccountBuildsRegistered exactly like DashPayBackfillGateImpl
+        // (proven by that class's own tests); this proves the binder
+        // sequences drain → note → sweep, never sweep first.
+        val sdk = readySdk()
+        val gate = FakeBackfillGate(shouldRun = false)
+        gate.persistedCoverage = true
+        var coverageStillPersistedAtSweep: Boolean? = null
+        sdk.onDrain = { _ ->
+            DashPayContactDrainReport(bound = true, queuedBefore = 29, drainScheduled = true, queuedAfter = 0)
+        }
+        sdk.onProvision = { _ ->
+            coverageStillPersistedAtSweep = gate.persistedCoverage
+            DashPayContactProvisionReport(
+                bound = true, syncSuccess = 1, syncErrors = 0, pendingBefore = 0, drainScheduled = false
+            )
+        }
+        val binder = binder(sdk, backfillGate = gate, scope = this)
+        binder.bindIfEnabled(unlock)
+
+        binder.provisionContactAccountsIfEnabled(force = true)
+
+        assertEquals(1, gate.coverageInvalidations)
+        assertEquals(false, coverageStillPersistedAtSweep)
+    }
+
+    @Test
+    fun runPath_invalidationLandsBeforeTheFollowUpSweep() = runBlocking {
+        val sdk = readySdk()
+        val gate = FakeBackfillGate(shouldRun = true)
+        gate.persistedCoverage = true
+        val coverageAtSweep = mutableListOf<Boolean>()
+        sdk.onProvision = { _ ->
+            coverageAtSweep.add(gate.persistedCoverage)
+            if (sdk.provisionCalls == 1) {
+                DashPayContactProvisionReport(
+                    bound = true, syncSuccess = 1, syncErrors = 0,
+                    pendingBefore = 29, drainScheduled = true, pendingAfter = 0
+                )
+            } else {
+                DashPayContactProvisionReport(
+                    bound = true, syncSuccess = 1, syncErrors = 0,
+                    pendingBefore = 0, drainScheduled = false
+                )
+            }
+        }
+        val binder = binder(sdk, backfillGate = gate, scope = this)
+        binder.bindIfEnabled(unlock)
+
+        binder.provisionContactAccountsIfEnabled(force = true)
+
+        // The primary sweep ran before anything was known (coverage still
+        // recorded); the pass's registrations then invalidated it, and the
+        // follow-up sweep observed the already-cleared state.
+        assertEquals(listOf(true, false), coverageAtSweep)
+        assertEquals(1, gate.coverageInvalidations)
+    }
+
+    // ── post-drain dark-contact diagnostics ──────────────────────────────
+
+    @Test
+    fun gateSkip_drain_readsReceivalCoverageDiagnostics() = runBlocking {
+        val sdk = readySdk()
+        sdk.receivalCoverage = DashPayReceivalCoverage(
+            establishedContacts = 61, receivalAccounts = 32, darkContacts = 29,
+            darkContactIdSample = listOf("9darkContactIdA", "9darkContactIdB")
+        )
+        val gate = FakeBackfillGate(shouldRun = false)
+        val binder = binder(sdk, backfillGate = gate, scope = this)
+        binder.bindIfEnabled(unlock)
+
+        binder.provisionContactAccountsIfEnabled(force = true)
+
+        assertEquals(1, sdk.receivalCoverageReads)
+    }
+
+    @Test
+    fun runPath_sweepPassAlsoReadsReceivalCoverageDiagnostics() = runBlocking {
+        val sdk = readySdk() // default report: nothing built, no follow-up
+        val gate = FakeBackfillGate(shouldRun = true)
+        val binder = binder(sdk, backfillGate = gate, scope = this)
+        binder.bindIfEnabled(unlock)
+
+        binder.provisionContactAccountsIfEnabled(force = true)
+
+        // One drain (inside the pass) → one diagnostics line.
+        assertEquals(1, sdk.receivalCoverageReads)
     }
 
     @Test


### PR DESCRIPTION
## Problem

Restored wallets can permanently miss historical DashPay contact payments. The SDK's rescan reconcile (inside dashPaySyncNow) rewinds the SPV synced height only for the contact receival accounts that exist at that moment — but the app runs it BEFORE the signer-backed drain that actually registers those accounts. On a restored wallet the first sweep reconciles against zero accounts and backfills nothing; the accounts appear seconds later on a path that never rewinds; and on gate-skip launches the standalone drain registered accounts no sweep ever ran for. If the gate's persisted coverage then survived, the backfill those accounts are owed was suppressed on every later launch. Field-verified on a restored device: the gate evaluated 213 contact requests and a full rewind was armed, yet a known contact receive never materialized.

## Fix

1. **Same-cycle follow-up sweep** — a drain (either the sweep pass's own step-2 drain or drainDeferredAccountBuilds on the gate-skip path) whose registrations the gate accepts as NEW buys at most ONE follow-up sweep in the same provisioning cycle, routed through the gate's own evaluate so armed-marker bookkeeping stays coherent. A gate that still refuses (e.g. a replay in flight) is respected and the debt stays recorded.
2. **Durable invalidation** — DashPayBackfillGate.noteAccountBuildsRegistered (now suspend, returns acceptance) durably clears persisted coverage — the same four-key removal the address-window heal uses — BEFORE the verdict returns, so a crash between drain and sweep self-heals next launch. concludeNoRewindObserved refuses while a registration is outstanding: quiet is not evidence while a sweep is owed.
3. **Dark-contact diagnostics** — after every drain, one INFO line: established contacts vs receival accounts and up to five ids for contacts with no receival account (the class the SDK's re-enqueue asymmetry can strand — see dashpay/platform#4475 for the SDK-side fixes).

No SDK/FFI changes; all app-side in the seam services.

## Tests

12 targeted tests staged red-then-green (one follow-up per cycle on both paths, none when nothing registers, none when the loop guard mutes, invalidation-lands-before-sweep on both paths, crash-simulation across two gate instances over one store, conclude-refusal, diagnostics reads) — including a rewrite of one pre-existing test whose assertion encoded the bug. Full wallet suite: 1874 tests, 0 failures.

Known residual (documented in code): registrations landing during an in-progress replay watch don't interrupt the watch (its deliberate anti-livelock rule); a crash in that window can still record stale coverage. Making the in-progress marker registration-aware is a follow-up decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only DashPay receival coverage diagnostics, including uncovered contact counts and a limited sample of contact IDs.
  * Coverage diagnostics can be viewed without starting the SDK or performing native wallet operations.

* **Bug Fixes**
  * Improved account provisioning to perform a follow-up sweep when new receival accounts are registered.
  * Coverage data is invalidated when registrations change, ensuring subsequent checks reflect current wallet state.
  * Prevented coverage from being finalized while account registrations remain outstanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->