### PR TITLE
fix(scan): keep the scanner escapable when the camera is refused

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/ui/components/MenuItem.kt
+++ b/common/src/main/java/org/dash/wallet/common/ui/components/MenuItem.kt
@@ -40,7 +40,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
-import android.content.res.Configuration
 import androidx.compose.ui.text.TextMeasurer
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.rememberTextMeasurer

--- a/common/src/main/java/org/dash/wallet/common/ui/scan/ScanActivity.kt
+++ b/common/src/main/java/org/dash/wallet/common/ui/scan/ScanActivity.kt
@@ -63,6 +63,7 @@ import org.dash.wallet.common.SecureActivity
 import org.dash.wallet.common.databinding.ScanActivityBinding
 import org.dash.wallet.common.ui.dialogs.AdaptiveDialog
 import org.dash.wallet.common.util.OnFirstPreDraw
+import org.dash.wallet.common.util.openAppSettings
 import org.slf4j.LoggerFactory
 import java.util.EnumMap
 
@@ -203,19 +204,55 @@ class ScanActivity : SecureActivity(), TextureView.SurfaceTextureListener {
     private fun showProblemWarnDialog() {
         AdaptiveDialog.create(
             null,
-            getString(R.string.scan_camera_permission_dialog_title),
+            getString(R.string.scan_camera_problem_dialog_title),
             getString(R.string.scan_camera_problem_dialog_message),
             getString(R.string.button_dismiss)
-        ).show(this)
+        ).show(this) { leaveScanner() }
     }
 
     private fun showPermissionWarnDialog() {
+        // Asked after a refusal, a false rationale flag means the system will not prompt again
+        // (the user chose "don't allow" twice, or picked "don't ask again"), so re-requesting
+        // is a no-op and App info is the only way back. A true flag means we may still ask
+        // in-app, which is a far smaller detour than sending the user to system settings.
+        val canAskAgain = shouldShowRequestPermissionRationale(Manifest.permission.CAMERA)
+
         AdaptiveDialog.create(
             null,
             getString(R.string.scan_camera_permission_dialog_title),
-            getString(R.string.scan_camera_permission_dialog_message),
-            getString(R.string.button_dismiss)
-        ).show(this)
+            getString(
+                if (canAskAgain) {
+                    R.string.scan_camera_permission_dialog_message
+                } else {
+                    R.string.scan_camera_permission_denied_dialog_message
+                }
+            ),
+            getString(R.string.button_not_now),
+            getString(if (canAskAgain) R.string.permission_allow else R.string.button_settings)
+        ).show(this) { accepted ->
+            if (accepted == true) {
+                if (canAskAgain) {
+                    requestCameraPermission()
+                } else {
+                    // onResume() opens the camera on the way back, so granting it in system
+                    // settings drops the user straight into a working scanner.
+                    openAppSettings()
+                }
+            } else {
+                leaveScanner()
+            }
+        }
+    }
+
+    /**
+     * Leaves a scanner that has nothing left to offer. The screen has one job and cannot do it,
+     * so rather than parking the user on a dead camera preview behind a dismissed dialog, hand
+     * them back to where they came from — every caller has another way in, whether that is
+     * typing an address, pasting one, or picking a contact.
+     */
+    private fun leaveScanner() {
+        setResult(RESULT_CANCELED)
+        finish()
     }
 
     private fun requestCameraPermission() {

--- a/common/src/main/java/org/dash/wallet/common/ui/scan/ScanActivity.kt
+++ b/common/src/main/java/org/dash/wallet/common/ui/scan/ScanActivity.kt
@@ -25,6 +25,7 @@ import android.app.Activity
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
+import android.content.res.ColorStateList
 import android.graphics.RectF
 import android.graphics.SurfaceTexture
 import android.graphics.drawable.ColorDrawable
@@ -78,6 +79,7 @@ class ScanActivity : SecureActivity(), TextureView.SurfaceTextureListener {
     @Volatile
     private var surfaceCreated = false
     private var sceneTransition: Animator? = null
+    private var cameraUnavailable = false
     private lateinit var vibrator: Vibrator
     private lateinit var cameraThread: HandlerThread
 
@@ -103,12 +105,6 @@ class ScanActivity : SecureActivity(), TextureView.SurfaceTextureListener {
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         vibrator = getSystemService(VIBRATOR_SERVICE) as Vibrator
-        viewModel.showPermissionWarnDialog.observe(this) {
-            showPermissionWarnDialog()
-        }
-        viewModel.showProblemWarnDialog.observe(this) {
-            showProblemWarnDialog()
-        }
 
         // Stick to the orientation the activity was started with. We cannot declare this in the
         // AndroidManifest.xml, because it's not allowed in combination with the windowIsTranslucent=true
@@ -130,6 +126,16 @@ class ScanActivity : SecureActivity(), TextureView.SurfaceTextureListener {
         cameraThread = HandlerThread("cameraThread", Process.THREAD_PRIORITY_BACKGROUND)
         cameraThread.start()
         cameraHandler = Handler(cameraThread.looper)
+
+        // Registered after the views are inflated: both dialogs also reveal the content view.
+        viewModel.showPermissionWarnDialog.observe(this) {
+            showCameraUnavailableUi()
+            showPermissionWarnDialog()
+        }
+        viewModel.showProblemWarnDialog.observe(this) {
+            showCameraUnavailableUi()
+            showProblemWarnDialog()
+        }
 
         if (ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
             requestCameraPermission()
@@ -153,13 +159,17 @@ class ScanActivity : SecureActivity(), TextureView.SurfaceTextureListener {
                 window
                     .setBackgroundDrawable(ColorDrawable(resources.getColor(android.R.color.transparent)))
                 OnFirstPreDraw.listen(contentView) {
-                    val finalRadius =
-                        (contentView.width.coerceAtLeast(contentView.height)).toFloat()
-                    val duration = resources.getInteger(android.R.integer.config_mediumAnimTime)
-                    sceneTransition =
-                        ViewAnimationUtils.createCircularReveal(contentView, x, y, 0f, finalRadius)
-                    sceneTransition!!.duration = duration.toLong()
-                    sceneTransition!!.interpolator = AccelerateInterpolator()
+                    // The camera may already have been refused before the first draw; in that case
+                    // the content is showing without a transition and must not be hidden again.
+                    if (!cameraUnavailable) {
+                        val finalRadius =
+                            (contentView.width.coerceAtLeast(contentView.height)).toFloat()
+                        val duration = resources.getInteger(android.R.integer.config_mediumAnimTime)
+                        sceneTransition =
+                            ViewAnimationUtils.createCircularReveal(contentView, x, y, 0f, finalRadius)
+                        sceneTransition!!.duration = duration.toLong()
+                        sceneTransition!!.interpolator = AccelerateInterpolator()
+                    }
                     // TODO Here, the transition should start in a paused state, showing the first frame
                     // of the animation. Sadly, RevealAnimator doesn't seem to support this, unlike
                     // (subclasses of) ValueAnimator.
@@ -167,6 +177,27 @@ class ScanActivity : SecureActivity(), TextureView.SurfaceTextureListener {
                 }
             }
         }
+    }
+
+    /**
+     * Called when the camera cannot be used at all: the permission was refused, or the device
+     * failed to hand the camera over. When the scanner is opened with a circular-reveal
+     * transition, the content view starts fully transparent over a transparent window and is
+     * only made visible by [maybeTriggerSceneTransition], which runs off the successful
+     * camera-open path. Without the camera that never happens, leaving an all-black screen with
+     * no visible close button and no way back out of the scanner (MO-1016). Show the controls
+     * over an opaque background instead.
+     */
+    private fun showCameraUnavailableUi() {
+        cameraUnavailable = true
+        sceneTransition?.cancel()
+        sceneTransition = null
+        contentView.alpha = 1f
+        window.setBackgroundDrawable(ColorDrawable(ContextCompat.getColor(this, R.color.dash_black)))
+        // The close icon is nearly black, which is legible over the camera preview but not over
+        // the empty background that replaces it.
+        binding.scanCloseButton.imageTintList =
+            ColorStateList.valueOf(ContextCompat.getColor(this, R.color.dash_white))
     }
 
     private fun showProblemWarnDialog() {

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -52,6 +52,8 @@
 
     <!-- Generic buttons -->
     <string name="button_dismiss">Dismiss</string>
+    <string name="button_not_now">Not now</string>
+    <string name="button_settings">Settings</string>
     <string name="network_unavailable_return">Return to Wallet</string>
     <string name="button_continue">Continue</string>
     <string name="get_quote">Get Quote</string>
@@ -131,6 +133,8 @@
     <string name="scan_camera_problem_dialog_message">The camera has a problem. You probably need to restart the device.</string>
     <string name="scan_camera_permission_dialog_title">Camera permission</string>
     <string name="scan_camera_permission_dialog_message">In order to scan QR codes, you need to grant permission to use the camera.</string>
+    <!-- Shown instead of the message above once the system will no longer prompt for the camera, so the only way back is system settings -->
+    <string name="scan_camera_permission_denied_dialog_message">In order to scan QR codes, camera access has to be turned on for this app in Settings.</string>
 
     <!-- address input -->
     <string name="address_input_title">Send Dash</string>

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/MayaAddressInputScreen.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/MayaAddressInputScreen.kt
@@ -179,7 +179,6 @@ fun MayaAddressInputScreen(
                                 title = source.name,
                                 enabled = !unsupported,
                                 subtitle = source.address?.takeIf { it.isNotEmpty() },
-                                subtitleMaxLines = 1,
                                 subtitleMiddleEllipsis = true,
                                 icon = source.icon,
                                 trailingButtonText = if (connected || unsupported) {
@@ -213,7 +212,6 @@ fun MayaAddressInputScreen(
                             ActionItem(
                                 title = stringResource(R.string.maya_clipboard),
                                 subtitle = clipboardAddress,
-                                subtitleMaxLines = 1,
                                 subtitleMiddleEllipsis = true,
                                 icon = R.drawable.ic_maya_clipboard,
                                 onClick = onClipboardClick


### PR DESCRIPTION
Fixes [MO-1016](https://dashpay.atlassian.net/browse/MO-1016) — *no X button on some devices when scan QR code with disabled Camera*.

## The bug

`ScanActivity` supports a circular-reveal open animation. When it is launched with `getTransitionIntent`, `onCreate` sets `contentView.alpha = 0f` over a transparent window and leaves it that way until `maybeTriggerSceneTransition()` runs — and that call lives inside `openRunnable`, the **successful camera-open path**. Refuse the camera and it never runs, so the whole scanner stays invisible: an all-black screen with no close button behind the warning dialog, and after dismissing it no way out but restarting the wallet.

The main screen was never affected because `WalletFragment` uses the plain `getIntent` (changed incidentally in #1385), and neither is the lock screen's Scan to Send. That is what QA meant by "already fixed on the main screen". The five remaining call sites all use the transition and all carry the bug:

- `SendCoinsQrActivity`
- `PaymentsPayFragment`
- `AddressInputFragment`
- `MayaAddressInputFragment`
- `DEXRefundAddressFragment`

It is only *noticeable* on devices without a navigation bar, where there is no on-screen Back button to escape with — hence the report.

So the fix belongs in `ScanActivity`, not at the call sites.

## The changes

**1. `fix(scan): keep the close button reachable when the camera is refused`**

Both warning dialogs now reveal the content over an opaque background first, and tint the close icon white so it is legible there — `ic_nav_bar_close` is nearly black, which works over the camera preview but not over the empty background that replaces it. The transition setup is skipped if the camera was already refused before the first draw, so it cannot hide the content again.

**2. `fix: repair the build broken by #1542`** — *unrelated, see note below*

**3. `fix(scan): give the camera-permission dialog somewhere to go`**

The X is an escape hatch, not a resolution. The dialog was a dead end — one Dismiss button that dropped the user back onto a scanner that still could not scan — and on a permanent refusal the system never prompts again, so there was no in-app route back at all.

- Dismissing either warning now **leaves the scanner**. It has one job and cannot do it, and every caller offers another way in (typing an address, pasting one, picking a contact). The close button stays as the safety net.
- The permission dialog gained a **primary action**, keyed off `shouldShowRequestPermissionRationale`: after a first refusal it is **Allow**, which re-asks in-app; once the system will no longer prompt it becomes **Settings**, opening App info through the existing `Context.openAppSettings()`. `onResume()` already opens the camera on the way back, so granting it there lands the user in a working scanner with no extra code. This mirrors the location-permission flow in `exploredash`.
- The **message follows the same split**, since telling someone to grant a permission they can no longer be asked for is a dead end of its own.
- Drive-by: the camera-*problem* dialog was titled "Camera permission", which it is not. It now uses `scan_camera_problem_dialog_title` ("Sorry"), a string already present and unused.

Three new English strings: `button_not_now`, `button_settings`, `scan_camera_permission_denied_dialog_message`.

## Please look at this separately

**`master` does not compile as of 74bd90a04 (#1542)** — `MenuItem.kt` imports `Configuration` twice (ambiguous import, `:common` fails), and `MayaAddressInputScreen` passes `subtitleMaxLines = 1` to `ActionItem`, which has no such parameter (`:integrations:maya` fails). Nothing builds without the repair, so it is carried here as its own commit. `ActionItem` already renders its subtitle at `maxLines = 1` and both call sites also pass `subtitleMiddleEllipsis = true`, so the argument was redundant and dropping it preserves the rendering. **Worth landing on its own, ahead of this PR.**

## Testing

Verified on an API 34 emulator with gesture navigation (no navigation bar), driving `ScanActivity` directly with the transition extras.

Reproduced the original bug on `master` first: after Don't allow → Dismiss, a fully black screen with no X, `ScanActivity` still the resumed activity.

With the fix:

| Action | Result |
|---|---|
| Refuse once | Dialog shows original copy, **Allow** / Not now; X visible behind it |
| Tap Allow | System prompt re-appears |
| Refuse again | Copy switches to the Settings wording, **Settings** / Not now |
| Tap Settings | App info opens on the right app |
| Grant there, press back | Lands straight in a live camera preview |
| Tap Not now | Scanner closes, returns to the caller |
| Tap the X | Scanner closes, returns to the caller |

## Left alone

The camera-problem copy still reads *"The camera has a problem. You probably need to restart the device."*, which sits oddly on a single button that now closes the screen. Rewording needs a translated string and a product opinion, so I left it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scanner behavior when camera access is denied or unavailable.
  * Added clearer guidance for enabling camera permission through system settings.
  * Scanner warnings now provide reliable options to retry, open settings, or exit.

* **UI Improvements**
  * Added a clear unavailable-camera screen with a close button.
  * Allowed longer “Paste address from” descriptions to wrap across multiple lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->