### PR TITLE
feat(dashpay): allow claiming invitations as small as 0.003 DASH

### DIFF
--- a/wallet/src/de/schildbach/wallet/Constants.java
+++ b/wallet/src/de/schildbach/wallet/Constants.java
@@ -321,8 +321,9 @@ public final class Constants {
     public static final Coin DASH_PAY_FEE_CONTESTED_NAME = Coin.parseCoin("0.20");
     public static final Coin DASH_PAY_FEE = Coin.parseCoin("0.03");
 
-    // 150,000,000
-    public static final Coin DASH_PAY_INVITE_MIN = DASH_PAY_FEE.div(10);
+    // 300,000,000 credits; enough to create an identity, register a non-contested
+    // username and usually send a contact request
+    public static final Coin DASH_PAY_INVITE_MIN = Coin.parseCoin("0.003");
 
     public static boolean IS_TESTNET_BUILD = Constants.NETWORK_PARAMETERS.getId().equals(NetworkParameters.ID_TESTNET);
 

--- a/wallet/src/de/schildbach/wallet/data/CreditBalanceInfo.kt
+++ b/wallet/src/de/schildbach/wallet/data/CreditBalanceInfo.kt
@@ -13,7 +13,9 @@ data class CreditBalanceInfo(
         const val CREDITS_PER_DUFF = 1_000
         const val MAX_OPERATION_COST = 100_000_000.toLong()
         val MAX_OPERATION_COST_COIN = MAX_OPERATION_COST / CREDITS_PER_DUFF
-        const val LOW_BALANCE = MAX_OPERATION_COST * 10
+        // warn when only ~2 operations worth of credits remain, so users onboarded
+        // with small invites (0.003 - 0.01 DASH) are not warned on every operation
+        const val LOW_BALANCE = MAX_OPERATION_COST * 2
     }
     fun isBalanceEnough(): Boolean {
         return balance >= MAX_OPERATION_COST

--- a/wallet/src/de/schildbach/wallet/ui/DashPayUserActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/DashPayUserActivity.kt
@@ -217,7 +217,7 @@ class DashPayUserActivity : LockScreenActivity() {
                     if (answer == true) {
                         SendCoinsActivity.startBuyCredits(this@DashPayUserActivity)
                     } else {
-                        if (shouldWarn)
+                        if (!isEmpty)
                             viewModel.sendContactRequest()
                     }
                 } else {

--- a/wallet/src/de/schildbach/wallet/ui/EditProfileActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/EditProfileActivity.kt
@@ -438,7 +438,7 @@ class EditProfileActivity : LockScreenActivity() {
                     if (answer == true) {
                         SendCoinsActivity.startBuyCredits(this@EditProfileActivity)
                     } else {
-                        if (shouldWarn)
+                        if (!isEmpty)
                             save()
                     }
                 } else {

--- a/wallet/src/de/schildbach/wallet/ui/SearchUserFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/SearchUserFragment.kt
@@ -290,8 +290,6 @@ class SearchUserFragment : Fragment(R.layout.activity_search_dashpay_profile_roo
     override fun onAcceptRequest(usernameSearchResult: UsernameSearchResult, position: Int) {
         dashPayViewModel.logEvent(AnalyticsConstants.UsersContacts.ACCEPT_REQUEST)
         // need to check balance
-        dashPayViewModel.sendContactRequest(usernameSearchResult.fromContactRequest!!.userId)
-
         lifecycleScope.launch {
             val enough = dashPayViewModel.hasEnoughCredits()
             if (enough == null) {
@@ -317,7 +315,7 @@ class SearchUserFragment : Fragment(R.layout.activity_search_dashpay_profile_roo
                     if (answer == true) {
                     SendCoinsActivity.startBuyCredits(requireActivity())
                     } else {
-                        if (shouldWarn)
+                        if (!isEmpty)
                             dashPayViewModel.sendContactRequest(usernameSearchResult.fromContactRequest!!.userId)
                     }
                 } else {

--- a/wallet/src/de/schildbach/wallet/ui/dashpay/NotificationsFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/dashpay/NotificationsFragment.kt
@@ -296,7 +296,7 @@ class NotificationsFragment : Fragment(R.layout.fragment_notifications) {
                     if (answer == true) {
                         SendCoinsActivity.startBuyCredits(requireActivity())
                     } else {
-                        if (shouldWarn)
+                        if (!isEmpty)
                             dashPayViewModel.sendContactRequest(usernameSearchResult.fromContactRequest!!.userId)
                     }
                 } else {

--- a/wallet/src/de/schildbach/wallet/ui/username/request/RequestUserNameViewModel.kt
+++ b/wallet/src/de/schildbach/wallet/ui/username/request/RequestUserNameViewModel.kt
@@ -465,7 +465,7 @@ class RequestUserNameViewModel @Inject constructor(
         val inviteBalance = _inviteBalance.value
         val enoughBalance = when {
             isUsingInvite() && contestable -> inviteBalance >= Constants.DASH_PAY_FEE_CONTESTED
-            isUsingInvite() && !contestable -> inviteBalance >= Constants.DASH_PAY_FEE
+            isUsingInvite() && !contestable -> inviteBalance >= Constants.DASH_PAY_INVITE_MIN
             identityBalance > 0L && contestable -> (Coin.valueOf(identityBalance / 1000) + walletBalance) > Coin.valueOf(
                 CONTEST_DOCUMENT_FEE / 1000)
             identityBalance > 0L && !contestable -> (Coin.valueOf(identityBalance / 1000) + walletBalance) > Coin.valueOf(


### PR DESCRIPTION
## Problem

The invite-link validation (`TopUpRepository.validateInvitation`) already accepts invitations down to `DASH_PAY_INVITE_MIN` (0.003 DASH), but the username request screen required the invite to hold the full `DASH_PAY_FEE` (0.03 DASH). A small invite (e.g. 0.005 DASH) therefore passed link validation, walked the user through onboarding, and then dead-ended on a permanently disabled *Request username* button — with the explanatory balance row hidden for the non-contested invite path.

In practice invitations are expected to be ~0.005–0.01 DASH, which comfortably covers identity creation, a non-contested username and 1–2 contact requests (a contact request costs ~80–90M credits; 0.005 DASH = 500M credits).

## Changes

- **RequestUserNameViewModel**: gate non-contested usernames from an invite on `DASH_PAY_INVITE_MIN` instead of `DASH_PAY_FEE`. Contested usernames still require `DASH_PAY_FEE_CONTESTED` (0.25) as before.
- **Constants**: make `DASH_PAY_INVITE_MIN` an explicit `0.003` instead of deriving it from `DASH_PAY_FEE` (so future fee changes don't silently move the invite floor), and fix the stale credits comment (0.003 DASH = 300,000,000 credits, not 150,000,000).
- **CreditBalanceInfo**: lower `LOW_BALANCE` from 10× to 2× `MAX_OPERATION_COST` (1B → 200M credits). Previously every user onboarded with a small invite was below the 0.01 DASH warning threshold and got the *low balance / buy credits* dialog on every single contact request, accept, and profile update. Now the warning appears only when ~2 operations worth of credits remain.
- **Low-balance dialog fix** (`DashPayUserActivity`, `SearchUserFragment`, `NotificationsFragment`, `EditProfileActivity`): tapping *Maybe later* used `if (shouldWarn)` to decide whether to proceed — but an empty balance also sets `shouldWarn`, so operations were attempted even when the balance couldn't cover them. Changed to `if (!isEmpty)`: warn-but-allow when low, block when truly empty. (`DashPayUserBottomSheetViewModel` already implemented this correctly.)
- **SearchUserFragment.onAcceptRequest**: removed an unconditional `sendContactRequest` fired *before* the balance check, which double-enqueued the operation and made the check pointless. Now matches the sibling flows in `DashPayUserActivity` and `NotificationsFragment`.

## Result

A user claiming a ~0.005 DASH invite can now register an identity + non-contested username and perform normal operations (contact requests/accepts, profile updates) without nagging, until their credit balance genuinely runs out — at which point operations are blocked with the buy-credits dialog instead of failing on-chain.

## Testing

- `:wallet:compile_testNet3DebugJavaWithJavac` passes.
- No existing unit-test coverage of these paths; the amount gates were verified by code audit (all remaining `DASH_PAY_FEE` usages are wallet-funded, non-invite paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Invite eligibility now uses a fixed minimum credit balance.
  - Low-credit warnings appear closer to the point where credits may run out.

- **Bug Fixes**
  - Contact requests and profile updates are no longer submitted when the credit balance is empty.
  - Improved handling of credit warnings during contact requests, profile editing, username requests, and notifications.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->