### PR TITLE
fix: classify a stale funding reservation as NotBroadcast on the atomic send path

### DIFF
--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/SdkL1SendService.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/SdkL1SendService.kt
@@ -108,6 +108,16 @@ internal const val ADDRESS_POOL_TAG_EXTERNAL = 0
  * network", blocking the safe dashj fallback). The message-prefix rules
  * below stay for the transition window.
  *
+ * [DashSdkError.PlatformWallet.StaleReservationToken] (code 34) joins them
+ * for the same reason (dashpay/platform#4309). It used to reach only the
+ * DEFERRED surface, so its arm lived only in
+ * [classifyDeferredBroadcastFailure]; #4309 age-guards the atomic
+ * finalize → broadcast path against the same reservation bound and reuses
+ * the same code, so it now reaches the plain send and the drain as well.
+ * Both classifiers keep an arm: this one is the general case, and the
+ * deferred one stays ahead of it only to name the deferred surface in the
+ * reason string.
+ *
  * Everything else defers to [classifyBroadcastFailure]; notably
  * [DashSdkError.PlatformWallet.TransactionBroadcastUnconfirmed] (code 20 —
  * the SDK's own "may already be on the network, inputs stay reserved, do
@@ -164,6 +174,27 @@ internal fun classifyCoreSendFailure(t: Throwable): SdkWriteResult<Nothing> = wh
     t is DashSdkError.PlatformWallet.TransactionBroadcastRejected ->
         SdkWriteResult.NotBroadcast(
             "core send definitively rejected before reaching the network: ${t.message}", t
+        )
+    // Typed stale funding reservation (code 34). Until dashpay/platform#4309
+    // this code could only come from the DEFERRED token surface, so the arm
+    // lived only in [classifyDeferredBroadcastFailure]; #4309 age-guards the
+    // ATOMIC finalize → broadcast path against the same bound and reuses the
+    // same code, which puts it on this classifier's paths too — the plain
+    // send (`sendToAddresses`) and the drain ([CoreSendAllNative]).
+    //
+    // Definitive pre-network by the SDK contract: the guard refuses BEFORE
+    // touching the broadcaster, and releases the still-owned reservation
+    // owner-guarded on the way out, so the freed inputs are immediately
+    // reselectable. Without this arm it falls through to
+    // [classifyBroadcastFailure] and returns Ambiguous — surfacing a payment
+    // that provably never left the device as "may be on the network" and
+    // blocking the safe dashj fallback.
+    //
+    // NOT retryable in place (the handle is consumed on this outcome); the
+    // caller must rebuild, which the reason string says.
+    t is DashSdkError.PlatformWallet.StaleReservationToken ->
+        SdkWriteResult.NotBroadcast(
+            "core send refused pre-network (funding reservation aged out — rebuild): ${t.message}", t
         )
     t is DashSdkError.PlatformWallet.WalletOperation &&
         (t.message?.startsWith("set_funding failed") == true ||

--- a/wallet/test/de/schildbach/wallet/service/platform/sdk/SdkL1SendServiceTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/platform/sdk/SdkL1SendServiceTest.kt
@@ -313,6 +313,30 @@ class SdkL1SendServiceTest {
     }
 
     @Test
+    fun classify_staleReservationToken_isNotBroadcast_onTheAtomicSendPath() {
+        // dashpay/platform#4309 age-guards the ATOMIC finalize → broadcast
+        // path (plain send and drain) against the same reservation bound as
+        // the deferred surface, reusing native code 34. The guard refuses
+        // BEFORE touching the broadcaster and releases the reservation
+        // owner-guarded, so this is definitively pre-network — Ambiguous here
+        // would show a payment that never left the device as "may be on the
+        // network" and block the dashj fallback.
+        val stale = DashSdkError.PlatformWallet.StaleReservationToken(
+            "finalized transaction reservation has outlived its lifetime; rebuild the payment"
+        )
+        val result = classifyCoreSendFailure(stale)
+        assertTrue(result is SdkWriteResult.NotBroadcast)
+        assertSame(stale, (result as SdkWriteResult.NotBroadcast).cause)
+        // The ambiguous broadcast sibling must not be dragged along: only the
+        // pre-network refusal downgrades.
+        assertTrue(
+            classifyCoreSendFailure(
+                DashSdkError.PlatformWallet.TransactionBroadcastUnconfirmed("timeout after send")
+            ) is SdkWriteResult.Ambiguous
+        )
+    }
+
+    @Test
     fun classify_typedArms_reachTheDeferredTableToo() {
         // classifyDeferredBroadcastFailure defers to classifyCoreSendFailure,
         // so the typed trio must classify identically on the BIP70 deferred
@@ -321,7 +345,8 @@ class SdkL1SendServiceTest {
             error in listOf<Throwable>(
                 DashSdkError.PlatformWallet.WalletOperation("transaction build failed: bad recipients blob"),
                 DashSdkError.PlatformWallet.SigningKeyUnavailable("keystore locked"),
-                DashSdkError.PlatformWallet.TransactionBroadcastRejected("rejected by core")
+                DashSdkError.PlatformWallet.TransactionBroadcastRejected("rejected by core"),
+                DashSdkError.PlatformWallet.StaleReservationToken("reservation aged out")
             )
         ) {
             assertTrue(


### PR DESCRIPTION
## What

Adds a typed `StaleReservationToken` arm to `classifyCoreSendFailure`, so a stale funding reservation on the **atomic** send path classifies `NotBroadcast` instead of `Ambiguous`.

## Why

[dashpay/platform#4309](https://github.com/dashpay/platform/pull/4309) age-guards the finalized-transaction handle path (`finalize` → `broadcastTransaction`) against the same reservation bound the deferred BIP70 surface already used, and deliberately **reuses native code 34** (`ErrorStaleReservationToken`) rather than minting a new one.

Until then, code 34 could only arrive from the deferred surface, so the arm lived only in `classifyDeferredBroadcastFailure`. After #4309 it also reaches:

- `SdkL1SendService.sendToAddress` → `ManagedPlatformWallet.sendToAddresses` (the plain send)
- `CoreSendAllNative` → `ManagedCoreWallet.broadcastTransaction` (send-all / CoinJoin drain)

Neither is covered by the deferred classifier, so the error fell through `classifyCoreSendFailure`'s message-prefix rules to `classifyBroadcastFailure` and came back **`Ambiguous`**.

That is wrong in the direction that costs the user most. The SDK contract guarantees this refusal happens *before* the broadcaster is touched, and the guard releases the still-owned reservation owner-guarded on the way out, so the inputs are immediately reselectable. Classifying it `Ambiguous` shows a payment that provably never left the device as "may be on the network" **and** blocks the safe dashj fallback — the exact failure mode the existing typed arms (`CoreInsufficientFunds`, `SigningKeyUnavailable`, `TransactionBroadcastRejected`) were added to prevent.

## Changes

- `SdkL1SendService.kt` — typed `StaleReservationToken` arm in `classifyCoreSendFailure`, placed with the other definitively-pre-network arms, plus KDoc explaining why both classifiers keep an arm (the deferred one stays ahead only to name the deferred surface in the reason string).
- `SdkL1SendServiceTest.kt` — `classify_staleReservationToken_isNotBroadcast_onTheAtomicSendPath`, and code 34 added to the deferred-table parity list.

## Testing

`:wallet:testProdDebugUnitTest --tests SdkL1SendServiceTest` — **71 tests, 0 failures.**

Verified non-vacuous: with the production arm reverted, the new test fails (`AssertionError`) and it is the only failure. The existing deferred-path test still passes without it, confirming the two classifiers are independently covered.

The new test also asserts the ambiguous sibling `TransactionBroadcastUnconfirmed` (code 20) keeps its `Ambiguous` classification, so the pair cannot collapse into one rule.

## Notes

- Safe to land **before** #4309. Against the current AAR the arm is unreachable, so this is a no-op until the native guard ships.
- A second gap from #4309 is **not** addressed here and needs a platform-side change first: `PlatformWalletError::InputMidBroadcast` (the new build refusal when a coin selection picks an input held by an in-flight dispatch) maps to `ErrorUnknown` (99) and so also classifies `Ambiguous`. Fixing it by message-prefix matching would be fragile — the message embeds an outpoint — so the right fix is claiming a real FFI code upstream and adding a typed arm here. Not yet raised upstream.

