### PR TITLE
fix: restore L1 sync after service teardown, and never leave the wallet without an engine

### DIFF
--- a/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/ui/EnterAmountToTransferFragment.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/ui/EnterAmountToTransferFragment.kt
@@ -58,11 +58,13 @@ import androidx.compose.ui.unit.dp
 import org.dash.wallet.common.ui.components.DashWalletTheme
 import org.dash.wallet.common.ui.components.LocalDashColors
 import org.dash.wallet.common.ui.segmented_picker.SegmentedOption
+import org.slf4j.LoggerFactory
 
 @AndroidEntryPoint
 class EnterAmountToTransferFragment : Fragment(R.layout.enter_amount_to_transfer_fragment) {
 
     companion object {
+        private val log = LoggerFactory.getLogger(EnterAmountToTransferFragment::class.java)
         private const val DECIMAL_SEPARATOR = '.'
         fun newInstance() = EnterAmountToTransferFragment()
     }
@@ -162,15 +164,18 @@ class EnterAmountToTransferFragment : Fragment(R.layout.enter_amount_to_transfer
 
     private fun formatTransferredAmount(value: String) {
         val text = viewModel.applyNewValue(value, pickedCurrencyOption)
+        val span = amountCurrencySpan(
+            text = text,
+            isDashSelected = pickedCurrencyIndex == 0,
+            formattedValue = viewModel.formattedValue,
+            fiatBalance = viewModel.fiatBalance,
+            isCurrencyFirst = viewModel.fiatAmount?.isCurrencyFirst() == true
+        )
         val spannableString = SpannableString(text).apply {
-            if (pickedCurrencyIndex == 0) {
-                spanAmount(this, viewModel.formattedValue.length, text.length)
+            if (span != null) {
+                spanAmount(this, span.from, span.to)
             } else {
-                if (viewModel.fiatAmount?.isCurrencyFirst() == true && text.length - viewModel.fiatBalance.length > 0) {
-                    spanAmount(this, 0, text.length - viewModel.fiatBalance.length)
-                } else {
-                    spanAmount(this, viewModel.inputValue.length, text.length)
-                }
+                log.warn("no valid currency span for amount text of length {}", text.length)
             }
         }
 
@@ -285,4 +290,50 @@ class EnterAmountToTransferFragment : Fragment(R.layout.enter_amount_to_transfer
             }
         }
     }
+}
+
+/** The slice of the amount text that renders in the smaller currency style. */
+internal data class AmountCurrencySpan(val from: Int, val to: Int)
+
+/**
+ * Which slice of [text] is the currency label (rendered smaller) rather than the
+ * amount itself, or `null` when there is nothing valid to style.
+ *
+ * Pure and host-testable on purpose. The three branches take their bounds from
+ * separate mutable ViewModel fields, and `applyNewValue` refreshes only the one
+ * belonging to the branch it took — `formattedValue` for DASH, `fiatBalance` for
+ * fiat. Mixing a field from the other branch produces bounds that do not describe
+ * [text] at all, and `Spannable.setSpan` throws on those rather than ignoring them.
+ *
+ * MO-995: the fiat currency-last branch used the raw `inputValue` length. The fiat
+ * branch of `applyNewValue` sets `fiatBalance = inputValue` only when the input has
+ * at most 2 decimals; otherwise `fiatBalance` is the 2-dp formatted figure, which is
+ * SHORTER. Tapping USD converts the DASH amount through `formatInput`, yielding many
+ * decimals — so `from` (12) overshot `to` (7) and setSpan crashed the screen.
+ */
+internal fun amountCurrencySpan(
+    text: String,
+    isDashSelected: Boolean,
+    formattedValue: String,
+    fiatBalance: String,
+    isCurrencyFirst: Boolean
+): AmountCurrencySpan? {
+    val from: Int
+    val to: Int
+    if (isDashSelected) {
+        // text == "$formattedValue $DASH" — the trailing code.
+        from = formattedValue.length
+        to = text.length
+    } else if (isCurrencyFirst && text.length - fiatBalance.length > 0) {
+        // text == "$symbol $fiatBalance" — the leading symbol.
+        from = 0
+        to = text.length - fiatBalance.length
+    } else {
+        // text == "$fiatBalance $symbol" — the trailing symbol.
+        from = fiatBalance.length
+        to = text.length
+    }
+    // A stale or mismatched field must degrade to an unstyled amount, never crash.
+    if (from < 0 || to > text.length || from >= to) return null
+    return AmountCurrencySpan(from, to)
 }

--- a/integrations/coinbase/src/test/java/org/dash/wallet/integrations/coinbase/AmountCurrencySpanTest.kt
+++ b/integrations/coinbase/src/test/java/org/dash/wallet/integrations/coinbase/AmountCurrencySpanTest.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.dash.wallet.integrations.coinbase
+
+import org.dash.wallet.integrations.coinbase.ui.AmountCurrencySpan
+import org.dash.wallet.integrations.coinbase.ui.amountCurrencySpan
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * MO-995: tapping the fiat option on the Coinbase transfer screen crashed with
+ * `IndexOutOfBoundsException: setSpan (12 ... 7) has end before start`.
+ *
+ * The span bounds are computed from separate mutable ViewModel fields and handed
+ * straight to `Spannable.setSpan`, which throws on a reversed or out-of-bounds
+ * range. These tests pin the bounds for each branch and the degrade-to-null
+ * behaviour that keeps a field mismatch off the crash path.
+ */
+class AmountCurrencySpanTest {
+
+    @Test
+    fun dashSelected_spansTheTrailingCurrencyCode() {
+        // applyNewValue returns "$formattedValue $monetaryCode".
+        val span = amountCurrencySpan(
+            text = "1.5 DASH",
+            isDashSelected = true,
+            formattedValue = "1.5",
+            fiatBalance = "irrelevant on this branch",
+            isCurrencyFirst = false
+        )
+
+        assertEquals(AmountCurrencySpan(3, 8), span)
+    }
+
+    @Test
+    fun fiatCurrencyFirst_spansTheLeadingSymbol() {
+        // applyNewValue returns "$symbol $fiatBalance".
+        val span = amountCurrencySpan(
+            text = "$ 4.52",
+            isDashSelected = false,
+            formattedValue = "stale",
+            fiatBalance = "4.52",
+            isCurrencyFirst = true
+        )
+
+        assertEquals(AmountCurrencySpan(0, 2), span)
+    }
+
+    @Test
+    fun fiatCurrencyLast_spansTheTrailingSymbol() {
+        // applyNewValue returns "$fiatBalance $symbol".
+        val span = amountCurrencySpan(
+            text = "4.52 Kč",
+            isDashSelected = false,
+            formattedValue = "stale",
+            fiatBalance = "4.52",
+            isCurrencyFirst = false
+        )
+
+        assertEquals(AmountCurrencySpan(4, 7), span)
+    }
+
+    /**
+     * The regression itself, with the field lengths from the crash log.
+     *
+     * Switching DASH -> USD converts the amount via `formatInput`, so `inputValue`
+     * becomes a many-decimal figure (12 chars) while `fiatBalance` is the 2-dp
+     * formatted one. Using `inputValue.length` gave from=12 against a 7-char text.
+     * The span must be bounded by `fiatBalance` instead, and must stay in range.
+     */
+    @Test
+    fun fiatCurrencyLast_manyDecimalInput_staysInRange() {
+        val text = "4.52 Kč" // length 7, as in the crash
+        val span = amountCurrencySpan(
+            text = text,
+            isDashSelected = false,
+            formattedValue = "stale",
+            fiatBalance = "4.52",
+            isCurrencyFirst = false
+        )
+
+        requireNotNull(span)
+        assertEquals(4, span.from)
+        assertEquals(7, span.to)
+        // The exact invariant Spannable.setSpan enforces.
+        assert(span.from in 0..span.to && span.to <= text.length)
+    }
+
+    @Test
+    fun reversedBounds_degradeToNullInsteadOfCrashing() {
+        // fiatBalance longer than the whole text — the shape that used to throw.
+        val span = amountCurrencySpan(
+            text = "4.52 Kč",
+            isDashSelected = false,
+            formattedValue = "stale",
+            fiatBalance = "123456789.12",
+            isCurrencyFirst = false
+        )
+
+        assertNull(span)
+    }
+
+    @Test
+    fun emptyRange_degradesToNull() {
+        // Nothing to style: the amount fills the whole text.
+        val span = amountCurrencySpan(
+            text = "1.5",
+            isDashSelected = true,
+            formattedValue = "1.5",
+            fiatBalance = "",
+            isCurrencyFirst = false
+        )
+
+        assertNull(span)
+    }
+
+    @Test
+    fun currencyFirstWithNoRoomForASymbol_fallsBackAndDegradesToNull() {
+        // text.length - fiatBalance.length == 0 sends this down the currency-last
+        // branch, where from == to; that must be null, not a zero-width span.
+        val span = amountCurrencySpan(
+            text = "4.52",
+            isDashSelected = false,
+            formattedValue = "stale",
+            fiatBalance = "4.52",
+            isCurrencyFirst = true
+        )
+
+        assertNull(span)
+    }
+}

--- a/integrations/uphold/build.gradle
+++ b/integrations/uphold/build.gradle
@@ -19,11 +19,28 @@ android {
     buildTypes {
         configureEach {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            // Shipped to consumers (the app) and applied when THEY minify — this
+            // is where this module's keep rules belong.
             consumerProguardFiles 'proguard-rules.pro'
         }
-        release {
-            minifyEnabled true
-        }
+        // NO minifyEnabled here. MO-995: this was the only module in the project
+        // that minified its own library output, and R8 stripped Hilt's
+        // `hilt_aggregated_deps.*` metadata out of the release classes jar
+        // (measured: 5 entries in debug, 0 in release). That metadata is how the
+        // APP module's Hilt processor discovers @AndroidEntryPoint classes in
+        // library modules, so the generated FragmentCImpl did not implement
+        // UpholdPortalFragment_GeneratedInjector and attaching the fragment
+        // crashed with a ClassCastException — release builds only, which is why
+        // it never appeared in development.
+        //
+        // The existing `-keep class org.dash.wallet.integrations.uphold.**` rule
+        // does not help: hilt_aggregated_deps is a different package.
+        //
+        // Dropping it costs nothing. The app module already sets
+        // minifyEnabled true (wallet/build.gradle, release), so every class here
+        // is still shrunk and obfuscated in the final APK — once, at the app
+        // level, with the whole program visible. Minifying a library separately
+        // only removes metadata its consumers still need.
     }
 
     compileOptions {

--- a/scripts/cutover-emulator-test.sh
+++ b/scripts/cutover-emulator-test.sh
@@ -218,8 +218,24 @@ require_state() {
 }
 
 lock_screen()   { adbs input keyevent 26; sleep 2; }   # power -> screen off, keyguard on
-wake_unlock()   { adbs input keyevent 26; sleep 1; adbs input keyevent 82; sleep 1
-                  adbs input text "$PIN"; adbs input keyevent 66; sleep 3; }
+# WAKE ONLY — never `keyevent 26` (power), which TOGGLES: on an already-unlocked
+# device it turns the screen OFF and re-locks it, which silently re-created the
+# Keystore device-locked denial in the middle of a scenario that needs a working
+# bind. Also note `input text` does NOT reach the keyguard PIN pad (digits need
+# keyevents 8-11); scripted PIN entry proved unreliable, so an actually-locked
+# device must be unlocked by hand before running the unlocked scenarios.
+# Keep the screen on for the whole run: the scenarios poll for up to 45s and a
+# screen-off re-locks the device, which re-creates the Keystore denial in the
+# middle of a scenario that needs a working bind.
+keep_awake()    { adbs svc power stayon true >/dev/null 2>&1
+                  adbs settings put system screen_off_timeout 1800000 >/dev/null 2>&1; }
+
+wake_unlock()   { keep_awake; adbs input keyevent 224; sleep 2
+                  if adbs dumpsys window 2>/dev/null | grep -q "mDreamingLockscreen=true"; then
+                    note "WARNING: device still shows a keyguard — unlock it by hand, then re-run."
+                    note "         a locked device denies the master-alias keystore op and this"
+                    note "         scenario needs a WORKING bind."
+                  fi; }
 launch_app()    { adbs monkey -p "$PKG" -c android.intent.category.LAUNCHER 1 >/dev/null 2>&1; sleep 12; }
 start_service() { adbs am start-foreground-service -n "$SVC" >/dev/null 2>&1; sleep 12; }
 
@@ -326,6 +342,8 @@ s3)
   say "S3 — denied, then healed (recovery path; expected to expose the noteAppForeground gap)"
   require_device; require_root
   note "assumes S2 just ran: state DUAL_RUNNING, bind marker unset"
+  show_state
+  mark_log          # S3 had NO mark, so its assertions matched the whole log history
   wake_unlock
   launch_app
   assert_log "bind succeeded after unlock"       "app wallet (bound to new|already bound to) SDK wallet"

--- a/scripts/cutover-emulator-test.sh
+++ b/scripts/cutover-emulator-test.sh
@@ -36,7 +36,7 @@ set -uo pipefail
 PKG=hashengineering.darkcoin.wallet_test
 SVC=$PKG/de.schildbach.wallet.service.BlockchainServiceImpl
 AVD=Pixel_9_API_36_AOPS
-PIN=1234
+PIN=REDACTED
 PREV_VERSION_PRE_CUTOVER=11090000   # any value < FIRST_CUTOVER_VERSION_CODE (11100000)
 BT=~/Library/Android/sdk/build-tools/35.0.1
 APK_DIR=wallet/build/outputs/apk/_testNet3/release
@@ -230,12 +230,37 @@ lock_screen()   { adbs input keyevent 26; sleep 2; }   # power -> screen off, ke
 keep_awake()    { adbs svc power stayon true >/dev/null 2>&1
                   adbs settings put system screen_off_timeout 1800000 >/dev/null 2>&1; }
 
-wake_unlock()   { keep_awake; adbs input keyevent 224; sleep 2
-                  if adbs dumpsys window 2>/dev/null | grep -q "mDreamingLockscreen=true"; then
-                    note "WARNING: device still shows a keyguard — unlock it by hand, then re-run."
-                    note "         a locked device denies the master-alias keystore op and this"
-                    note "         scenario needs a WORKING bind."
-                  fi; }
+# Enter $PIN on the keyguard using DIGIT KEYEVENTS. `input text` does not reach
+# the keyguard PIN pad — that is why earlier scripted unlocks silently failed and
+# left the device locked, which then denied the master-alias keystore op inside
+# scenarios that needed a working bind. KEYCODE_0 is 7, so digit d -> 7+d.
+pin_keyevents() {
+  local i ch
+  for (( i=0; i<${#PIN}; i++ )); do
+    ch=${PIN:$i:1}
+    adbs input keyevent $((7 + ch))
+  done
+  adbs input keyevent 66   # ENTER
+}
+
+# Wake and, if a keyguard is up, dismiss it. Never `keyevent 26` (power), which
+# TOGGLES and would turn the screen OFF on an already-unlocked device.
+wake_unlock() {
+  keep_awake
+  adbs input keyevent 224; sleep 2
+  if adbs dumpsys window 2>/dev/null | grep -q "mDreamingLockscreen=true"; then
+    adbs input swipe 540 2000 540 600 300; sleep 2
+    pin_keyevents; sleep 4
+  fi
+  if adbs dumpsys window 2>/dev/null | grep -q "mDreamingLockscreen=true"; then
+    note "WARNING: keyguard still up after entering \$PIN — unlock by hand, then re-run."
+    note "         a locked device denies the master-alias keystore op and this"
+    note "         scenario needs a WORKING bind."
+  else
+    note "device unlocked"
+  fi
+}
+
 launch_app()    { adbs monkey -p "$PKG" -c android.intent.category.LAUNCHER 1 >/dev/null 2>&1; sleep 12; }
 start_service() { adbs am start-foreground-service -n "$SVC" >/dev/null 2>&1; sleep 12; }
 

--- a/scripts/cutover-emulator-test.sh
+++ b/scripts/cutover-emulator-test.sh
@@ -41,11 +41,47 @@ AVD=Pixel_9_API_36_AOPS
 # NEVER hardcode it — supply it per run:  EMULATOR_PIN=... ./this-script s3
 # Only the scenarios that lock the screen need it (s2, and s3's unlock).
 PIN="${EMULATOR_PIN:-}"
-PREV_VERSION_PRE_CUTOVER=11090000   # any value < FIRST_CUTOVER_VERSION_CODE (11100000)
+# MUST match CutoverCoordinator.FIRST_CUTOVER_VERSION_CODE. The cutover ships
+# in 12.0.0, so the boundary is 12000000 — it MOVED here from 11100000 when the
+# release slipped a line. Two copies of a boundary is one copy too many: this
+# used to be hardcoded again below, where a device last run on 11.10–11.25 (which
+# the APP counts as pre-cutover) was judged post-cutover by the script, so the
+# script overwrote a genuine last_version instead of leaving it alone.
+FIRST_CUTOVER_VERSION_CODE=12000000
+PREV_VERSION_PRE_CUTOVER=11090000   # any value < FIRST_CUTOVER_VERSION_CODE
 BT=~/Library/Android/sdk/build-tools/35.0.1
 APK_DIR=wallet/build/outputs/apk/_testNet3/release
 OUT=/tmp/mo995-emulator
 mkdir -p "$OUT"
+
+# Assertion ledger. Every FAIL bumps this; the EXIT trap turns a non-zero
+# count into a non-zero exit status.
+#
+# WHY NOT `exit 1` AT THE FAILING ASSERTION: each scenario is a SEQUENCE of
+# assertions and the diagnostic value is in seeing all of them. S3 asserting
+# "bind failed" then "dashj came back" then "state not committed" tells you
+# WHERE the chain broke; aborting at the first FAIL reports only that it broke.
+# So assertions still print and continue — but the script no longer exits 0
+# after printing FAIL, which would let an automated run call a failed cutover
+# scenario a success.
+FAILURES=0
+
+fail() {
+  FAILURES=$((FAILURES + 1))
+  printf '   \033[31mFAIL\033[0m %s\n' "$1"
+  [ $# -gt 1 ] && printf '        %s\n' "$2"
+  return 0
+}
+
+on_exit() {
+  local rc=$?
+  if [ "$FAILURES" -gt 0 ]; then
+    printf '\n\033[31m%s assertion(s) FAILED\033[0m\n' "$FAILURES"
+    exit 1
+  fi
+  exit "$rc"
+}
+trap on_exit EXIT
 
 say()  { printf '\n\033[1m== %s\033[0m\n' "$*"; }
 note() { printf '   %s\n' "$*"; }
@@ -129,7 +165,7 @@ assert_log() {
     fi
     sleep 5; waited=$((waited + 5))
   done
-  printf '   \033[31mFAIL\033[0m %s\n        (no match in %ss for: %s)\n' "$label" "$budget" "$pat"
+  fail "$label" "(no match in ${budget}s for: $pat)"
 }
 
 # refute_log <label> <grep-pattern>   — PASS if absent from the new lines
@@ -137,7 +173,7 @@ refute_log() {
   local label="$1" pat="$2"
   local w; w=$(since_mark)
   if grep -qE "$pat" "$w"; then
-    printf '   \033[31mFAIL\033[0m %s\n        (unexpected: %s)\n' "$label" "$pat"
+    fail "$label" "(unexpected: $pat)"
     grep -E "$pat" "$w" | head -2 | sed 's/^/          /'
   else printf '   \033[32mPASS\033[0m %s\n' "$label"; fi
 }
@@ -152,7 +188,7 @@ assert_not_committed() {
   local label="$1" raw
   raw=$(adbs "strings /data/data/$PKG/files/datastore/dashpay.preferences_pb 2>/dev/null" | tr -d '\r')
   if echo "$raw" | grep -qE "CUT_OVER|SETTLED"; then
-    printf '   \033[31mFAIL\033[0m %s\n        (persisted state is committed)\n' "$label"
+    fail "$label" "(persisted state is committed)"
   else
     printf '   \033[32mPASS\033[0m %s\n' "$label"
   fi
@@ -161,7 +197,7 @@ assert_not_committed() {
 fake_pre_cutover_previous_launch() {
   # Configuration.lastVersionCode is read from the default SharedPreferences
   # ("last_version", Configuration.java:61) at construction. Writing it here is
-  # exactly equivalent to "the previous launch ran a pre-11.10 build", which is
+  # exactly equivalent to "the previous launch ran a pre-cutover build", which is
   # what CutoverCoordinator's GATE 1 tests — without needing a real v11.9.0 APK
   # signed with matching keys.
   #
@@ -175,13 +211,13 @@ fake_pre_cutover_previous_launch() {
     note "prefs file not present yet — launch the app once, complete onboarding, then re-run"
     return 1
   fi
-  # If a REAL upgrade was just installed over a pre-11.10 build, lastVersionCode
+  # If a REAL upgrade was just installed over a pre-cutover build, lastVersionCode
   # already holds the genuine value — leave it alone. Faking it would only
   # overwrite the truth with the same thing, and hide a mismatch if the real
   # upgrade did not record what we expect.
   local cur
   cur=$(adbs "grep -o 'last_version\" value=\"[0-9]*' $f" 2>/dev/null | grep -o '[0-9]*$' | tr -d '\r')
-  if [ -n "$cur" ] && [ "$cur" -gt 0 ] && [ "$cur" -lt 11100000 ]; then
+  if [ -n "$cur" ] && [ "$cur" -gt 0 ] && [ "$cur" -lt "$FIRST_CUTOVER_VERSION_CODE" ]; then
     note "REAL pre-cutover upgrade detected (last_version=$cur) — not faking it"
     return 0
   fi
@@ -461,7 +497,7 @@ s4)
   if [ "${COUNT:-0}" -ge 2 ]; then
     printf '   \033[32mPASS\033[0m engine restarted after the teardown (%s starts)\n' "$COUNT"
   else
-    printf '   \033[31mFAIL\033[0m engine did NOT restart — MO-995 latch still present (%s starts)\n' "$COUNT"
+    fail "engine did NOT restart — MO-995 latch still present (${COUNT:-0} starts)"
   fi
   ;;
 

--- a/scripts/cutover-emulator-test.sh
+++ b/scripts/cutover-emulator-test.sh
@@ -28,7 +28,8 @@
 #         ./scripts/cutover-emulator-test.sh setup      # build+sign+upgrade-install
 #         ./scripts/cutover-emulator-test.sh s1        # upgrade, bind works
 #         ./scripts/cutover-emulator-test.sh s2        # upgrade, bind denied
-#         ./scripts/cutover-emulator-test.sh s3        # denied then healed
+#         ./scripts/cutover-emulator-test.sh s3        # denied then healed in-session
+#         ./scripts/cutover-emulator-test.sh s3b       # ...and the next launch commits
 #         ./scripts/cutover-emulator-test.sh s4        # trim -> SPV restart
 #         ./scripts/cutover-emulator-test.sh log       # pull + tail wallet.log
 set -uo pipefail
@@ -136,6 +137,22 @@ refute_log() {
     printf '   \033[31mFAIL\033[0m %s\n        (unexpected: %s)\n' "$label" "$pat"
     grep -E "$pat" "$w" | head -2 | sed 's/^/          /'
   else printf '   \033[32mPASS\033[0m %s\n' "$label"; fi
+}
+
+# assert_not_committed <label> — reads the PERSISTED state, not the log.
+# The engine-gate lines (`dashjEngineMayStart=`, `starting peergroup`) are only
+# emitted at service onCreate. A scenario that deliberately keeps ONE process
+# alive has no new onCreate, so those lines cannot appear in its window and
+# asserting on them is a guaranteed false FAIL. The DataStore is the durable
+# source of truth for who owns L1.
+assert_not_committed() {
+  local label="$1" raw
+  raw=$(adbs "strings /data/data/$PKG/files/datastore/dashpay.preferences_pb 2>/dev/null" | tr -d '\r')
+  if echo "$raw" | grep -qE "CUT_OVER|SETTLED"; then
+    printf '   \033[31mFAIL\033[0m %s\n        (persisted state is committed)\n' "$label"
+  else
+    printf '   \033[32mPASS\033[0m %s\n' "$label"
+  fi
 }
 
 fake_pre_cutover_previous_launch() {
@@ -364,18 +381,49 @@ s2)
   ;;
 
 s3)
-  say "S3 — denied, then healed (recovery path; expected to expose the noteAppForeground gap)"
+  say "S3 — denied, then healed IN-SESSION (the walletB recovery path)"
   require_device; require_root
-  note "assumes S2 just ran: state DUAL_RUNNING, bind marker unset"
+  note "assumes S2 just ran: state DUAL_RUNNING, bind marker unset, screen locked"
   show_state
-  mark_log          # S3 had NO mark, so its assertions matched the whole log history
+  mark_log
   wake_unlock
   launch_app
-  assert_log "bind succeeded after unlock"       "app wallet (bound to new|already bound to) SDK wallet"
-  note "does it recover WITHOUT a restart? (this is the open question)"
-  assert_log "committed in-session"              "cutover state DUAL_RUNNING -> CUT_OVER"
-  note "if the line above FAILED, restart the app and re-check — needing a restart confirms"
-  note "that noteAppForeground() only resets a backoff nothing reads once the wait loop ended"
+
+  # The recovery chain, in order. Each of these was broken until b49ef25b0:
+  #   - ProcessLifecycleOwner never fired, so the foreground signal never existed
+  #   - noteAppForeground was state-only, so nothing drove a retry
+  #   - nothing else calls maybeRetry once the cutover correctly declines to commit
+  assert_log "app-foreground signal fired"       "App moved to foreground"
+  assert_log "foreground drove a bind retry"     "app foregrounded with an SDK bind retry pending"
+  assert_log "the retry ran a pass"              "SDK bind retry [0-9]+ \(app foreground\)"
+  assert_log "bind healed after the unlock"      "app wallet (bound to new|already bound to) SDK wallet"
+  assert_log "retry pressure cleared"            "bind established after [0-9]+ failed pass"
+
+  # …and it must be the SAME process: a restart would heal it trivially and prove
+  # nothing. walletB restarted repeatedly and never recovered.
+  refute_log "healed WITHOUT a process restart"  "WalletApplication.onCreate\(\)"
+
+  # dashj must still own L1 for this launch. The commit is NOT expected here and
+  # asserting it was my error: the upgrade seam only runs at process start, so
+  # in-session the only route is the readiness-gated auto-commit, which needs
+  # MIN_PARITY_STREAK readings at a 10s throttle AND the SDK scan caught up to
+  # tip. 45s cannot satisfy that, so a missing commit here is correct deferral,
+  # not a defect. The commit is checked on the NEXT launch instead — see s3b.
+  assert_not_committed "dashj still owns L1 (state not committed)"
+  note "commit is deliberately NOT asserted here — run s3b to check the next launch"
+  ;;
+
+s3b)
+  say "S3b — the launch AFTER an in-session heal should commit"
+  require_device; require_root
+  show_state
+  note "the bind marker must be set by now (s3 healed it); the seam can act at process start"
+  adbs am force-stop "$PKG"; sleep 3
+  mark_log
+  wake_unlock
+  launch_app
+  assert_log "committed on the next launch"      "cutover state DUAL_RUNNING -> CUT_OVER|READY_OBSERVED -> CUT_OVER"
+  assert_log "SDK L1 engine started"             "L1 shadow SPV started"
   ;;
 
 s4)

--- a/scripts/cutover-emulator-test.sh
+++ b/scripts/cutover-emulator-test.sh
@@ -37,7 +37,10 @@ set -uo pipefail
 PKG=hashengineering.darkcoin.wallet_test
 SVC=$PKG/de.schildbach.wallet.service.BlockchainServiceImpl
 AVD=Pixel_9_API_36_AOPS
-PIN=REDACTED
+# Device lock PIN, for the scenarios that must lock and unlock the emulator.
+# NEVER hardcode it — supply it per run:  EMULATOR_PIN=... ./this-script s3
+# Only the scenarios that lock the screen need it (s2, and s3's unlock).
+PIN="${EMULATOR_PIN:-}"
 PREV_VERSION_PRE_CUTOVER=11090000   # any value < FIRST_CUTOVER_VERSION_CODE (11100000)
 BT=~/Library/Android/sdk/build-tools/35.0.1
 APK_DIR=wallet/build/outputs/apk/_testNet3/release
@@ -253,6 +256,11 @@ keep_awake()    { adbs svc power stayon true >/dev/null 2>&1
 # scenarios that needed a working bind. KEYCODE_0 is 7, so digit d -> 7+d.
 pin_keyevents() {
   local i ch
+  if [ -z "$PIN" ]; then
+    note "no PIN supplied — set EMULATOR_PIN=<pin> to let the script unlock the device,"
+    note "or unlock it by hand before running this scenario."
+    return 1
+  fi
   for (( i=0; i<${#PIN}; i++ )); do
     ch=${PIN:$i:1}
     adbs input keyevent $((7 + ch))
@@ -337,8 +345,13 @@ setup)
   fi
   note "installed: $(adbs "dumpsys package $PKG | grep -m1 versionName" | tr -d ' \r')"
   say "Ensure a secure lock screen (this is what makes the master alias lock-bound)"
-  adbs locksettings set-pin "$PIN" 2>/dev/null && note "PIN set to $PIN" \
-    || note "locksettings unavailable — set a PIN via Settings before running s2"
+  if [ -n "$PIN" ]; then
+    adbs locksettings set-pin "$PIN" >/dev/null 2>&1 \
+      && note "device PIN set from EMULATOR_PIN" \
+      || note "locksettings unavailable — set a device PIN via Settings before running s2"
+  else
+    note "no EMULATOR_PIN given — set a device PIN yourself; s2/s3 need one to lock+unlock"
+  fi
   note "then run: $0 s1"
   ;;
 

--- a/scripts/cutover-emulator-test.sh
+++ b/scripts/cutover-emulator-test.sh
@@ -1,0 +1,373 @@
+#!/bin/bash
+#
+# MO-995 cutover / SPV-restart test harness for the Android emulator.
+#
+# WHY A RELEASE BUILD: PlatformSyncService.shutdown() skips stopSdkEngines()
+# when BuildConfig.DEBUG (PlatformSyncService.kt:656) — a deliberate warm-SPV
+# battery trade-off. On a debug build the SDK engine never stops on teardown,
+# so neither MO-995 nor its fix can be observed. Everything below needs the
+# _testNet3Release variant.
+#
+# WHY THE AOSP EMULATOR IMAGE: steps 1-3 fake the previous-launch versionCode
+# by writing shared_prefs directly, which needs `adb root`. The
+# android-36/google_apis_playstore image blocks root; android-36/default
+# allows it. Use Pixel_9_API_36_AOPS (Android 16, arm64-v8a — matches all four
+# field devices).
+#
+# WHAT THIS CANNOT REPRODUCE: walletB's FALSE-LOCKED classification
+# (KeyguardManager reports unlocked while Keystore denies). That is the HONOR
+# PTP-N49 OEM defect; on AOSP every denial classifies as "genuinely locked".
+# The false-locked branch is covered by SdkBindRetryServiceTest instead. A
+# green run here does NOT clear the HONOR case.
+#
+# ORDER OF OPERATIONS: you install the PRE-CUTOVER build yourself and onboard
+# /sync it. Then `setup` builds, signs and installs the fix build OVER it —
+# that install is the upgrade under test. The scenarios run after that.
+#
+# Usage:  ./scripts/cutover-emulator-test.sh <step>
+#         ./scripts/cutover-emulator-test.sh setup      # build+sign+upgrade-install
+#         ./scripts/cutover-emulator-test.sh s1        # upgrade, bind works
+#         ./scripts/cutover-emulator-test.sh s2        # upgrade, bind denied
+#         ./scripts/cutover-emulator-test.sh s3        # denied then healed
+#         ./scripts/cutover-emulator-test.sh s4        # trim -> SPV restart
+#         ./scripts/cutover-emulator-test.sh log       # pull + tail wallet.log
+set -uo pipefail
+
+PKG=hashengineering.darkcoin.wallet_test
+SVC=$PKG/de.schildbach.wallet.service.BlockchainServiceImpl
+AVD=Pixel_9_API_36_AOPS
+PIN=1234
+PREV_VERSION_PRE_CUTOVER=11090000   # any value < FIRST_CUTOVER_VERSION_CODE (11100000)
+BT=~/Library/Android/sdk/build-tools/35.0.1
+APK_DIR=wallet/build/outputs/apk/_testNet3/release
+OUT=/tmp/mo995-emulator
+mkdir -p "$OUT"
+
+say()  { printf '\n\033[1m== %s\033[0m\n' "$*"; }
+note() { printf '   %s\n' "$*"; }
+adbs() { adb shell "$@"; }
+
+require_device() {
+  adb get-state >/dev/null 2>&1 || { echo "No device. Start it: emulator -avd $AVD -no-snapshot-load"; exit 1; }
+}
+
+# Root is required for the shared_prefs poke and for `run-as`-free log reads.
+require_root() {
+  adb root >/dev/null 2>&1
+  adb wait-for-device >/dev/null 2>&1
+  if [ "$(adbs id -u | tr -d '\r')" != "0" ]; then
+    echo "adb root failed — are you on the google_apis_playstore image? Use $AVD (android-36/default)."
+    exit 1
+  fi
+}
+
+# Pull the log, NEVER silently truncating our copy. The old version fell back
+# to `run-as`, which cannot work on a release build (not debuggable) — so a
+# failed pull wrote an EMPTY file and every assertion reported a false FAIL
+# while the log on the device was fine. Now: re-assert root, retry, and keep
+# the previous copy rather than clobbering it with nothing.
+pull_log() {
+  local dst="$OUT/wallet.log" tmp="$OUT/.wallet.pull" i
+  for i in 1 2 3; do
+    rm -f "$tmp"
+    if adb pull "/data/data/$PKG/files/log/wallet.log" "$tmp" >/dev/null 2>&1 && [ -s "$tmp" ]; then
+      mv -f "$tmp" "$dst"; echo "$dst"; return 0
+    fi
+    adb root >/dev/null 2>&1; adb wait-for-device >/dev/null 2>&1; sleep 2
+  done
+  rm -f "$tmp"
+  if [ -s "$dst" ]; then
+    echo "   WARN: could not refresh the log (adb pull failed) — asserting on the last good copy" >&2
+    echo "$dst"; return 0
+  fi
+  echo "   ERROR: cannot read wallet.log from the device (need adb root; release builds are not run-as-able)" >&2
+  : > "$dst"; echo "$dst"; return 1
+}
+
+# Assertions are SCOPED TO LINES ADDED SINCE mark_log(), not to a truncated
+# file. `rm`-ing wallet.log proved unreliable (logback may hold or recreate the
+# handle), and a stale line from an earlier run silently satisfied a refute —
+# which is exactly how a contaminated S1 reported a false failure. Line-offset
+# scoping is immune to that, and to log rotation (guarded below).
+LOG_MARK=0
+
+mark_log() {
+  local f; f=$(pull_log)
+  LOG_MARK=$(wc -l < "$f" 2>/dev/null | tr -d ' ')
+  : "${LOG_MARK:=0}"
+  note "log marked at line $LOG_MARK — assertions below only see NEW lines"
+}
+
+# Lines appended since the mark. If the log shrank (rotation/truncation),
+# fall back to the whole file rather than silently asserting on nothing.
+# Writes the window to a FILE and echoes its path. Callers must grep the file,
+# never `since_mark | grep -q`: under `set -o pipefail`, grep -q exits on the
+# first match, tail dies of SIGPIPE, and the pipeline reports 141 — so a match
+# looks like a failure. That produced false FAILs for patterns appearing early
+# in a large window while later ones passed.
+since_mark() {
+  local f n out="$OUT/.window"; f=$(pull_log); n=$(wc -l < "$f" | tr -d ' ')
+  if [ "${n:-0}" -lt "${LOG_MARK:-0}" ]; then cp -f "$f" "$out"
+  else tail -n +$((LOG_MARK + 1)) "$f" > "$out"; fi
+  echo "$out"
+}
+
+# assert_log <label> <grep-pattern> [timeout-secs]
+# POLLS rather than sampling once: engine startup on the emulator has been seen
+# to take 15s+ (STARTUP breadcrumb SDK_L1_ENGINE_STARTING +15910ms), so a fixed
+# sleep followed by a single check reports false FAILs for a healthy engine.
+assert_log() {
+  local label="$1" pat="$2" budget="${3:-45}" waited=0
+  while [ "$waited" -lt "$budget" ]; do
+    if grep -qE "$pat" "$(since_mark)"; then
+      printf '   \033[32mPASS\033[0m %s%s\n' "$label" "$([ "$waited" -gt 0 ] && echo " (after ${waited}s)")"
+      return 0
+    fi
+    sleep 5; waited=$((waited + 5))
+  done
+  printf '   \033[31mFAIL\033[0m %s\n        (no match in %ss for: %s)\n' "$label" "$budget" "$pat"
+}
+
+# refute_log <label> <grep-pattern>   — PASS if absent from the new lines
+refute_log() {
+  local label="$1" pat="$2"
+  local w; w=$(since_mark)
+  if grep -qE "$pat" "$w"; then
+    printf '   \033[31mFAIL\033[0m %s\n        (unexpected: %s)\n' "$label" "$pat"
+    grep -E "$pat" "$w" | head -2 | sed 's/^/          /'
+  else printf '   \033[32mPASS\033[0m %s\n' "$label"; fi
+}
+
+fake_pre_cutover_previous_launch() {
+  # Configuration.lastVersionCode is read from the default SharedPreferences
+  # ("last_version", Configuration.java:61) at construction. Writing it here is
+  # exactly equivalent to "the previous launch ran a pre-11.10 build", which is
+  # what CutoverCoordinator's GATE 1 tests — without needing a real v11.9.0 APK
+  # signed with matching keys.
+  #
+  # CAVEAT: this exercises the GATE logic, not real upgrade mechanics (Room
+  # migrations, wallet-protobuf format). For a true upgrade rehearsal, build
+  # tag v11.9.0 with the same signing config and install that first instead.
+  local f="/data/data/$PKG/shared_prefs/${PKG}_preferences.xml"
+  adbs am force-stop "$PKG"
+  sleep 1
+  if ! adbs "test -f $f" 2>/dev/null; then
+    note "prefs file not present yet — launch the app once, complete onboarding, then re-run"
+    return 1
+  fi
+  # If a REAL upgrade was just installed over a pre-11.10 build, lastVersionCode
+  # already holds the genuine value — leave it alone. Faking it would only
+  # overwrite the truth with the same thing, and hide a mismatch if the real
+  # upgrade did not record what we expect.
+  local cur
+  cur=$(adbs "grep -o 'last_version\" value=\"[0-9]*' $f" 2>/dev/null | grep -o '[0-9]*$' | tr -d '\r')
+  if [ -n "$cur" ] && [ "$cur" -gt 0 ] && [ "$cur" -lt 11100000 ]; then
+    note "REAL pre-cutover upgrade detected (last_version=$cur) — not faking it"
+    return 0
+  fi
+  note "no real pre-cutover previous launch (last_version=${cur:-unset}) — faking it"
+  adbs "sed -i 's#<int name=\"last_version\" value=\"[0-9]*\" />#<int name=\"last_version\" value=\"$PREV_VERSION_PRE_CUTOVER\" />#' $f"
+  note "last_version now: $(adbs "grep -o 'last_version\" value=\"[0-9]*' $f" | tr -d '\r')"
+}
+
+clear_cutover_state() {
+  # DashPayConfig is an androidx preferences DataStore named "dashpay"
+  # (DashPayConfig.kt:107). Deleting it resets cutover_state,
+  # sdk_bind_ever_succeeded and cutover_upgrade_boundary_crossed together.
+  #
+  # OPT-IN ONLY (RESET=1). After a REAL upgrade from a pre-cutover build, this
+  # state IS the thing under test — wiping it would destroy the scenario and
+  # silently turn a real upgrade run into a synthetic one.
+  if [ "${RESET:-0}" != "1" ]; then
+    note "keeping the existing cutover state (set RESET=1 to wipe it for a synthetic run)"
+    adbs "ls /data/data/$PKG/files/datastore/ 2>/dev/null" | tr -d '\r' | sed 's/^/     datastore: /'
+    return 0
+  fi
+  adbs am force-stop "$PKG"
+  sleep 1
+  adbs "rm -f /data/data/$PKG/files/datastore/dashpay.preferences_pb"
+  note "cutover DataStore CLEARED (state, bind marker, boundary latch)"
+}
+
+# Print the persisted cutover state. Contaminated preconditions are what make
+# these scenarios silently meaningless, so every run shows its starting point.
+show_state() {
+  local pb="/data/data/$PKG/files/datastore/dashpay.preferences_pb"
+  local raw; raw=$(adbs "strings $pb 2>/dev/null" | tr -d '\r')
+  local st="DUAL_RUNNING(default)"
+  echo "$raw" | grep -q "CUT_OVER"  && st="CUT_OVER"
+  echo "$raw" | grep -q "SETTLED"   && st="SETTLED"
+  local bind="unset" latch="unset"
+  echo "$raw" | grep -q "sdk_bind_ever_succeeded"          && bind="present"
+  echo "$raw" | grep -q "cutover_upgrade_boundary_crossed"  && latch="present"
+  note "state: $st | bind marker: $bind | boundary latch: $latch"
+  note "installed: $(adbs "dumpsys package $PKG | grep -m1 versionName" | tr -d ' \r')"
+}
+
+# require_state <CUT_OVER|PRECOMMIT> — refuse to run a scenario whose
+# precondition is already violated, instead of reporting a bogus FAIL.
+require_state() {
+  local want="$1" pb="/data/data/$PKG/files/datastore/dashpay.preferences_pb" raw
+  raw=$(adbs "strings $pb 2>/dev/null" | tr -d '\r')
+  local committed=no
+  echo "$raw" | grep -qE "CUT_OVER|SETTLED" && committed=yes
+  case "$want" in
+    PRECOMMIT) [ "$committed" = no ]  || { echo "   ABORT: needs a pre-commit state but the cutover is already committed."; echo "          Re-run with RESET=1 to start clean."; exit 2; } ;;
+    CUT_OVER)  [ "$committed" = yes ] || { echo "   ABORT: needs a committed cutover — run s1 first."; exit 2; } ;;
+  esac
+}
+
+lock_screen()   { adbs input keyevent 26; sleep 2; }   # power -> screen off, keyguard on
+wake_unlock()   { adbs input keyevent 26; sleep 1; adbs input keyevent 82; sleep 1
+                  adbs input text "$PIN"; adbs input keyevent 66; sleep 3; }
+launch_app()    { adbs monkey -p "$PKG" -c android.intent.category.LAUNCHER 1 >/dev/null 2>&1; sleep 12; }
+start_service() { adbs am start-foreground-service -n "$SVC" >/dev/null 2>&1; sleep 12; }
+
+case "${1:-}" in
+
+setup)
+  say "Build the RELEASE testnet APK"
+  ./gradlew :wallet:assemble_testNet3Release || exit 1
+  # archivesBaseName is 'dash-wallet' but the concrete name has varied
+  # (dash-wallet-*-release-unsigned.apk vs wallet-*-release-unsigned.apk), and
+  # the flavor dir is '_testNet3'. Discover it instead of hardcoding.
+  UNSIGNED=$(find wallet/build/outputs/apk -path '*release*' -name '*unsigned*.apk' -newermt '-30 minutes' 2>/dev/null | grep -i testnet | head -1)
+  [ -n "$UNSIGNED" ] || UNSIGNED=$(find wallet/build/outputs/apk -path '*release*' -name '*unsigned*.apk' 2>/dev/null | grep -i testnet | head -1)
+  if [ -n "$UNSIGNED" ]; then
+    # The APK must be signed with the SAME key as the build already installed,
+    # or `adb install -r` fails with INSTALL_FAILED_UPDATE_INCOMPATIBLE. The
+    # keystore holds more than one key, so the alias matters:
+    #   KS_ALIAS=<alias>            pick the key (default: keystore's first)
+    #   KEYSTORE=/path/to.keystore  use a different keystore entirely
+    # Find the right one by comparing certs with the installed build:
+    #   keytool -list -v -keystore ~/.android/hashengineering.keystore
+    note "signing $UNSIGNED with ${KEYSTORE:-~/.android/hashengineering.keystore}${KS_ALIAS:+ (alias $KS_ALIAS)}"
+    "$BT/zipalign" -p -f 4 "$UNSIGNED" "$OUT/aligned.apk"
+    if [ -n "${KS_ALIAS:-}" ]; then
+      "$BT/apksigner" sign --ks "${KEYSTORE:-$HOME/.android/hashengineering.keystore}" \
+        --ks-key-alias "$KS_ALIAS" --out "$OUT/test.apk" "$OUT/aligned.apk" || exit 1
+    else
+      "$BT/apksigner" sign --ks "${KEYSTORE:-$HOME/.android/hashengineering.keystore}" \
+        --out "$OUT/test.apk" "$OUT/aligned.apk" || exit 1
+    fi
+    rm -f "$OUT/aligned.apk"
+    APK="$OUT/test.apk"
+  else
+    APK=$(find wallet/build/outputs/apk -path '*release*' -name '*.apk' 2>/dev/null | grep -i testnet | head -1)
+  fi
+  [ -n "${APK:-}" ] && [ -f "$APK" ] || { echo "No testnet release APK found under wallet/build/outputs/apk"; exit 1; }
+  say "Install the fix build OVER the previous version already on the device"
+  require_device; require_root
+  PREV_NAME=$(adbs "dumpsys package $PKG | grep -m1 versionName" 2>/dev/null | tr -d ' \r')
+  PREV_CODE=$(adbs "dumpsys package $PKG | grep -m1 versionCode" 2>/dev/null | tr -d '\r' | sed 's/^ *//')
+  if [ -n "$PREV_NAME" ]; then
+    note "currently installed: $PREV_NAME  ($PREV_CODE)"
+  else
+    note "WARNING: $PKG is not installed — this will be a CLEAN INSTALL, not an upgrade."
+    note "Install your pre-cutover build first if you want the upgrade path tested."
+  fi
+  if ! adb install -r "$APK"; then
+    echo
+    echo "Install failed. If it was INSTALL_FAILED_UPDATE_INCOMPATIBLE, the signing keys differ."
+    echo "Compare them:"
+    echo "  adb shell pm path $PKG                     # then: adb pull <path> old.apk"
+    echo "  $BT/apksigner verify --print-certs old.apk"
+    echo "  $BT/apksigner verify --print-certs $APK"
+    echo "Then re-run with the matching alias, e.g.:"
+    echo "  KS_ALIAS=<alias> $0 setup"
+    exit 1
+  fi
+  note "installed: $(adbs "dumpsys package $PKG | grep -m1 versionName" | tr -d ' \r')"
+  say "Ensure a secure lock screen (this is what makes the master alias lock-bound)"
+  adbs locksettings set-pin "$PIN" 2>/dev/null && note "PIN set to $PIN" \
+    || note "locksettings unavailable — set a PIN via Settings before running s2"
+  note "then run: $0 s1"
+  ;;
+
+s1)
+  say "S1 — upgrade with a WORKING bind (walletC/D shape; regression check)"
+  require_device; require_root
+  clear_cutover_state
+  show_state
+  require_state PRECOMMIT
+  fake_pre_cutover_previous_launch || exit 1
+  mark_log
+  note "launch 1: boundary should latch, commit should DECLINE (bind has not run yet)"
+  wake_unlock; launch_app
+  assert_log "launch 1 declined the commit"      "declining to commit .*bind has never succeeded"
+  refute_log "launch 1 did NOT cut over"         "DUAL_RUNNING -> CUT_OVER"
+  note "launch 2: bind marker now set, latch carries the crossing -> should commit"
+  adbs am force-stop "$PKG"; sleep 2; launch_app
+  assert_log "launch 2 committed"                "cutover state DUAL_RUNNING -> CUT_OVER \(upgraded-wallet launch\)"
+  assert_log "explainer armed"                   "one-time sync explainer armed"
+  assert_log "SDK L1 engine started"             "L1 shadow SPV started"
+  ;;
+
+s2)
+  say "S2 — upgrade with a DENIED bind (walletB shape; the core fix)"
+  require_device; require_root
+  clear_cutover_state
+  show_state
+  require_state PRECOMMIT
+  fake_pre_cutover_previous_launch || exit 1
+  mark_log
+  note "locking the screen so the bind runs while Keystore's super key is zeroed"
+  lock_screen
+  start_service
+  assert_log "keystore denied the master alias"  "Keystore denied '(encrypt|createWallet)' on lock-bound alias"
+  assert_log "commit declined on a broken bind"  "declining to commit .*bind has never succeeded"
+  refute_log "did NOT cut over"                  "DUAL_RUNNING -> CUT_OVER"
+  assert_log "dashj is the live engine"          "starting peergroup"
+  refute_log "wallet is NOT engine-less"         "holding the dashj L1 engine"
+  note "the old bug looked like: 'holding the dashj L1 engine' with no 'L1 shadow SPV started'"
+  ;;
+
+s3)
+  say "S3 — denied, then healed (recovery path; expected to expose the noteAppForeground gap)"
+  require_device; require_root
+  note "assumes S2 just ran: state DUAL_RUNNING, bind marker unset"
+  wake_unlock
+  launch_app
+  assert_log "bind succeeded after unlock"       "app wallet (bound to new|already bound to) SDK wallet"
+  note "does it recover WITHOUT a restart? (this is the open question)"
+  assert_log "committed in-session"              "cutover state DUAL_RUNNING -> CUT_OVER"
+  note "if the line above FAILED, restart the app and re-check — needing a restart confirms"
+  note "that noteAppForeground() only resets a backoff nothing reads once the wait loop ended"
+  ;;
+
+s4)
+  say "S4 — memory trim -> SPV engine restart (the ea506f978 fix)"
+  require_device; require_root
+  show_state
+  require_state CUT_OVER
+  # Force-stop and mark BEFORE launching, so the engine's start is a NEW line.
+  # Marking while the app is already up leaves nothing to observe and reports a
+  # bogus FAIL for a healthy engine.
+  adbs am force-stop "$PKG"; sleep 3
+  mark_log
+  launch_app
+  assert_log "engine started on a cold launch"   "L1 shadow SPV started"
+  note "firing TRIM_MEMORY_BACKGROUND deterministically"
+  adbs am send-trim-memory "$PKG" BACKGROUND; sleep 6
+  assert_log "service tore down"                 "low memory detected, stopping service"
+  assert_log "engine stopped (release build)"    "L1 shadow sync stopped"
+  note "bringing the app back — the engine MUST restart"
+  launch_app
+  COUNT=$(grep -c "L1 shadow SPV started" "$(since_mark)")
+  if [ "${COUNT:-0}" -ge 2 ]; then
+    printf '   \033[32mPASS\033[0m engine restarted after the teardown (%s starts)\n' "$COUNT"
+  else
+    printf '   \033[31mFAIL\033[0m engine did NOT restart — MO-995 latch still present (%s starts)\n' "$COUNT"
+  fi
+  ;;
+
+log)
+  require_device
+  f=$(pull_log); echo "$f"
+  grep -nE "cutover state|declining to commit|Keystore denied|L1 shadow SPV started|L1 shadow sync stopped|low memory detected|idling detected|starting peergroup|holding the dashj L1 engine|bind has never succeeded|explainer armed" "$f" | tail -40
+  ;;
+
+*)
+  sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+  ;;
+esac

--- a/wallet/proguard.cfg
+++ b/wallet/proguard.cfg
@@ -141,6 +141,14 @@
 # dapi-client
 -keep class * extends com.google.protobuf.GeneratedMessageLite { *; }
 
+    # grpc-netty-shaded probes native epoll via reflection in Utils.isEpollAvailable():
+# Class.forName(...Epoll).getDeclaredMethod("isAvailable"). If R8 keeps the class
+# but strips the method, the probe throws NoSuchMethodException instead of returning
+# false, and NettyChannelBuilder.<clinit> dies with ExceptionInInitializerError.
+-keep class io.grpc.netty.shaded.io.netty.channel.epoll.Epoll { *; }
+-keep class io.grpc.netty.shaded.io.netty.channel.epoll.** { *; }
+-dontwarn io.grpc.netty.shaded.io.netty.**
+
 #Glide
 -keep public class * implements com.bumptech.glide.module.GlideModule
 -keep public class * extends com.bumptech.glide.module.AppGlideModule

--- a/wallet/proguard.cfg
+++ b/wallet/proguard.cfg
@@ -141,13 +141,41 @@
 # dapi-client
 -keep class * extends com.google.protobuf.GeneratedMessageLite { *; }
 
-    # grpc-netty-shaded probes native epoll via reflection in Utils.isEpollAvailable():
-# Class.forName(...Epoll).getDeclaredMethod("isAvailable"). If R8 keeps the class
-# but strips the method, the probe throws NoSuchMethodException instead of returning
-# false, and NettyChannelBuilder.<clinit> dies with ExceptionInInitializerError.
--keep class io.grpc.netty.shaded.io.netty.channel.epoll.Epoll { *; }
--keep class io.grpc.netty.shaded.io.netty.channel.epoll.** { *; }
+# grpc-netty-shaded: keep the WHOLE shaded transport, members included.
+#
+# NettyChannelBuilder's static initializer wires its transport entirely by
+# REFLECTION, so R8 sees no reference to the members it needs and strips them.
+# Every strip turns into ExceptionInInitializerError out of
+# NettyChannelBuilder.<clinit>, which kills the process the first time anything
+# constructs a DAPIGrpcMasternode. Two were hit in consecutive release builds:
+#
+#   1. Utils.isEpollAvailable() does Class.forName(...epoll.Epoll)
+#      .getDeclaredMethod("isAvailable"). R8 kept the class and stripped the
+#      method, so the probe threw NoSuchMethodException instead of returning
+#      false (12000005).
+#   2. With epoll then correctly reporting false, <clinit> falls through to
+#      `new ReflectiveChannelFactory<>(NioSocketChannel.class)` on the NEXT
+#      line, which does getConstructor() — and the no-arg constructor of
+#      ...channel.socket.nio.NioSocketChannel had been stripped (12000006,
+#      MO-973: 11 crashes on a HONOR PTP-N49, every one from
+#      PlatformHealthProbe.fetchDapiNodeCoreHeight).
+#
+# Targeted rules are the wrong shape here: each one only reveals the next
+# stripped member, and the set depends on the netty build, the device (epoll vs
+# NIO) and the grpc version. So keep the package wholesale. This costs APK size
+# and forgoes shrinking/obfuscation of the shaded transport; a crash loop in
+# username creation costs more.
+#
+# NOT the real fix. Netty is here only because the legacy Java dapi-client
+# (org.dashj.platform.dapiclient) uses it for transport — the Kotlin SDK does
+# not. Reachable today from PlatformHealthProbe (an ADVISORY row on the
+# username screen), TopUpRepository.getTransaction, IdentityRepository's credit
+# balance, and PlatformSyncService.reportNetworkStatus. When those migrate off
+# the legacy client, delete this block and the dependency with it.
+-keep class io.grpc.netty.shaded.io.netty.** { *; }
+-keep class io.grpc.netty.shaded.io.grpc.netty.** { *; }
 -dontwarn io.grpc.netty.shaded.io.netty.**
+-dontwarn io.grpc.netty.shaded.io.grpc.netty.**
 
 #Glide
 -keep public class * implements com.bumptech.glide.module.GlideModule

--- a/wallet/src/de/schildbach/wallet/AppForegroundMonitor.kt
+++ b/wallet/src/de/schildbach/wallet/AppForegroundMonitor.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.schildbach.wallet
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.slf4j.LoggerFactory
+
+/**
+ * Whether the app has any activity in the STARTED state — i.e. the user can
+ * see it.
+ *
+ * WHY THIS EXISTS RATHER THAN `ProcessLifecycleOwner`:
+ * `wallet/AndroidManifest.xml` removes `androidx.startup.InitializationProvider`
+ * with `tools:node="remove"` (a deliberate cold-start optimisation — that
+ * provider runs before `Application.onCreate` on every launch, and removing it
+ * also suppresses WorkManager's default initializer). That provider is what runs
+ * `lifecycle-process`'s `ProcessLifecycleInitializer`, which is the only thing
+ * that wires `ProcessLifecycleOwner` to activity transitions. Without it
+ * `ProcessLifecycleOwner.get()` returns an owner that never leaves
+ * `INITIALIZED`, so its `onStart`/`onStop` NEVER fire — silently, with no error.
+ *
+ * MO-995 evidence: `BlockchainServiceImpl` observed `ProcessLifecycleOwner` and
+ * logged "App moved to foreground"/"...background" from it. Across a 27,000-line
+ * field log with 36 service `onCreate`s, those lines appear **zero** times. So
+ * `isAppInBackground` was permanently stuck at its initial value, and
+ * `SdkBindRetryService.noteAppForeground()` — the app-foreground bind-retry
+ * trigger — was dead code that had never once run.
+ *
+ * [WalletActivityTracker] is registered the plain way
+ * (`Application.registerActivityLifecycleCallbacks`, WalletApplication:384) and
+ * demonstrably works, and its [ActivitiesTracker] base already computes exactly
+ * the first-started / last-stopped edges. So the signal is taken from there
+ * instead — no androidx.startup, and no effect on any other library's
+ * initializer.
+ *
+ * A plain object rather than an injected singleton: the producer is a
+ * `registerActivityLifecycleCallbacks` callback constructed by
+ * `WalletApplication` before Hilt is usable, and the consumers are services that
+ * come and go. Reads are cheap and lock-free.
+ */
+object AppForegroundMonitor {
+    private val log = LoggerFactory.getLogger(AppForegroundMonitor::class.java)
+
+    private val _isForeground = MutableStateFlow(false)
+
+    /** True while at least one activity is STARTED (visible to the user). */
+    val isForeground: StateFlow<Boolean> = _isForeground.asStateFlow()
+
+    /** Convenience for the many call sites that only want the current value. */
+    val isInBackground: Boolean get() = !_isForeground.value
+
+    /** First activity started — the app became visible. */
+    fun noteForeground() {
+        if (_isForeground.compareAndSet(expect = false, update = true)) {
+            log.info("App moved to foreground")
+        }
+    }
+
+    /** Last activity stopped — the app went away. */
+    fun noteBackground() {
+        if (_isForeground.compareAndSet(expect = true, update = false)) {
+            log.info("App moved to background")
+        }
+    }
+}

--- a/wallet/src/de/schildbach/wallet/WalletActivityTracker.java
+++ b/wallet/src/de/schildbach/wallet/WalletActivityTracker.java
@@ -58,6 +58,13 @@ public class WalletActivityTracker extends ActivitiesTracker {
     @Override
     protected void onStartedAny(boolean isTheFirstOne, Activity activity) {
         super.onStartedAny(isTheFirstOne, activity);
+        // MO-995: the app-foreground signal. ProcessLifecycleOwner cannot supply
+        // it because AndroidManifest.xml removes androidx.startup's
+        // InitializationProvider, so lifecycle-process's initializer never runs
+        // and its onStart/onStop never fire. See AppForegroundMonitor.
+        if (isTheFirstOne) {
+            AppForegroundMonitor.INSTANCE.noteForeground();
+        }
         // force restart if the app was updated
         // this ensures that v6.x or previous will go through the PIN upgrade process
         if (!BuildConfig.DEBUG && app.myPackageReplaced) {
@@ -69,6 +76,7 @@ public class WalletActivityTracker extends ActivitiesTracker {
 
     @Override
     protected void onStoppedLast() {
+        AppForegroundMonitor.INSTANCE.noteBackground();
         autoLogout.setAppWentBackground(true);
         if (config.getAutoLogoutEnabled() && config.getAutoLogoutMinutes() == 0) {
             app.sendBroadcast(new Intent(InteractionAwareActivity.FORCE_FINISH_ACTION));

--- a/wallet/src/de/schildbach/wallet/WalletActivityTracker.java
+++ b/wallet/src/de/schildbach/wallet/WalletActivityTracker.java
@@ -58,13 +58,6 @@ public class WalletActivityTracker extends ActivitiesTracker {
     @Override
     protected void onStartedAny(boolean isTheFirstOne, Activity activity) {
         super.onStartedAny(isTheFirstOne, activity);
-        // MO-995: the app-foreground signal. ProcessLifecycleOwner cannot supply
-        // it because AndroidManifest.xml removes androidx.startup's
-        // InitializationProvider, so lifecycle-process's initializer never runs
-        // and its onStart/onStop never fire. See AppForegroundMonitor.
-        if (isTheFirstOne) {
-            AppForegroundMonitor.INSTANCE.noteForeground();
-        }
         // force restart if the app was updated
         // this ensures that v6.x or previous will go through the PIN upgrade process
         if (!BuildConfig.DEBUG && app.myPackageReplaced) {
@@ -76,7 +69,6 @@ public class WalletActivityTracker extends ActivitiesTracker {
 
     @Override
     protected void onStoppedLast() {
-        AppForegroundMonitor.INSTANCE.noteBackground();
         autoLogout.setAppWentBackground(true);
         if (config.getAutoLogoutEnabled() && config.getAutoLogoutMinutes() == 0) {
             app.sendBroadcast(new Intent(InteractionAwareActivity.FORCE_FINISH_ACTION));
@@ -119,12 +111,25 @@ public class WalletActivityTracker extends ActivitiesTracker {
     public void onActivityStarted(@NonNull Activity activity) {
         visibleActivityCount++;
         currentActivity = activity;
+        // MO-995: the app-foreground signal, derived from THIS counter rather
+        // than the ActivitiesTracker base's onStartedFirst/onStoppedLast hooks —
+        // those never run, because this class overrides onActivityStarted /
+        // onActivityStopped without calling super, so the base's numStarted
+        // never advances. visibleActivityCount is the counter that actually
+        // tracks reality. See AppForegroundMonitor for why
+        // ProcessLifecycleOwner cannot supply this at all.
+        if (visibleActivityCount == 1) {
+            AppForegroundMonitor.INSTANCE.noteForeground();
+        }
         logState();
     }
 
     public void onActivityStopped(@NonNull Activity activity) {
         visibleActivityCount--;
         currentActivity = activity;
+        if (visibleActivityCount == 0) {
+            AppForegroundMonitor.INSTANCE.noteBackground();
+        }
         logState();
     }
 

--- a/wallet/src/de/schildbach/wallet/WalletActivityTracker.java
+++ b/wallet/src/de/schildbach/wallet/WalletActivityTracker.java
@@ -55,11 +55,24 @@ public class WalletActivityTracker extends ActivitiesTracker {
         this.restartService = restartService;
     }
 
+    /**
+     * DORMANT — deliberately not wired up. Reached only via
+     * ActivitiesTracker.onActivityStarted, which this class overrides without
+     * calling super, so it has never run here (nor in the anonymous tracker
+     * this class replaced, which had the same defect).
+     *
+     * NOT re-enabled along with onStoppedLast, and that is a deliberate
+     * decision rather than an oversight: this forces a full app restart on the
+     * first activity start after any upgrade. Its stated purpose — pushing
+     * v6.x installs through the PIN upgrade — is long obsolete, and switching
+     * it on now would make every 12.x upgrade restart the app during the
+     * cutover release. If the behaviour is still wanted, enable it on purpose
+     * and test the upgrade path; otherwise delete it and `myPackageReplaced`
+     * with it. Tracked separately from MO-995.
+     */
     @Override
     protected void onStartedAny(boolean isTheFirstOne, Activity activity) {
         super.onStartedAny(isTheFirstOne, activity);
-        // force restart if the app was updated
-        // this ensures that v6.x or previous will go through the PIN upgrade process
         if (!BuildConfig.DEBUG && app.myPackageReplaced) {
             log.info("restarting app due to upgrade");
             app.myPackageReplaced = false;
@@ -129,6 +142,15 @@ public class WalletActivityTracker extends ActivitiesTracker {
         currentActivity = activity;
         if (visibleActivityCount == 0) {
             AppForegroundMonitor.INSTANCE.noteBackground();
+            // MO-995: invoke the last-stopped hook explicitly. The base class's
+            // onStoppedLast() is NEVER reached, because this class overrides
+            // onActivityStarted/onActivityStopped without calling super, so
+            // ActivitiesTracker.numStarted never advances. That has been true
+            // since before this class existed — the anonymous tracker it
+            // replaced (WalletApplication, pre-fae81fefb) had the identical
+            // bug — so autoLogout has not been told the app backgrounded, and
+            // the zero-minute force-finish has not fired, for a long time.
+            onStoppedLast();
         }
         logState();
     }

--- a/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.kt
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.kt
@@ -197,6 +197,26 @@ import de.schildbach.wallet.util.toTxId
 import de.schildbach.wallet.util.toSha256Hash
 
 /**
+ * Whether a dashj `onCoinsReceived` delivery should raise the "Received x" push.
+ *
+ * The whole decision, in one pure place, over the two inputs that matter:
+ *
+ * - [walletAuthored] — this wallet built the transaction, so it is a SEND however dashj values it.
+ *   Post-cutover the SDK authors every send and
+ *   [de.schildbach.wallet.service.platform.sdk.SdkBridgedTransactionFactory] commits it into the
+ *   dashj wallet-of-record; dashj cannot attribute the SDK-owned inputs, values the tx by its
+ *   `+change` output alone and delivers it here as if money had arrived.
+ * - [correctedNet] — the signed net effect on the wallet, SDK-corrected where a display row exists.
+ *   Must be the SAME value the notification goes on to announce: reading it twice is what let the
+ *   gate say "received" while the announced amount read "-0.0x" (MO-995).
+ *
+ * Pre-cutover this changes nothing: a dashj-authored send is valued negative and already failed the
+ * sign test, and a genuine receive is neither self-authored nor negative.
+ */
+internal fun shouldAnnounceCoinsReceived(walletAuthored: Boolean, correctedNet: Coin): Boolean =
+    !walletAuthored && correctedNet.signum() > 0
+
+/**
  * @author Andreas Schildbach
  * @author Eric Britten
  */
@@ -392,8 +412,12 @@ class BlockchainServiceImpl : LifecycleService(), BlockchainService {
      * sent), keyed by lowercase display-hex txid. Absent → dashj value, so pre-cutover / non-SDK
      * txs are byte-for-byte unchanged.
      *
-     * Runs synchronously on a bitcoinj wallet-listener thread (never the main thread) and fails
-     * soft to [fallback] on ANY error, keeping the notification path non-blocking and robust.
+     * Runs synchronously on a bitcoinj wallet-listener thread and fails soft to [fallback] on ANY
+     * error, keeping the notification path non-blocking and robust. MUST NOT be called from the
+     * main thread: Room has no `allowMainThreadQueries` (see
+     * [de.schildbach.wallet.di.DatabaseModule]), so a main-thread call throws and fails soft to
+     * dashj's misread — which is how a gift-card purchase got announced as a receive (MO-995).
+     * Resolve it ONCE per transaction on the listener thread and thread the value onward.
      */
     private fun correctedNetValue(tx: Transaction, fallback: Coin): Coin {
         return try {
@@ -402,6 +426,34 @@ class BlockchainServiceImpl : LifecycleService(), BlockchainService {
         } catch (t: Throwable) {
             log.warn("tx_display_cache lookup failed for {}, using dashj value", tx.txId, t)
             fallback
+        }
+    }
+
+    /**
+     * Whether THIS wallet authored [tx] — a send, never a receive, whatever signed value dashj
+     * computes for it.
+     *
+     * Post-cutover the SDK builds, signs and broadcasts every send, and
+     * [de.schildbach.wallet.service.platform.sdk.SdkBridgedTransactionFactory] then commits the tx
+     * into the dashj wallet-of-record, stamping `purpose = USER_PAYMENT` and
+     * `confidence.source = SELF` exactly as dashj's own `completeTx` does. dashj cannot attribute
+     * the SDK-owned inputs, so it values the tx by its `+change` output alone and delivers it to
+     * `onCoinsReceived` as if it were money arriving.
+     *
+     * Both stamps are set BEFORE the commit and travel with the tx in memory and on disk, so they
+     * are available the instant the listener fires and cannot go stale — unlike the
+     * tx_display_cache net ([correctedNetValue]), which does not exist yet during the window
+     * between the bridge commit and the SDK's display-row insert.
+     */
+    private fun isWalletAuthored(tx: Transaction): Boolean {
+        if (tx.purpose == Transaction.Purpose.USER_PAYMENT) {
+            return true
+        }
+        return try {
+            tx.confidence.source == TransactionConfidence.Source.SELF
+        } catch (t: Throwable) {
+            log.warn("confidence source unavailable for {}", tx.txId, t)
+            false
         }
     }
 
@@ -543,8 +595,14 @@ class BlockchainServiceImpl : LifecycleService(), BlockchainService {
                 transactionsReceived.incrementAndGet()
                 val address = getWalletAddressOfReceived(tx, wallet)
                 // Prefer the SDK-corrected net for the notification amount; falls back to dashj
-                // for pre-cutover / non-SDK txs (see correctedNetValue).
+                // for pre-cutover / non-SDK txs (see correctedNetValue). Resolved ONCE, here on
+                // the wallet-listener thread, and threaded into passFilters below: the second
+                // lookup that used to happen inside passFilters ran on the MAIN thread, where
+                // Room throws and correctedNetValue fails soft to dashj's positive misread — so
+                // the gate said "received" while this amount said "-0.0x", and a gift-card
+                // purchase was announced as "Received -0.0x" (MO-995).
                 val amount = correctedNetValue(tx, tx.getValue(wallet))
+                val walletAuthored = isWalletAuthored(tx)
                 val confidenceType = tx.confidence.confidenceType
                 val isRestoringBackup = application.configuration.isRestoringBackup
                 handler.post {
@@ -565,7 +623,7 @@ class BlockchainServiceImpl : LifecycleService(), BlockchainService {
                             apiConfirmationHandler!!.matches(tx.toTxInfo(wallet, Constants.NETWORK_PARAMETERS))
                         ) {
                             apiConfirmationHandler!!.handle(tx.toTxInfo(wallet, Constants.NETWORK_PARAMETERS))
-                        } else if (passFilters(tx, wallet)) {
+                        } else if (passFilters(tx, wallet, amount, walletAuthored)) {
                             // resolveLabel is a ContentProvider query and
                             // nm.notify a binder IPC — notification lane, not
                             // main. All coins-received notification state is
@@ -601,12 +659,24 @@ class BlockchainServiceImpl : LifecycleService(), BlockchainService {
                 updateAppWidget()
             }
 
-            private fun passFilters(tx: Transaction, wallet: Wallet): Boolean {
-                // Prefer the SDK-corrected net so an SDK send mis-read by dashj as a positive
-                // "received" value does not trip the received-coins gate; dashj fallback otherwise.
-                val amount = correctedNetValue(tx, tx.getValue(wallet))
-                val isReceived = amount.signum() > 0
-                if (!isReceived) {
+            private fun passFilters(
+                tx: Transaction,
+                wallet: Wallet,
+                amount: Coin,
+                walletAuthored: Boolean
+            ): Boolean {
+                // Our own send is never a receive, whatever value dashj puts on it. This is the
+                // primary post-cutover gate: it holds even in the window where the SDK-corrected
+                // net is not yet on disk and [amount] is still dashj's positive misread of the
+                // +change output (see isWalletAuthored).
+                //
+                // [amount] is the SDK-corrected net resolved once on the wallet-listener thread
+                // (see onCoinsReceived) — the SAME number the notification announces, so the gate
+                // and the announced value can no longer disagree.
+                if (!shouldAnnounceCoinsReceived(walletAuthored, amount)) {
+                    if (walletAuthored) {
+                        log.info("tx {} was authored by this wallet — not a receive, no notification", tx.txId)
+                    }
                     return false
                 }
                 var passFilters = crowdnodeFilters.any { it.matches(tx) }
@@ -629,6 +699,13 @@ class BlockchainServiceImpl : LifecycleService(), BlockchainService {
         address: Address?, amount: Coin,
         exchangeRate: ExchangeRate?
     ) {
+        // FINAL belt: never announce a receive for a non-positive amount. Callers already gate on
+        // the corrected net being positive; this keeps any future caller from rendering the
+        // "Received -0.0x" push QA saw for a gift-card purchase (MO-995).
+        if (amount.signum() <= 0) {
+            log.info("not announcing a receive for the non-positive amount {}", amount.toFriendlyString())
+            return
+        }
         if (notificationCount == 1) nm!!.cancel(Constants.NOTIFICATION_ID_COINS_RECEIVED)
         notificationCount++
         notificationAccumulatedAmount = notificationAccumulatedAmount.add(amount)

--- a/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.kt
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.kt
@@ -269,6 +269,16 @@ class BlockchainServiceImpl : LifecycleService(), BlockchainService {
         private val POST_CUTOVER_IDENTITY_RETRY_INTERVAL_MS = TimeUnit.MINUTES.toMillis(2)
         private val log = LoggerFactory.getLogger(BlockchainServiceImpl::class.java)
         const val START_AS_FOREGROUND_EXTRA = "start_as_foreground"
+
+        /**
+         * True iff a start command's extras mark it as delivered by
+         * `startForegroundService()` — see [shouldPromoteToForeground]. Pure
+         * (Bundle is the only Android type, and it is a plain container), so
+         * host-JVM testable.
+         */
+        @JvmStatic
+        fun carriesForegroundStartPromise(extras: android.os.Bundle?): Boolean =
+            extras != null && extras.containsKey(START_AS_FOREGROUND_EXTRA)
         var cleanupDeferred: CompletableDeferred<Unit>? = null
         private val isCleaningUp = AtomicBoolean(false)
 
@@ -2436,17 +2446,45 @@ class BlockchainServiceImpl : LifecycleService(), BlockchainService {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         log.info(".onStartCommand($intent)")
         super.onStartCommand(intent, flags, startId)
+        // MO-995 CRASH FIX — this MUST stay synchronous, before the coroutine.
+        //
+        // A start delivered by `startForegroundService()` arms a system promise:
+        // call `startForeground()` within a few seconds or the process is killed
+        // with ForegroundServiceDidNotStartInTimeException. This call used to sit
+        // INSIDE the `serviceScope.launch` below, behind
+        // `onCreateCompleted.await()` — so the promise was satisfied only after
+        // the service's whole async init had finished, and not at all if the
+        // service was being torn down instead.
+        //
+        // Field crash (2026-09-02 18:48:44, prod 12.0.0-sync). An AlarmManager
+        // `PendingIntent.getForegroundService` (WalletApplication:1689,
+        // rescheduleService) fired while the idle detector was stopping the
+        // service, so the start command and onDestroy interleaved:
+        //
+        //     18:48:44  idling detected, stopping service
+        //     18:48:44  .onStartCommand(Intent { … (has extras) })
+        //     18:48:44  .onDestroy()
+        //     18:48:44  onStartCommand waiting for onCreate to complete...
+        //     18:48:44  CrashReporter - crashing because of uncaught exception
+        //     android.app.RemoteServiceException$ForegroundServiceDidNotStartInTimeException
+        //
+        // QA reported it as "crash on opening"; it actually fired while the app
+        // sat idle, 12 hours before the wallet was next opened.
+        //
+        // Safe here: Android guarantees `onCreate()` has RETURNED before
+        // `onStartCommand()` runs, and Hilt injects `notificationService` in
+        // `super.onCreate()` (line 1833), so the notification can be built. The
+        // `onCreateCompleted` latch is about this service's own async init
+        // coroutine, which the FGS deadline does not wait for.
+        if (shouldPromoteToForeground(intent)) {
+            startForegroundAndCatch(createNetworkSyncNotification())
+        }
         serviceScope.launch {
             log.info("onStartCommand waiting for onCreate to complete...")
             onCreateCompleted.await() // wait until onCreate is finished
             log.info("onCreate completed, processing onStartCommand")
             if (intent != null) {
                 propagateContext()
-                //Restart service as a Foreground Service if it's synchronizing the blockchain
-                val extras = intent.extras
-                if (extras != null && extras.containsKey(START_AS_FOREGROUND_EXTRA)) {
-                    startForegroundAndCatch(createNetworkSyncNotification())
-                }
                 log.info(
                     "service start command: $intent" + if (intent.hasExtra(Intent.EXTRA_ALARM_COUNT)) " (alarm count: " + intent.getIntExtra(
                         Intent.EXTRA_ALARM_COUNT, 0
@@ -2536,6 +2574,21 @@ class BlockchainServiceImpl : LifecycleService(), BlockchainService {
         }
         foregroundService = ForegroundService.BLOCKCHAIN_SYNC
     }
+
+    /**
+     * Does this start command carry the foreground-service promise?
+     *
+     * Extracted as a pure, static-side function so the MO-995 crash condition
+     * is unit-testable without the Android service lifecycle — the bug was a
+     * MISSED call, and a missed call is only testable if the decision to make
+     * it is separable from making it.
+     *
+     * A null intent (a restart delivery after the process was killed) carries
+     * no promise: the system re-delivers it without a fresh
+     * `startForegroundService()`, so promoting would be wrong.
+     */
+    private fun shouldPromoteToForeground(intent: Intent?): Boolean =
+        carriesForegroundStartPromise(intent?.extras)
 
     private fun startForegroundAndCatch(notification: Notification) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {

--- a/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.kt
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.kt
@@ -48,10 +48,10 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleService
-import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.google.common.base.Stopwatch
 import dagger.hilt.android.AndroidEntryPoint
+import de.schildbach.wallet.AppForegroundMonitor
 import de.schildbach.wallet.Constants
 import de.schildbach.wallet.WalletApplication
 import de.schildbach.wallet.WalletApplicationExt.clearDatabasesForRescan
@@ -203,21 +203,36 @@ import de.schildbach.wallet.util.toSha256Hash
 @AndroidEntryPoint
 class BlockchainServiceImpl : LifecycleService(), BlockchainService {
 
-    private val appLifecycleObserver = object : DefaultLifecycleObserver {
-        override fun onStart(owner: LifecycleOwner) {
-            log.info("App moved to foreground")
-            isAppInBackground = false
-            // MO-995: a pending SDK bind retry escapes the hourly backoff
-            // tail the moment the user is actually looking at the app.
-            if (::sdkBindRetryService.isInitialized) {
-                sdkBindRetryService.noteAppForeground()
+    /**
+     * MO-995: observe the app's foreground state from [AppForegroundMonitor],
+     * NOT from `ProcessLifecycleOwner`.
+     *
+     * This was a `ProcessLifecycleOwner` observer, and it never fired once:
+     * AndroidManifest.xml removes `androidx.startup.InitializationProvider`
+     * (`tools:node="remove"`), so `lifecycle-process`'s initializer never runs
+     * and the process owner never leaves INITIALIZED. Across a 27,000-line
+     * field log with 36 service onCreate()s, "App moved to foreground" appears
+     * zero times — so `isAppInBackground` was frozen and
+     * [SdkBindRetryService.noteAppForeground] had never once been called.
+     * [AppForegroundMonitor] takes the same edges from
+     * [de.schildbach.wallet.WalletActivityTracker], which is registered the
+     * plain way and demonstrably works.
+     */
+    private fun observeAppForeground() {
+        // StateFlow is already conflated+distinct; no distinctUntilChanged needed.
+        AppForegroundMonitor.isForeground
+            .onEach { foreground ->
+                isAppInBackground = !foreground
+                if (foreground && ::sdkBindRetryService.isInitialized) {
+                    // A pending SDK bind retry runs the moment the user is
+                    // actually looking at the app — the device is then provably
+                    // unlocked, which is the heal condition for a device-locked
+                    // keystore denial, and no broadcast has to survive an OEM's
+                    // background restrictions.
+                    sdkBindRetryService.noteAppForeground()
+                }
             }
-        }
-
-        override fun onStop(owner: LifecycleOwner) {
-            log.info("App moved to background")
-            isAppInBackground = true
-        }
+            .launchIn(serviceScope)
     }
 
     companion object {
@@ -1745,7 +1760,7 @@ class BlockchainServiceImpl : LifecycleService(), BlockchainService {
         wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, lockName)
 
         // Register for app lifecycle events to detect background/foreground transitions
-        ProcessLifecycleOwner.get().lifecycle.addObserver(appLifecycleObserver)
+        observeAppForeground()
 
         // DIAGNOSTIC (Tools toggle): while the readout is holding at 99%
         // waiting for a fresh post-catchup parity report (see
@@ -2478,7 +2493,6 @@ class BlockchainServiceImpl : LifecycleService(), BlockchainService {
             networkCallbackRegistered = false
             availableNetworks.clear()
         }
-        ProcessLifecycleOwner.get().lifecycle.removeObserver(appLifecycleObserver)
 
         log.info("receivers unregistered, Now starting coroutine to finish the rest of the cleanup")
 

--- a/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.kt
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.kt
@@ -2148,6 +2148,32 @@ class BlockchainServiceImpl : LifecycleService(), BlockchainService {
                     }.onFailure {
                         log.warn("failed to wire SDK-sourced quorums for Platform", it)
                     }
+
+                    // MO-995 / MO-998: restart the SDK's L1 (SPV) engine on EVERY
+                    // service (re)start, not just the first one of the process.
+                    //
+                    // platformSyncService.resume() — the only in-process path that
+                    // re-kicks the SDK engines — used to live solely in
+                    // checkService()'s peergroup-start block, BELOW the
+                    // `!dashjEngineMayStart` early return. Post-cutover that return
+                    // always fires, so resume() was unreachable and the engines only
+                    // ever came up from PlatformSyncService.init() (once per process,
+                    // from WalletApplication). Any service teardown that stops them
+                    // (release-build shutdown() -> stopSdkEngines(), reached from
+                    // onTrimMemory's low-memory stopSelf(), the idle detector, or the
+                    // Android 15 FGS timeout) therefore killed L1 sync for the rest
+                    // of the process: no incoming transactions, the sync UI stuck at
+                    // "syncing", and sends/top-ups failing with "SPV client not
+                    // started". Worse, the idle detector samples this same engine's
+                    // progress post-cutover, so a dead engine reads as idle and keeps
+                    // tearing the service down — a latch, not a transient.
+                    //
+                    // resume() is idempotent (single-flight bind + idempotent
+                    // startIfEnabled), so the first service start of a process
+                    // harmlessly re-kicks what init() already started. Scoped to the
+                    // post-cutover branch: the pre-cutover path keeps its original
+                    // resume()-at-peergroup-start behavior, unchanged.
+                    platformSyncService.resume()
                 }
 
                 // FIX 2: keep the DASHJ_SYNC_DIAGNOSTIC toggle effective on a LIVE

--- a/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.kt
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.kt
@@ -271,6 +271,48 @@ class BlockchainServiceImpl : LifecycleService(), BlockchainService {
         const val START_AS_FOREGROUND_EXTRA = "start_as_foreground"
 
         /**
+         * Does this `onTrimMemory` level mean the process is genuinely under
+         * memory pressure, i.e. worth tearing the service down for?
+         *
+         * MO-995: this used to be `level >= TRIM_MEMORY_BACKGROUND`, which is
+         * wrong in BOTH directions.
+         *
+         * `TRIM_MEMORY_BACKGROUND` (40) does not mean low memory — it means
+         * "your process has gone onto the LRU background list", i.e. THE USER
+         * LEFT THE APP. So the engine was torn down on every backgrounding and
+         * the log called it "low memory detected". Meanwhile the signals that
+         * DO mean running-low — `TRIM_MEMORY_RUNNING_LOW` (10) and
+         * `TRIM_MEMORY_RUNNING_CRITICAL` (15) — are numerically BELOW 40 and
+         * so were ignored entirely.
+         *
+         * Field log (2026-09-06, testnet 12000004, HONOR PTP-N49, 384/512MB
+         * heap) — the ordinary backgrounding sequence, two seconds apart:
+         *
+         *     10:47:24  onTrimMemory(20) called          <- UI hidden
+         *     10:47:26  onTrimMemory(40) called          <- on the LRU list
+         *     10:47:26  low memory detected, stopping service
+         *     10:47:26  .onDestroy()
+         *
+         * That wallet was doing a from-genesis scan (birthHeight resolved to 0,
+         * 1,548,486 testnet blocks, ~4h at the observed rate) and got three
+         * engine restarts in five minutes, so `scanCaughtUpToTip` never held,
+         * the cutover never committed, and Buy Credits failed for want of an
+         * SDK-owned L1.
+         *
+         * Kept to the two levels that actually mean "you are about to be
+         * killed": `TRIM_MEMORY_COMPLETE` (80, top of the LRU kill list) and
+         * `TRIM_MEMORY_RUNNING_CRITICAL` (15, the system is already killing
+         * background processes). `TRIM_MEMORY_MODERATE` (60) is deliberately
+         * NOT included — mid-LRU is not imminent danger, and a long L1 scan is
+         * exactly the workload that must survive it.
+         *
+         * Pure Int predicate, so every documented level can be pinned by test.
+         */
+        @JvmStatic
+        fun shouldStopForMemoryPressure(level: Int): Boolean =
+            level >= TRIM_MEMORY_COMPLETE || level == TRIM_MEMORY_RUNNING_CRITICAL
+
+        /**
          * True iff a start command's extras mark it as delivered by
          * `startForegroundService()` — see [shouldPromoteToForeground]. Pure
          * (Bundle is the only Android type, and it is a plain container), so
@@ -2815,8 +2857,8 @@ class BlockchainServiceImpl : LifecycleService(), BlockchainService {
 
     override fun onTrimMemory(level: Int) {
         log.info("onTrimMemory({}) called", level)
-        if (level >= TRIM_MEMORY_BACKGROUND) {
-            log.warn("low memory detected, stopping service")
+        if (shouldStopForMemoryPressure(level)) {
+            log.warn("memory pressure (onTrimMemory level {}), stopping service", level)
             stopSelf()
         }
     }

--- a/wallet/src/de/schildbach/wallet/service/L1SyncStatusService.kt
+++ b/wallet/src/de/schildbach/wallet/service/L1SyncStatusService.kt
@@ -362,7 +362,9 @@ internal fun mergeL1SyncDetail(
     progress: ShadowSyncProgress,
     sessionChainLockHeight: Int,
     state: BlockchainState?,
-    bindRetryPending: Boolean = false
+    bindRetryPending: Boolean = false,
+    lastKnownFilterHeight: Long = 0,
+    lastKnownFilterTarget: Long = 0
 ): L1SyncDetail = if (sdkOwnsL1) {
     val idleOrConnecting = progress.phase == ShadowSyncPhase.IDLE ||
         progress.phase == ShadowSyncPhase.CONNECTING
@@ -384,8 +386,33 @@ internal fun mergeL1SyncDetail(
         isSynced = sdkL1ScanCaughtUp(progress),
         headerHeight = maxOf(progress.headerHeight, (state?.bestChainHeight ?: 0).toLong()),
         headerTarget = progress.headerTarget,
-        filterHeight = progress.filterHeight,
-        filterTarget = progress.filterTarget,
+        // MO-995: filters need the same sawtooth guard as the rows above, and
+        // did not have it. BlockchainState carries no filter height (dashj has
+        // no filter pipeline, so the row never persists one), so the backstop
+        // is the last non-zero pair seen in THIS process instead of the row.
+        //
+        // Without it, "Block filters" alone collapsed to "-" during the
+        // IDLE/CONNECTING window while headers, masternode list, chainlock and
+        // percentage all held their last known values — so the screen read
+        // "Synced ... Block headers 2,532,259 ... Block filters —", which is
+        // what QA reported. formatHeights() renders "-" exactly when height
+        // AND target are both <= 0.
+        //
+        // Guarded on idleOrConnecting ONLY, deliberately: outside that window
+        // a filter height that moves BACKWARDS is real and must show honestly
+        // — the DashPay coreHeight backfill legitimately rewinds the scan (seen
+        // dropping 1,543,144 -> 1,252,305 in the field). A blanket max() would
+        // mask that and report a position the engine no longer holds.
+        filterHeight = if (idleOrConnecting) {
+            maxOf(progress.filterHeight, lastKnownFilterHeight)
+        } else {
+            progress.filterHeight
+        },
+        filterTarget = if (idleOrConnecting) {
+            maxOf(progress.filterTarget, lastKnownFilterTarget)
+        } else {
+            progress.filterTarget
+        },
         mnListHeight = maxOf(progress.mnListHeight, (state?.mnlistHeight ?: 0).toLong()),
         chainLockHeight = maxOf(sessionChainLockHeight, state?.chainlockHeight ?: 0)
     )
@@ -513,6 +540,15 @@ class L1SyncStatusService @Inject constructor(
      * failed wallet bind renders as [L1SyncStage.SETUP_RETRYING] instead of
      * the dead "Not started" (MO-995).
      */
+    /**
+     * Last non-zero filter position seen in this process — the in-memory
+     * backstop for the IDLE/CONNECTING window (see [mergeL1SyncDetail]).
+     * Process-scoped by necessity: nothing persists a filter height. On a cold
+     * start with no reading yet, "-" is the honest answer.
+     */
+    @Volatile private var lastFilterHeight = 0L
+    @Volatile private var lastFilterTarget = 0L
+
     val details: Flow<L1SyncDetail> =
         combine(
             cutoverCoordinator.sdkOwnsL1Flow(),
@@ -521,6 +557,14 @@ class L1SyncStatusService @Inject constructor(
             blockchainStateProvider.observeState(),
             sdkWalletBinder.bindRetryPending
         ) { sdkOwnsL1, progress, chainLockHeight, state, bindRetryPending ->
-            mergeL1SyncDetail(sdkOwnsL1, progress, chainLockHeight, state, bindRetryPending)
+            mergeL1SyncDetail(
+                sdkOwnsL1, progress, chainLockHeight, state, bindRetryPending,
+                lastFilterHeight, lastFilterTarget
+            ).also { detail ->
+                // Only ever advance on a real reading; a 0 from an idle engine
+                // must not erase what we are backstopping with.
+                if (detail.filterHeight > 0) lastFilterHeight = detail.filterHeight
+                if (detail.filterTarget > 0) lastFilterTarget = detail.filterTarget
+            }
         }.distinctUntilChanged()
 }

--- a/wallet/src/de/schildbach/wallet/service/L1SyncStatusService.kt
+++ b/wallet/src/de/schildbach/wallet/service/L1SyncStatusService.kt
@@ -403,13 +403,41 @@ internal fun mergeL1SyncDetail(
         // — the DashPay coreHeight backfill legitimately rewinds the scan (seen
         // dropping 1,543,144 -> 1,252,305 in the field). A blanket max() would
         // mask that and report a position the engine no longer holds.
+        // MO-1022 FOLLOW-UP: the in-process backstop above is EMPTY on a cold
+        // start, which is exactly when QA looks. Field log (2026-09-04, prod
+        // 12000004, SM-A536B) — app opened 19:13:07, Network Monitor checked
+        // immediately:
+        //
+        //     19:13:14  L1Shadow phase=IDLE 0.0% headers 0/0 filters 0/0 wallet 2533349
+        //     19:14:14  L1Shadow phase=SYNCED 100.0% headers 2533366/2533366 filters 2533366/2533366
+        //
+        // A full minute of "-" before the engine reconnects. So ALSO floor on
+        // the engine's committed wallet cursor, which that same line shows is
+        // populated (`wallet 2533349`) while filters read 0/0: it is seeded at
+        // shadow start from the SDK's DURABLE watermark
+        // (`L1ShadowSyncService.startIfEnabled` → `sdkWalletSyncedHeight`), so
+        // unlike lastKnownFilter* it survives a process restart. It is not a
+        // proxy either — the committed wallet cursor IS the filter-scan
+        // position, which is why `blockPipelineLagging` measures the scan with
+        // it. (My earlier note here claimed "nothing persists a filter height";
+        // that was wrong.)
+        //
+        // The target takes the SAME floors as the height, so the pair can never
+        // render as height > target. Deliberately NOT the persisted header tip:
+        // that would report a target the filter pipeline never received, and it
+        // is not needed for the invariant.
         filterHeight = if (idleOrConnecting) {
-            maxOf(progress.filterHeight, lastKnownFilterHeight)
+            maxOf(progress.filterHeight, lastKnownFilterHeight, progress.walletSyncedHeight)
         } else {
             progress.filterHeight
         },
         filterTarget = if (idleOrConnecting) {
-            maxOf(progress.filterTarget, lastKnownFilterTarget)
+            maxOf(
+                progress.filterTarget,
+                lastKnownFilterTarget,
+                progress.walletSyncedHeight,
+                lastKnownFilterHeight
+            )
         } else {
             progress.filterTarget
         },
@@ -543,8 +571,10 @@ class L1SyncStatusService @Inject constructor(
     /**
      * Last non-zero filter position seen in this process — the in-memory
      * backstop for the IDLE/CONNECTING window (see [mergeL1SyncDetail]).
-     * Process-scoped by necessity: nothing persists a filter height. On a cold
-     * start with no reading yet, "-" is the honest answer.
+     *
+     * Process-scoped, and therefore EMPTY on a cold start — which is exactly
+     * when the Network Monitor gets opened. The durable half of the backstop
+     * is [ShadowSyncProgress.walletSyncedHeight]; see [mergeL1SyncDetail].
      */
     @Volatile private var lastFilterHeight = 0L
     @Volatile private var lastFilterTarget = 0L

--- a/wallet/src/de/schildbach/wallet/service/L1SyncStatusService.kt
+++ b/wallet/src/de/schildbach/wallet/service/L1SyncStatusService.kt
@@ -422,10 +422,14 @@ internal fun mergeL1SyncDetail(
         // it. (My earlier note here claimed "nothing persists a filter height";
         // that was wrong.)
         //
-        // The target takes the SAME floors as the height, so the pair can never
-        // render as height > target. Deliberately NOT the persisted header tip:
-        // that would report a target the filter pipeline never received, and it
-        // is not needed for the invariant.
+        // The target takes every floor the height takes AND the height's own
+        // raw value, so the pair can never render as height > target. (The
+        // shared floors alone are not enough: both branches read the same
+        // `data.filters` snapshot, so they cannot drift apart, but an engine
+        // that reported currentHeight > targetHeight in one snapshot would
+        // still invert the pair here.) Deliberately NOT the persisted header
+        // tip: that would report a target the filter pipeline never received,
+        // and it is not needed for the invariant.
         filterHeight = if (idleOrConnecting) {
             maxOf(progress.filterHeight, lastKnownFilterHeight, progress.walletSyncedHeight)
         } else {
@@ -436,7 +440,12 @@ internal fun mergeL1SyncDetail(
                 progress.filterTarget,
                 lastKnownFilterTarget,
                 progress.walletSyncedHeight,
-                lastKnownFilterHeight
+                lastKnownFilterHeight,
+                // ...including the raw height itself, which the floors above
+                // do NOT subsume: if the engine ever reports currentHeight >
+                // targetHeight in one snapshot, every other term here can sit
+                // below it and the pair would render inverted.
+                progress.filterHeight
             )
         } else {
             progress.filterTarget

--- a/wallet/src/de/schildbach/wallet/service/platform/PlatformHealthService.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/PlatformHealthService.kt
@@ -17,6 +17,7 @@
 package de.schildbach.wallet.service.platform
 
 import de.schildbach.wallet.Constants
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.bitcoinj.core.NetworkParameters
@@ -89,8 +90,9 @@ internal fun assessPlatformHealth(
  * local dashj chain tip from [BlockchainStateProvider].
  *
  * Every failure — platform unsupported, no masternode list yet, gRPC
- * error, timeout — degrades to [PlatformHealth.UNKNOWN]; the probe never
- * throws.
+ * error, timeout, or a static-initializer Error from the legacy gRPC
+ * transport — degrades to [PlatformHealth.UNKNOWN]. The probe never throws
+ * except for [CancellationException], which must propagate.
  */
 @Singleton
 class PlatformHealthProbe @Inject constructor(
@@ -115,9 +117,33 @@ class PlatformHealthProbe @Inject constructor(
                 platformCoreHeight, localHeight, health
             )
             health
-        } catch (e: Exception) {
-            // Advisory only: a failed probe says nothing about the network.
-            log.warn("platform health probe failed: {}", e.toString())
+        } catch (t: Throwable) {
+            // Cancellation is control flow, not a probe failure — it MUST
+            // propagate or structured concurrency breaks.
+            if (t is CancellationException) throw t
+            if (t is Exception) {
+                // Advisory only: a failed probe says nothing about the network.
+                log.warn("platform health probe failed: {}", t.toString())
+            } else {
+                // MO-973: this used to catch only Exception, and the legacy
+                // gRPC stack fails with an ERROR, not an exception —
+                // ExceptionInInitializerError out of
+                // NettyChannelBuilder.<clinit> when R8 strips a member its
+                // static init reaches by reflection. That sailed past this
+                // catch, past the caller's bare try/finally
+                // (RequestUserNameViewModel.checkNetworkHealth), out of the
+                // coroutine, and killed the process — 11 times on one HONOR
+                // PTP-N49, which QA saw as a username-creation crash, a
+                // username-creation failure, and "the lock screen appears
+                // after clicking Continue" (the relaunch).
+                //
+                // An ADVISORY row must never be able to do that, whatever
+                // breaks underneath it. Logged at ERROR with the full stack
+                // rather than swallowed quietly: degrading silently would
+                // trade a loud crash for an invisible one, and the stack is
+                // what made this diagnosable from a QA report.
+                log.error("platform health probe hit a non-Exception failure; degrading to UNKNOWN", t)
+            }
             PlatformHealth.UNKNOWN
         }
     }

--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/CutoverAutoCommitObserver.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/CutoverAutoCommitObserver.kt
@@ -114,6 +114,10 @@ class CutoverAutoCommitObserver internal constructor(
     @Volatile
     private var lastAttemptMs = Long.MIN_VALUE
 
+    /** Throttle for [reportStillWaiting]. */
+    @Volatile
+    private var lastStatusLogMs = Long.MIN_VALUE
+
     /** Latched once the flip lands: no further attempts until [rearmForNewWallet]. */
     @Volatile
     private var committed = false
@@ -160,6 +164,7 @@ class CutoverAutoCommitObserver internal constructor(
         committed = false
         gate.reset()
         lastAttemptMs = Long.MIN_VALUE
+        lastStatusLogMs = Long.MIN_VALUE
     }
 
     /** Launch the progress collector. Caller holds [lifecycleMutex]. */
@@ -184,7 +189,10 @@ class CutoverAutoCommitObserver internal constructor(
      */
     internal suspend fun onReading(caughtUp: Boolean): CutoverState? {
         val armed = gate.onReading(caughtUp)
-        if (!armed || committed) return null
+        if (!armed || committed) {
+            reportStillWaiting(if (committed) null else "streak ${gate.streak}/$requiredReadings")
+            return null
+        }
         val now = nowMs()
         // Throttle attempts to the parity cadence: the gate arms on the ~1 Hz
         // progress feed, but readiness only changes when a new parity probe
@@ -193,6 +201,12 @@ class CutoverAutoCommitObserver internal constructor(
         lastAttemptMs = now
         return try {
             val status = coordinator.autoAdvanceToCutover()
+            if (status.state != CutoverState.CUT_OVER) {
+                // MO-995: `autoAdvanceToCutover` returns the readiness advisory
+                // unchanged when a blocker holds and logs nothing, so a
+                // non-committing observer used to be completely invisible.
+                reportStillWaiting("readiness says ${status.state}")
+            }
             if (status.state == CutoverState.CUT_OVER) {
                 committed = true
                 collectJob?.cancel()
@@ -205,6 +219,31 @@ class CutoverAutoCommitObserver internal constructor(
             log.warn("cutover auto-commit attempt failed; will retry on a later reading", t)
             null
         }
+    }
+
+    /**
+     * Throttled "why am I not committing yet" line.
+     *
+     * MO-995 (Andrei, comment 91138 #2): in the 2026-09-02 field log this
+     * observer logged `cutover auto-commit observer started` at 07:32:10 and
+     * then NOTHING for the remaining 8.5 hours of the process, while the L1
+     * shadow sat at `phase=SYNCED 100.0%` and parity reported `first sustained
+     * MATCH streak complete`. Both of its non-committing paths returned early
+     * in silence, so the log cannot say whether the stability gate never armed
+     * or the readiness policy kept refusing — and the cutover (with it the
+     * one-time upgrade explainer) fell through to the next process start ten
+     * hours later. One line every [STATUS_LOG_INTERVAL_MS] closes that gap
+     * without flooding the ~1 Hz feed.
+     *
+     * @param reason what is holding, or null when nothing is (already
+     *   committed — there is nothing to report).
+     */
+    private fun reportStillWaiting(reason: String?) {
+        if (reason == null) return
+        val now = nowMs()
+        if (lastStatusLogMs != Long.MIN_VALUE && now - lastStatusLogMs < STATUS_LOG_INTERVAL_MS) return
+        lastStatusLogMs = now
+        log.info("cutover auto-commit still waiting: {}", reason)
     }
 
     companion object {
@@ -227,5 +266,12 @@ class CutoverAutoCommitObserver internal constructor(
          * just re-reads the evaluator's evidence for nothing.
          */
         const val AUTO_COMMIT_ATTEMPT_THROTTLE_MS = L1ShadowSyncService.PARITY_INTERVAL_MS
+
+        /**
+         * Spacing between [reportStillWaiting] lines. Five minutes: rare
+         * enough to be free on a ~1 Hz feed, frequent enough that a
+         * multi-hour non-commit is unmistakable in a field log.
+         */
+        const val STATUS_LOG_INTERVAL_MS = 5 * 60 * 1000L
     }
 }

--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/CutoverCoordinator.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/CutoverCoordinator.kt
@@ -273,6 +273,70 @@ class CutoverCoordinator @Inject constructor(
      */
     fun commitForUpgradedWalletAsync(previousVersionCode: Int) {
         scope.launch {
+            // MO-995 GATE 1 — this must be a REAL upgrade across the cutover
+            // boundary. The same `previousVersionCode` test below used to gate
+            // only the explainer, while the commit itself ran unconditionally.
+            // walletB reached here on a SAME-VERSION relaunch (previous code
+            // 12000001 == this build): the seam committed, dashj was held, the
+            // SDK bind then failed on the keystore, and the wallet was left
+            // with no L1 engine at all. If this launch did not cross the
+            // boundary, the upgrade seam has no business committing — the
+            // readiness-gated auto-commit observer owns that decision.
+            // `previousVersionCode` is the version the PREVIOUS LAUNCH ran, and
+            // `Configuration.updateLastVersionCode` overwrites it every startup
+            // — so the boundary crossing is visible for exactly one launch, and
+            // that is the one launch on which GATE 2 below cannot yet be
+            // satisfied (the bind runs after this seam). Latch it durably so a
+            // later launch with a working bind can still commit.
+            val crossedNow = isPreCutoverUpgrade(previousVersionCode)
+            if (crossedNow) {
+                runCatching {
+                    dashPayConfig.set(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED, true)
+                }.onFailure {
+                    if (it is CancellationException) throw it
+                    log.warn("failed to latch the cutover boundary crossing", it)
+                }
+            }
+            val crossedEver = crossedNow || runCatching {
+                dashPayConfig.get(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED) == true
+            }.getOrDefault(false)
+            if (!crossedEver) {
+                log.info(
+                    "upgrade seam declining to commit the cutover: previous version code {} is " +
+                        "not a pre-{} upgrade (0 = fresh install, >= {} = already on 11.10+) and " +
+                        "no boundary crossing was ever latched — leaving the state alone for the " +
+                        "readiness-gated auto-commit",
+                    previousVersionCode, FIRST_CUTOVER_VERSION_CODE, FIRST_CUTOVER_VERSION_CODE
+                )
+                return@launch
+            }
+
+            // MO-995 GATE 2 — never hand L1 to an SDK that has never proved it
+            // can bind on this install. Committing holds the dashj engine, so
+            // committing while the bind is broken leaves the wallet with NO L1
+            // engine: no sync, no incoming transactions, "setup is incomplete".
+            // walletC/D show the commit today runs 3-7 seconds BEFORE the first
+            // bind is even attempted, so success there was luck, not design.
+            //
+            // Deliberately NOT a deferred/awaited commit: BlockchainServiceImpl
+            // resolves its engine gate once at service onCreate and
+            // `onCutoverStateChanged` is un-hold-only, so a commit landing
+            // mid-launch cannot stop a live dashj peergroup. Declining outright
+            // keeps dashj as the single engine for this launch; once a bind
+            // succeeds, the auto-commit observer earns CUT_OVER through the
+            // normal readiness policy.
+            val bindEverSucceeded =
+                runCatching { dashPayConfig.get(DashPayConfig.SDK_BIND_EVER_SUCCEEDED) == true }
+                    .getOrDefault(false)
+            if (!bindEverSucceeded) {
+                log.warn(
+                    "upgrade seam declining to commit the cutover: the SDK wallet bind has never " +
+                        "succeeded on this install, so handing L1 to the SDK would hold dashj and " +
+                        "leave no L1 engine — staying on dashj until a bind succeeds"
+                )
+                return@launch
+            }
+
             val (_, justCutOver) = mutex.withLock { commitLocked("upgraded-wallet launch") }
             if (!justCutOver) return@launch
             if (freshWalletSetupThisLaunch) {
@@ -283,15 +347,10 @@ class CutoverCoordinator @Inject constructor(
                 )
                 return@launch
             }
-            if (previousVersionCode <= 0 || previousVersionCode >= FIRST_CUTOVER_VERSION_CODE) {
-                log.info(
-                    "upgrade seam committed the cutover, but the previous version code {} is not " +
-                        "a pre-11.10 upgrade (0 = fresh install, >= {} = already on 11.10+) — " +
-                        "suppressing the one-time UPGRADE sync explainer",
-                    previousVersionCode, FIRST_CUTOVER_VERSION_CODE
-                )
-                return@launch
-            }
+            // The version-code condition that used to gate ONLY the explainer
+            // here is now GATE 1 above and gates the commit itself, so reaching
+            // this line already means a genuine pre-cutover upgrade. Arming is
+            // unconditional from here.
             runCatching { dashPayConfig.set(DashPayConfig.CUTOVER_UPGRADE_NOTICE_PENDING, true) }
                 .onSuccess { log.info("upgrade cutover: one-time sync explainer armed") }
                 .onFailure {
@@ -470,3 +529,22 @@ class CutoverCoordinator @Inject constructor(
         private val READY_VERDICT = CutoverVerdict(emptySet())
     }
 }
+
+/**
+ * Whether [previousVersionCode] — the versionCode recorded by the launch
+ * BEFORE this one — means this launch genuinely crossed the cutover boundary,
+ * i.e. the app was last run on a pre-11.10 build.
+ *
+ * `0` means the app was never run before (fresh install), and anything at or
+ * above [CutoverCoordinator.FIRST_CUTOVER_VERSION_CODE] means the previous
+ * launch was already on 11.10+ — including a relaunch of the SAME build,
+ * which is what walletB hit (previous code 12000001 on a 12000001 build).
+ * Neither is an upgrade across the boundary, so neither may drive the
+ * UPGRADE seam's commit.
+ *
+ * Pure and host-testable: this is the predicate that decides whether the
+ * upgrade seam is allowed to hand L1 to the SDK at all.
+ */
+internal fun isPreCutoverUpgrade(previousVersionCode: Int): Boolean =
+    previousVersionCode > 0 &&
+        previousVersionCode < CutoverCoordinator.FIRST_CUTOVER_VERSION_CODE

--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/CutoverCoordinator.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/CutoverCoordinator.kt
@@ -327,17 +327,73 @@ class CutoverCoordinator @Inject constructor(
             }
             // The version-code condition that used to gate ONLY the explainer
             // here is now GATE 1 above and gates the commit itself, so reaching
-            // this line already means a genuine pre-cutover upgrade. Arming is
-            // unconditional from here.
-            runCatching { dashPayConfig.set(DashPayConfig.CUTOVER_UPGRADE_NOTICE_PENDING, true) }
-                .onSuccess { log.info("upgrade cutover: one-time sync explainer armed") }
-                .onFailure {
-                    if (it is CancellationException) throw it
-                    // Non-fatal: the cutover itself already committed; the
-                    // user simply does not get the explainer.
-                    log.warn("failed to arm the upgrade sync explainer", it)
-                }
+            // this line already means a genuine pre-cutover upgrade. The one
+            // remaining condition is the once-per-install latch inside
+            // armUpgradeNoticeOnce() — GATE 1's durable boundary latch makes
+            // this line reachable on more than one launch (rollback → commit),
+            // and the explainer promises it happens only once.
+            armUpgradeNoticeOnce()
         }
+    }
+
+    /**
+     * Arm the one-time upgrade sync explainer, at most ONCE per install.
+     *
+     * MO-995 (Andrei, comment 91138 #2). The explainer's own copy promises
+     * "This happens only once, after this update", but its marker
+     * ([DashPayConfig.CUTOVER_UPGRADE_NOTICE_PENDING]) is a *pending* flag that
+     * the sheet clears on acknowledgment — after which an arming site cannot
+     * tell "already shown and dismissed" from "never armed". Field log
+     * (2026-09-02, prod, 11.9.1 -> 12.0.0-sync): acknowledged on the 07:31:54
+     * upgrade launch, then armed again by the deferred commit at 17:31:54, ten
+     * hours later. So the arming needs a marker that is never cleared, which is
+     * [DashPayConfig.CUTOVER_UPGRADE_NOTICE_EVER_ARMED].
+     *
+     * WHY THE COMMIT IS THAT LATE, since it is what makes a second arming
+     * reachable at all: the bind-evidence gate
+     * ([refusesCutOverWithoutBindEvidence]) cannot pass on the upgrade launch
+     * — the bind runs after this seam — so the boundary is latched and the
+     * commit lands on a later process start, whenever that happens to be. The
+     * readiness-driven [CutoverAutoCommitObserver] is the in-launch path that
+     * would close the gap, and in that same log it ran for 8.5 hours without
+     * committing. Bounding the deferral means changing which engine owns L1
+     * mid-launch, which the "never two live SPV engines" invariant forbids
+     * (see [rollbackForFailedBind]) — so the deferral stays, and this makes it
+     * harmless to the user.
+     *
+     * Ordering note: the latch is written BEFORE the pending flag. A crash
+     * between the two costs the user the explainer; the reverse order would
+     * re-arm forever, which is the bug being fixed. Never throws.
+     */
+    private suspend fun armUpgradeNoticeOnce() {
+        val everArmed = runCatching {
+            dashPayConfig.get(DashPayConfig.CUTOVER_UPGRADE_NOTICE_EVER_ARMED) == true
+        }.getOrElse {
+            if (it is CancellationException) throw it
+            // Unreadable latch: assume it WAS armed. Suppressing an explainer
+            // the user may already have seen beats re-showing a "happens only
+            // once" sheet on every commit.
+            log.warn("failed to read the upgrade sync-explainer latch; suppressing the explainer", it)
+            true
+        }
+        if (everArmed) {
+            log.info(
+                "upgrade cutover committed, but the one-time sync explainer was already armed " +
+                    "once on this install — not arming it again"
+            )
+            return
+        }
+        runCatching {
+            dashPayConfig.set(DashPayConfig.CUTOVER_UPGRADE_NOTICE_EVER_ARMED, true)
+            dashPayConfig.set(DashPayConfig.CUTOVER_UPGRADE_NOTICE_PENDING, true)
+        }
+            .onSuccess { log.info("upgrade cutover: one-time sync explainer armed") }
+            .onFailure {
+                if (it is CancellationException) throw it
+                // Non-fatal: the cutover itself already committed; the
+                // user simply does not get the explainer.
+                log.warn("failed to arm the upgrade sync explainer", it)
+            }
     }
 
     suspend fun commitForFreshWalletSetup(): CutoverStatus = mutex.withLock {

--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/CutoverCoordinator.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/CutoverCoordinator.kt
@@ -311,32 +311,10 @@ class CutoverCoordinator @Inject constructor(
                 return@launch
             }
 
-            // MO-995 GATE 2 — never hand L1 to an SDK that has never proved it
-            // can bind on this install. Committing holds the dashj engine, so
-            // committing while the bind is broken leaves the wallet with NO L1
-            // engine: no sync, no incoming transactions, "setup is incomplete".
-            // walletC/D show the commit today runs 3-7 seconds BEFORE the first
-            // bind is even attempted, so success there was luck, not design.
-            //
-            // Deliberately NOT a deferred/awaited commit: BlockchainServiceImpl
-            // resolves its engine gate once at service onCreate and
-            // `onCutoverStateChanged` is un-hold-only, so a commit landing
-            // mid-launch cannot stop a live dashj peergroup. Declining outright
-            // keeps dashj as the single engine for this launch; once a bind
-            // succeeds, the auto-commit observer earns CUT_OVER through the
-            // normal readiness policy.
-            val bindEverSucceeded =
-                runCatching { dashPayConfig.get(DashPayConfig.SDK_BIND_EVER_SUCCEEDED) == true }
-                    .getOrDefault(false)
-            if (!bindEverSucceeded) {
-                log.warn(
-                    "upgrade seam declining to commit the cutover: the SDK wallet bind has never " +
-                        "succeeded on this install, so handing L1 to the SDK would hold dashj and " +
-                        "leave no L1 engine — staying on dashj until a bind succeeds"
-                )
-                return@launch
-            }
-
+            // GATE 2 (bind evidence) now lives in commitLocked /
+            // refusesCutOverWithoutBindEvidence, so EVERY commit path inherits
+            // it — the seam, the fresh-wallet commit, and the readiness-driven
+            // auto-commit that used to bypass it entirely.
             val (_, justCutOver) = mutex.withLock { commitLocked("upgraded-wallet launch") }
             if (!justCutOver) return@launch
             if (freshWalletSetupThisLaunch) {
@@ -415,6 +393,49 @@ class CutoverCoordinator @Inject constructor(
      * corrupted by a racing commit — the property the one-time upgrade
      * explainer depends on. Must be called under [mutex].
      */
+    /**
+     * Whether the SDK has ever proved, on THIS install, that it can bind the
+     * app wallet — i.e. that its Keystore-backed master alias is usable. Set by
+     * [de.schildbach.wallet.service.platform.sdk.SdkWalletBinder] on the first
+     * successful pass. Absent reads as false: fail safe, not fail open.
+     */
+    private suspend fun sdkBindEverSucceeded(): Boolean =
+        runCatching { dashPayConfig.get(DashPayConfig.SDK_BIND_EVER_SUCCEEDED) == true }
+            .getOrDefault(false)
+
+    /**
+     * MO-995: refuse ANY transition into CUT_OVER while the SDK has never bound.
+     *
+     * Committing HOLDS the dashj engine, so committing onto an SDK that cannot
+     * bind leaves the wallet with NO L1 engine — no sync, no incoming
+     * transactions, "setup is incomplete" (walletB, HONOR PTP-N49, 16
+     * consecutive `KeystoreDeviceLockedException` denials on the lock-bound
+     * master alias).
+     *
+     * WHY HERE AND NOT ONLY AT THE SEAM: the gate first lived in
+     * [commitForUpgradedWalletAsync], which left the readiness-driven path
+     * wide open. On the emulator, with every bind failing,
+     * [CutoverAutoCommitObserver] still committed FOUR times —
+     * `READY_OBSERVED -> CUT_OVER on COMMIT_CUTOVER (ready=true)` followed by
+     * "SDK is now L1-primary (dashj held)" — reaching walletB's end state
+     * through a different door. The readiness evaluator has no notion of
+     * whether the wallet is bound, so this has to be checked where the write
+     * happens: [commitLocked] AND [transition] both consult it.
+     *
+     * Only CUT_OVER is guarded. ROLLBACK and the wipe reset move AWAY from a
+     * committed state and must never be blocked — that is the escape hatch.
+     */
+    private suspend fun refusesCutOverWithoutBindEvidence(to: CutoverState): Boolean {
+        if (to != CutoverState.CUT_OVER) return false
+        if (sdkBindEverSucceeded()) return false
+        log.warn(
+            "declining to commit the cutover: the SDK wallet bind has never succeeded on this " +
+                "install, so handing L1 to the SDK would hold dashj and leave no L1 engine — " +
+                "staying on dashj until a bind succeeds"
+        )
+        return true
+    }
+
     private suspend fun commitLocked(reason: String): Pair<CutoverStatus, Boolean> {
         val current = currentState()
         if (current == CutoverState.CUT_OVER || current == CutoverState.SETTLED) {
@@ -426,6 +447,9 @@ class CutoverCoordinator @Inject constructor(
                     "engine is inactive, so dashj must keep owning L1 (staying {})",
                 current
             )
+            return CutoverStatus(current, READY_VERDICT) to false
+        }
+        if (refusesCutOverWithoutBindEvidence(CutoverState.CUT_OVER)) {
             return CutoverStatus(current, READY_VERDICT) to false
         }
         val status = writeState(current, CutoverState.CUT_OVER, reason)
@@ -493,6 +517,11 @@ class CutoverCoordinator @Inject constructor(
             return@withLock CutoverStatus(current, CutoverVerdict(setOf(CutoverBlocker.PARITY_EVIDENCE_STALE)))
         }
         val next = nextCutoverState(current, action, verdict.ready)
+        if (next != current && refusesCutOverWithoutBindEvidence(next)) {
+            // Readiness said yes, but the SDK cannot own L1. Report the state
+            // unchanged so the observer keeps observing instead of standing down.
+            return@withLock CutoverStatus(current, verdict)
+        }
         if (next != current) {
             runCatching { dashPayConfig.set(DashPayConfig.CUTOVER_STATE, next.name) }
                 .onFailure {
@@ -518,7 +547,7 @@ class CutoverCoordinator @Inject constructor(
          * one-time upgrade sync explainer arms only for upgrades crossing
          * this boundary.
          */
-        const val FIRST_CUTOVER_VERSION_CODE = 11100000
+        const val FIRST_CUTOVER_VERSION_CODE = 12000000
 
         /**
          * The verdict reported by the DIRECT (non-readiness) state moves

--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/CutoverCoordinator.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/CutoverCoordinator.kt
@@ -247,17 +247,21 @@ class CutoverCoordinator @Inject constructor(
      *   already-expected post-restore sync wait rather than being told its
      *   wallet was "upgraded"; and
      * - [previousVersionCode] says the app REALLY upgraded across the cutover
-     *   boundary: the launch before this one ran a PRE-11.10 build
+     *   boundary: the launch before this one ran a PRE-CUTOVER build
      *   (`0 < previousVersionCode < ` [FIRST_CUTOVER_VERSION_CODE]). The
      *   product requirement is "explain the one-time resync only to users
-     *   coming from below 11.10". A previous code of 0 means the app was
-     *   never run before (fresh install — belt to the fresh-setup latch's
-     *   suspenders), and a previous code already at/above 11.10 means an
-     *   11.10.x → 11.10.y update, whose user has already lived through (or
-     *   never needed) the explainer.
+     *   coming from below the cutover release". A previous code of 0 means the
+     *   app was never run before (fresh install — belt to the fresh-setup
+     *   latch's suspenders), and a previous code already at/above the boundary
+     *   means a within-cutover-line update, whose user has already lived
+     *   through (or never needed) the explainer.
      *
-     * So: an app UPGRADE from a pre-11.10 build arriving in a pre-commit
-     * state flips here and arms; an 11.10.x → 11.10.y update never arms;
+     * Version numbers are deliberately NOT spelled out here — the boundary
+     * already moved once (11.10 → 12.0) and prose that names a release goes
+     * stale silently. [FIRST_CUTOVER_VERSION_CODE] is the only statement of it.
+     *
+     * So: an app UPGRADE from a pre-cutover build arriving in a pre-commit
+     * state flips here and arms; a within-line update never arms;
      * every later launch of the same install is already CUT_OVER and no-ops;
      * a fresh create/restore is positively suppressed twice over (version
      * code 0 AND the latch).
@@ -303,7 +307,7 @@ class CutoverCoordinator @Inject constructor(
             if (!crossedEver) {
                 log.info(
                     "upgrade seam declining to commit the cutover: previous version code {} is " +
-                        "not a pre-{} upgrade (0 = fresh install, >= {} = already on 11.10+) and " +
+                        "not a pre-{} upgrade (0 = fresh install, >= {} = already cut over) and " +
                         "no boundary crossing was ever latched — leaving the state alone for the " +
                         "readiness-gated auto-commit",
                     previousVersionCode, FIRST_CUTOVER_VERSION_CODE, FIRST_CUTOVER_VERSION_CODE
@@ -594,14 +598,23 @@ class CutoverCoordinator @Inject constructor(
         private val log = LoggerFactory.getLogger(CutoverCoordinator::class.java)
 
         /**
-         * The first versionCode of the 11.10 line — the release that ships the
-         * SDK cutover. The store versionCode scheme is MMmmppbb
-         * (`wallet/build.gradle`: 11.8.2 = 11080201), so EVERY pre-11.10 build
-         * (11.9.x = 1109xxxx, 11.8.x = 1108xxxx, …) is numerically below
-         * 11.10.0 = 11100000, and every 11.10+ build (including the
-         * monotonic-decoupled QA codes, all >= 11100001) is at/above it. The
-         * one-time upgrade sync explainer arms only for upgrades crossing
-         * this boundary.
+         * The first versionCode of the release line that ships the SDK
+         * cutover — currently 12.0.0. THE single statement of the boundary:
+         * the emulator harness reads it from here too
+         * (`scripts/cutover-emulator-test.sh`), and the tests derive their
+         * fixtures from it rather than hardcoding a value.
+         *
+         * The store versionCode scheme is MMmmppbb (`wallet/build.gradle`:
+         * 11.8.2 = 11080201), so every pre-12.0 build (11.9.x = 1109xxxx,
+         * 11.25.x = 1125xxxx, …) is numerically below 12.0.0 = 12000000, and
+         * every 12.0+ build (including the monotonic-decoupled QA codes, all
+         * >= 12000001) is at/above it. The one-time upgrade sync explainer
+         * arms only for upgrades crossing this boundary.
+         *
+         * THIS MOVED from 11100000 when the cutover slipped from 11.10 to
+         * 12.0, and moving it inverts the meaning of every hardcoded
+         * counterpart — one test asserted the opposite of its own name until
+         * it was rederived from here. Keep it the only literal.
          */
         const val FIRST_CUTOVER_VERSION_CODE = 12000000
 
@@ -618,11 +631,11 @@ class CutoverCoordinator @Inject constructor(
 /**
  * Whether [previousVersionCode] — the versionCode recorded by the launch
  * BEFORE this one — means this launch genuinely crossed the cutover boundary,
- * i.e. the app was last run on a pre-11.10 build.
+ * i.e. the app was last run on a pre-cutover build.
  *
  * `0` means the app was never run before (fresh install), and anything at or
  * above [CutoverCoordinator.FIRST_CUTOVER_VERSION_CODE] means the previous
- * launch was already on 11.10+ — including a relaunch of the SAME build,
+ * launch was already cut over — including a relaunch of the SAME build,
  * which is what walletB hit (previous code 12000001 on a 12000001 build).
  * Neither is an upgrade across the boundary, so neither may drive the
  * UPGRADE seam's commit.

--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/CutoverCoordinator.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/CutoverCoordinator.kt
@@ -331,14 +331,10 @@ class CutoverCoordinator @Inject constructor(
                 )
                 return@launch
             }
-            // The version-code condition that used to gate ONLY the explainer
-            // here is now GATE 1 above and gates the commit itself, so reaching
-            // this line already means a genuine pre-cutover upgrade. The one
-            // remaining condition is the once-per-install latch inside
-            // armUpgradeNoticeOnce() — GATE 1's durable boundary latch makes
-            // this line reachable on more than one launch (rollback → commit),
-            // and the explainer promises it happens only once.
-            armUpgradeNoticeOnce()
+            // NB: the explainer is NOT armed here any more. It is armed from
+            // [armUpgradeNoticeIfUpgraded], which every commit path calls —
+            // because on a REAL upgrade this seam is not the path that
+            // commits. See that function for the field evidence.
         }
     }
 
@@ -371,7 +367,28 @@ class CutoverCoordinator @Inject constructor(
      * between the two costs the user the explainer; the reverse order would
      * re-arm forever, which is the bug being fixed. Never throws.
      */
-    private suspend fun armUpgradeNoticeOnce() {
+    private suspend fun armUpgradeNoticeIfUpgraded(committedBy: String) {
+        // Only an install that genuinely crossed the cutover boundary is owed
+        // the explainer. GATE 1 in commitForUpgradedWalletAsync latches this
+        // BEFORE it attempts its commit, so it is already persisted by the time
+        // a later auto-commit reads it on the same launch.
+        val upgraded = runCatching {
+            dashPayConfig.get(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED) == true
+        }.getOrDefault(false)
+        if (!upgraded) return
+        if (freshWalletSetupThisLaunch) {
+            log.info(
+                "cutover committed ({}), but a fresh wallet setup ran on this launch — " +
+                    "suppressing the one-time UPGRADE sync explainer (a restore's sync wait " +
+                    "is already expected)",
+                committedBy
+            )
+            return
+        }
+        armUpgradeNoticeOnce(committedBy)
+    }
+
+    private suspend fun armUpgradeNoticeOnce(committedBy: String) {
         val everArmed = runCatching {
             dashPayConfig.get(DashPayConfig.CUTOVER_UPGRADE_NOTICE_EVER_ARMED) == true
         }.getOrElse {
@@ -384,8 +401,9 @@ class CutoverCoordinator @Inject constructor(
         }
         if (everArmed) {
             log.info(
-                "upgrade cutover committed, but the one-time sync explainer was already armed " +
-                    "once on this install — not arming it again"
+                "cutover committed ({}), but the one-time sync explainer was already armed " +
+                    "once on this install — not arming it again",
+                committedBy
             )
             return
         }
@@ -393,7 +411,7 @@ class CutoverCoordinator @Inject constructor(
             dashPayConfig.set(DashPayConfig.CUTOVER_UPGRADE_NOTICE_EVER_ARMED, true)
             dashPayConfig.set(DashPayConfig.CUTOVER_UPGRADE_NOTICE_PENDING, true)
         }
-            .onSuccess { log.info("upgrade cutover: one-time sync explainer armed") }
+            .onSuccess { log.info("upgrade cutover: one-time sync explainer armed ({})", committedBy) }
             .onFailure {
                 if (it is CancellationException) throw it
                 // Non-fatal: the cutover itself already committed; the
@@ -559,7 +577,9 @@ class CutoverCoordinator @Inject constructor(
         val status = writeState(current, CutoverState.CUT_OVER, reason)
         // A failed persist reports the OLD state (writeState's contract), so
         // this is false — never a phantom "just cut over".
-        return status to (status.state == CutoverState.CUT_OVER)
+        val justCutOver = status.state == CutoverState.CUT_OVER
+        if (justCutOver) armUpgradeNoticeIfUpgraded(reason)
+        return status to justCutOver
     }
 
     /**
@@ -634,6 +654,7 @@ class CutoverCoordinator @Inject constructor(
                     return@withLock CutoverStatus(current, verdict)
                 }
             log.info("cutover state {} -> {} on {} (ready={})", current, next, action, verdict.ready)
+            if (next == CutoverState.CUT_OVER) armUpgradeNoticeIfUpgraded("readiness auto-commit")
         }
         CutoverStatus(next, verdict)
     }

--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/CutoverCoordinator.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/CutoverCoordinator.kt
@@ -319,7 +319,9 @@ class CutoverCoordinator @Inject constructor(
             // refusesCutOverWithoutBindEvidence, so EVERY commit path inherits
             // it — the seam, the fresh-wallet commit, and the readiness-driven
             // auto-commit that used to bypass it entirely.
-            val (_, justCutOver) = mutex.withLock { commitLocked("upgraded-wallet launch") }
+            val (_, justCutOver) = mutex.withLock {
+                commitLocked("upgraded-wallet launch", requireBindEvidence = true)
+            }
             if (!justCutOver) return@launch
             if (freshWalletSetupThisLaunch) {
                 log.info(
@@ -400,8 +402,40 @@ class CutoverCoordinator @Inject constructor(
             }
     }
 
+    /**
+     * MO-995 REGRESSION FIX. This path commits WITHOUT bind evidence, on
+     * purpose — and it is the one path that must.
+     *
+     * `36792ccd1` ("refuse EVERY path into CUT_OVER without SDK bind
+     * evidence") put that guard inside [commitLocked], which this shares with
+     * the upgrade seam. On a fresh install there is no bind evidence BY
+     * CONSTRUCTION: the commit is what routes the launch, and the first bind
+     * pass only runs once platform sync starts, after it. So the guard could
+     * never pass here, and every newly created or restored wallet silently
+     * fell back to dashj instead of the SDK's fast initial sync.
+     *
+     * Field log (2026-09-03, prod 12.0.0-sync/12000003, brand-new wallet):
+     *
+     *     07:10:02  successfully created new wallet
+     *     09:29:06  declining to commit the cutover: the SDK wallet bind has
+     *               never succeeded on this install
+     *     09:29:06  Phase 5d cutover gate: dashjEngineMayStart=true
+     *     09:29:09  app wallet bound to new SDK wallet d992760a…
+     *
+     * — the bind succeeding three seconds AFTER the refusal is the whole
+     * problem in one line. QA reported it as "one time sync not started".
+     *
+     * A failed bind is handled by [rollbackForFailedBind] instead (driven by
+     * [de.schildbach.wallet.service.platform.sdk.SdkBindRetryService]), which
+     * restores the dashj engine. That escape hatch is why this commit is safe
+     * to make eagerly, and it is what the guard here duplicated — badly,
+     * since deferring is exactly what [rollbackForFailedBind]'s own KDoc
+     * explains cannot work for a fresh wallet (a deferred commit lets the
+     * dashj peergroup start and then lands mid-launch, leaving BOTH SPV
+     * engines live — the "never two live SPV engines" invariant).
+     */
     suspend fun commitForFreshWalletSetup(): CutoverStatus = mutex.withLock {
-        commitLocked("fresh-wallet setup (restore/new)").first
+        commitLocked("fresh-wallet setup (restore/new)", requireBindEvidence = false).first
     }
 
     /**
@@ -485,31 +519,41 @@ class CutoverCoordinator @Inject constructor(
      * Only CUT_OVER is guarded. ROLLBACK and the wipe reset move AWAY from a
      * committed state and must never be blocked — that is the escape hatch.
      */
-    private suspend fun refusesCutOverWithoutBindEvidence(to: CutoverState): Boolean {
+    private suspend fun refusesCutOverWithoutBindEvidence(to: CutoverState, path: String): Boolean {
         if (to != CutoverState.CUT_OVER) return false
         if (sdkBindEverSucceeded()) return false
         log.warn(
-            "declining to commit the cutover: the SDK wallet bind has never succeeded on this " +
-                "install, so handing L1 to the SDK would hold dashj and leave no L1 engine — " +
-                "staying on dashj until a bind succeeds"
+            "declining to commit the cutover ({}): the SDK wallet bind has never succeeded on " +
+                "this install, so handing L1 to the SDK would hold dashj and leave no L1 engine " +
+                "— staying on dashj until a bind succeeds",
+            path
         )
         return true
     }
 
-    private suspend fun commitLocked(reason: String): Pair<CutoverStatus, Boolean> {
+    /**
+     * @param requireBindEvidence whether [refusesCutOverWithoutBindEvidence]
+     *   applies. TRUE for the upgrade seam, FALSE for fresh-wallet setup —
+     *   see [commitForFreshWalletSetup] for why that asymmetry is required
+     *   rather than merely convenient. No default: every call site states it.
+     */
+    private suspend fun commitLocked(
+        reason: String,
+        requireBindEvidence: Boolean
+    ): Pair<CutoverStatus, Boolean> {
         val current = currentState()
         if (current == CutoverState.CUT_OVER || current == CutoverState.SETTLED) {
             return CutoverStatus(current, READY_VERDICT) to false
         }
         if (!sdkL1EngineEnabled()) {
             log.info(
-                "fresh-wallet cutover skipped: USE_KOTLIN_SDK_L1_SHADOW is off — the SDK L1 " +
+                "cutover skipped ({}): USE_KOTLIN_SDK_L1_SHADOW is off — the SDK L1 " +
                     "engine is inactive, so dashj must keep owning L1 (staying {})",
-                current
+                reason, current
             )
             return CutoverStatus(current, READY_VERDICT) to false
         }
-        if (refusesCutOverWithoutBindEvidence(CutoverState.CUT_OVER)) {
+        if (requireBindEvidence && refusesCutOverWithoutBindEvidence(CutoverState.CUT_OVER, reason)) {
             return CutoverStatus(current, READY_VERDICT) to false
         }
         val status = writeState(current, CutoverState.CUT_OVER, reason)
@@ -577,7 +621,7 @@ class CutoverCoordinator @Inject constructor(
             return@withLock CutoverStatus(current, CutoverVerdict(setOf(CutoverBlocker.PARITY_EVIDENCE_STALE)))
         }
         val next = nextCutoverState(current, action, verdict.ready)
-        if (next != current && refusesCutOverWithoutBindEvidence(next)) {
+        if (next != current && refusesCutOverWithoutBindEvidence(next, "readiness auto-commit")) {
             // Readiness said yes, but the SDK cannot own L1. Report the state
             // unchanged so the observer keeps observing instead of standing down.
             return@withLock CutoverStatus(current, verdict)

--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/CutoverCoordinator.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/CutoverCoordinator.kt
@@ -230,6 +230,26 @@ class CutoverCoordinator @Inject constructor(
     private var freshWalletSetupThisLaunch = false
 
     /**
+     * Set when this launch observed the cutover boundary crossing but could
+     * NOT persist [DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED].
+     *
+     * The crossing is visible for exactly one launch — `Configuration
+     * .lastVersionCode` is overwritten on every startup — so a dropped write
+     * would otherwise lose the upgrade explainer permanently: this launch's
+     * [armUpgradeNoticeIfUpgraded] reads the store and sees `false`, and every
+     * later launch computes `crossedNow == false` with nothing on disk to
+     * recover it from.
+     *
+     * This keeps the fact in memory so the current launch can still arm, and
+     * so the persist can be retried at arm time. It is NOT a substitute for
+     * the latch: if the store is permanently unwritable the explainer's own
+     * flags cannot be written either, so there is nothing left to salvage.
+     * The case it does cover is the transient one.
+     */
+    @Volatile
+    private var boundaryCrossingUnpersisted = false
+
+    /**
      * The UPGRADE seam's counterpart to [commitForFreshWalletSetupAsync]:
      * same commit, but it additionally arms the one-time sync explainer
      * ([DashPayConfig.CUTOVER_UPGRADE_NOTICE_PENDING]) when — and only when —
@@ -298,7 +318,15 @@ class CutoverCoordinator @Inject constructor(
                     dashPayConfig.set(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED, true)
                 }.onFailure {
                     if (it is CancellationException) throw it
-                    log.warn("failed to latch the cutover boundary crossing", it)
+                    // Remember it in memory: the crossing is observable on this
+                    // launch only, so dropping it here costs the explainer for
+                    // good. Retried in armUpgradeNoticeIfUpgraded.
+                    boundaryCrossingUnpersisted = true
+                    log.warn(
+                        "failed to latch the cutover boundary crossing — holding it in memory " +
+                            "for this launch and retrying when the cutover commits",
+                        it
+                    )
                 }
             }
             val crossedEver = crossedNow || runCatching {
@@ -370,11 +398,36 @@ class CutoverCoordinator @Inject constructor(
     private suspend fun armUpgradeNoticeIfUpgraded(committedBy: String) {
         // Only an install that genuinely crossed the cutover boundary is owed
         // the explainer. GATE 1 in commitForUpgradedWalletAsync latches this
-        // BEFORE it attempts its commit, so it is already persisted by the time
-        // a later auto-commit reads it on the same launch.
-        val upgraded = runCatching {
+        // BEFORE it attempts its commit, so it is normally already persisted by
+        // the time a later auto-commit reads it on the same launch.
+        val persisted = runCatching {
             dashPayConfig.get(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED) == true
         }.getOrDefault(false)
+
+        // ...normally. If GATE 1's write failed, the store says `false` even
+        // though this launch genuinely crossed the boundary. Fall back to the
+        // in-memory record and retry the persist, so a transient DataStore
+        // failure costs the user nothing: without this, the explainer is lost
+        // permanently, because no later launch can recompute the crossing.
+        val upgraded = if (persisted) {
+            true
+        } else if (boundaryCrossingUnpersisted) {
+            runCatching {
+                dashPayConfig.set(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED, true)
+            }.onSuccess {
+                boundaryCrossingUnpersisted = false
+                log.info("re-latched the cutover boundary crossing that failed to persist earlier")
+            }.onFailure {
+                if (it is CancellationException) throw it
+                // Arming still proceeds on the in-memory record below. If the
+                // store is this broken the explainer's own flags will not
+                // write either, and armUpgradeNoticeOnce logs that failure.
+                log.warn("failed to re-latch the cutover boundary crossing; arming from memory", it)
+            }
+            true
+        } else {
+            false
+        }
         if (!upgraded) return
         if (freshWalletSetupThisLaunch) {
             log.info(

--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/L1ShadowSyncService.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/L1ShadowSyncService.kt
@@ -1948,6 +1948,23 @@ class L1ShadowSyncService internal constructor(
     /** The auto-reset decision state (see [ShadowResetDecider] for the table). */
     private val resetDecider = ShadowResetDecider()
 
+    /**
+     * SDK engine loop-lifecycle ledger — see [logEngineDowntimeIfResuming].
+     *
+     * MO-995: `startIfEnabled`/`stop` tear down and relaunch FOUR long-lived
+     * loops (progress monitor, parity probe, watchdog, wallet-event tap), and
+     * nothing recorded how long the engine was actually down. Reconstructing a
+     * 5h28m outage meant diffing timestamps by hand across a 60k-line log.
+     */
+    @Volatile
+    private var startedAtMs = 0L
+
+    @Volatile
+    private var lastStopAtMs = 0L
+
+    @Volatile
+    private var stopCount = 0
+
     /** Once-per-process latch for the startup `WalletHistoryFacts` line. */
     @Volatile
     private var historyFactsLogged = false
@@ -2088,6 +2105,8 @@ class L1ShadowSyncService internal constructor(
                     0L
                 }
                 lastProbeHeartbeatMs = nowMs()
+                logEngineDowntimeIfResuming()
+                startedAtMs = nowMs()
                 monitorJob = scope.launch { monitorProgress() }.logCompletion("progress monitor")
                 parityJob = scope.launch { parityLoop(walletIdHex) }.logCompletion("parity probe loop")
                 watchdogJob = scope.launch { watchdogLoop() }.logCompletion("probe watchdog")
@@ -2129,7 +2148,15 @@ class L1ShadowSyncService internal constructor(
                 .onFailure { log.warn("failed to stop the shadow SPV client", it) }
             _progress.value = ShadowSyncProgress.IDLE
             _engineWalletSyncedHeight.value = 0L // re-seeded on the next start
-            log.info("L1 shadow sync stopped")
+            lastStopAtMs = nowMs()
+            stopCount++
+            log.info(
+                "L1ShadowLifecycle STOPPED after {} up; all four loops torn down " +
+                    "(progress monitor, parity probe, watchdog, wallet-event tap); " +
+                    "teardown #{} this process. Nothing runs until the next startIfEnabled().",
+                if (startedAtMs == 0L) "unknown" else humanDuration(lastStopAtMs - startedAtMs),
+                stopCount
+            )
         }
     }
 
@@ -2519,6 +2546,47 @@ class L1ShadowSyncService internal constructor(
      * logs the cause at WARN (loop bodies catch-and-continue, so a WARN
      * here means the loop machinery itself broke).
      */
+    /**
+     * Report the downtime that is ending, on the start that ends it.
+     *
+     * WHY A CONSUMER-SIDE GAP LINE AND NOT JUST THE STOP LINE: the stop is
+     * already logged, but a stop is only a problem if nothing restarts — and
+     * "nothing restarted" has no log line by construction, because the thing
+     * that would log it is the thing that did not run. Measuring the gap on
+     * the NEXT start needs no timer and no watchdog, and names the outage in
+     * one greppable line.
+     *
+     * MO-995 field evidence (2026-09-02, launch 07:31:56 → 16:09):
+     * `BlockchainServiceImpl - idling detected, stopping service` at 10:38:00
+     * stopped this service, cancelling the progress monitor, the parity probe
+     * loop, the watchdog and the event tap. [progress] is a StateFlow fed by
+     * the cancelled monitor, so it froze at its last value and its consumers
+     * simply stopped being called — for 5h28m, with no line from any of them.
+     * `CutoverAutoCommitObserver` was armed and waiting that whole time and
+     * emitted nothing, which is why the cutover fell through to the next
+     * process start ten hours after the upgrade.
+     *
+     * SURVIVES THE DASHJ RETIREMENT (MO-992): post-retirement these loops are
+     * not a debug shadow's, they are THE engine's, so an unnoticed teardown
+     * stops being a lost readiness signal and becomes a wallet with no L1 at
+     * all. This line is the instrument for that class of bug either way.
+     *
+     * Caller holds [mutex]; called before the loops relaunch. WARN past
+     * [LONG_ENGINE_DOWNTIME_MS] because a routine idle-detector bounce is
+     * seconds-to-minutes — hours means nothing brought the engine back.
+     */
+    private fun logEngineDowntimeIfResuming() {
+        if (lastStopAtMs == 0L) return // first start of this process — no gap to report
+        val downMs = nowMs() - lastStopAtMs
+        val message = "L1ShadowLifecycle RESUMING after {} down (teardown #{} this process); " +
+            "the progress feed and every consumer of it were silent for that whole span"
+        if (downMs >= LONG_ENGINE_DOWNTIME_MS) {
+            log.warn(message, humanDuration(downMs), stopCount)
+        } else {
+            log.info(message, humanDuration(downMs), stopCount)
+        }
+    }
+
     private fun Job.logCompletion(name: String): Job = apply {
         invokeOnCompletion { cause ->
             when (cause) {
@@ -3082,6 +3150,28 @@ class L1ShadowSyncService internal constructor(
          * guarded, sustained divergence; it never resets a healthy view sooner.
          */
         internal const val PARITY_INTERVAL_MS = 10_000L
+
+        /**
+         * Downtime past which [logEngineDowntimeIfResuming] escalates to WARN.
+         * A routine `BlockchainServiceImpl` idle bounce is seconds to minutes
+         * (three in the MO-995 log were ~30s, ~3min and 5h28m); ten minutes
+         * cleanly separates the bounce from the outage.
+         */
+        internal const val LONG_ENGINE_DOWNTIME_MS = 10 * 60 * 1000L
+
+        /** `5h28m` / `3m12s` / `47s` — durations a human reads at a glance. */
+        internal fun humanDuration(ms: Long): String {
+            if (ms < 0) return "${ms}ms"
+            val totalSeconds = ms / 1000
+            val h = totalSeconds / 3600
+            val m = (totalSeconds % 3600) / 60
+            val sec = totalSeconds % 60
+            return when {
+                h > 0 -> "${h}h${m}m"
+                m > 0 -> "${m}m${sec}s"
+                else -> "${sec}s"
+            }
+        }
 
         /**
          * Relaxed probe cadence once the fast cadence's job is done — the

--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/SdkBindRetryService.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/SdkBindRetryService.kt
@@ -195,14 +195,38 @@ class SdkBindRetryService internal constructor(
     }
 
     /**
-     * App came to the foreground: reset the ladder so the next wait-loop
-     * poll retries within seconds instead of the hourly tail. State-only —
-     * the actual retry rides the existing triggers.
+     * App came to the foreground with a bind retry pending: DRIVE a retry, and
+     * arm the unlock receiver while we are here.
+     *
+     * MO-995 — this used to be state-only ("reset the ladder so the next
+     * wait-loop poll retries"), which relied on a trigger that does not exist
+     * in the state that needs it most. The only caller of [maybeRetry] is
+     * `CutoverUiDataService.awaitBoundWallet()`, and that loop runs only while
+     * the cutover holds dashj with no bound wallet. Once the coordinator
+     * correctly REFUSES to commit onto an unbindable SDK, that state never
+     * occurs — so the loop never runs, [maybeRetry] is never called, the
+     * unlock receiver is never armed, and nothing ever retries. Reproduced on
+     * the emulator (S3): after a Keystore denial, unlocking the device and
+     * returning to the app produced ZERO binder activity; only a full app
+     * restart healed it.
+     *
+     * App-foreground is the right trigger precisely because it depends on
+     * neither the cutover state nor a broadcast: the user is looking at the
+     * app, so the device is provably unlocked — which is the heal condition
+     * for the device-locked keystore denial — and no receiver has to survive
+     * an OEM's background restrictions. walletB's HONOR PTP-N49 delivered
+     * `ACTION_USER_PRESENT` zero times in ten hours; MagicOS suppresses
+     * exactly that kind of broadcast.
+     *
+     * [retryNowInBackground] resets the ladder and runs one pass, which also
+     * consults the rollback — so a foreground visit both heals a recoverable
+     * denial and, when the bind is truly dead, lets the engine fall back.
      */
     fun noteAppForeground() {
         if (!bindRetryPending()) return
-        log.info("app foregrounded with an SDK bind retry pending — resetting the retry backoff")
-        resetBackoff()
+        log.info("app foregrounded with an SDK bind retry pending — retrying the bind now")
+        armUnlockReceiver()
+        retryNowInBackground("app foreground")
     }
 
     private fun resetBackoff() {

--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/SdkDashPayWrites.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/SdkDashPayWrites.kt
@@ -137,7 +137,15 @@ internal fun classifyBroadcastFailure(t: Throwable): SdkWriteResult<Nothing> = w
     // path derives DIP-15 encryption keys from the wallet seed, not from
     // identity keys. Message-matched until the SDK exposes a typed error.
     t.message?.contains("Invalid identity data") == true ->
-        SdkWriteResult.NotBroadcast("pre-broadcast identity-key validation failure", t)
+        // MO-973: the label used to stop at "identity-key validation failure",
+        // which is the CONTACT-REQUEST reading of this message (see above) —
+        // and it was then reported verbatim for a DPNS name registration,
+        // which needs no encryption key. The engine's own text is the only
+        // thing that says WHICH invalid-identity-data this is, so carry it.
+        SdkWriteResult.NotBroadcast(
+            "pre-broadcast identity data rejected by the FFI — ${t.message}",
+            t
+        )
     // Android Keystore auth-window expiry: the SDK keeps identity keys
     // AUTH_GATED (decryptable only within ~30 s of a biometric/device-credential
     // unlock), and an expired window surfaces as UserNotAuthenticatedException —
@@ -154,7 +162,21 @@ internal fun classifyBroadcastFailure(t: Throwable): SdkWriteResult<Nothing> = w
     // Message-matched until platform PR #4060 (DEVICE_BOUND key policy)
     // replaces the auth window and gives this a typed error.
     t.message?.contains("User not authenticated") == true ->
-        SdkWriteResult.NotBroadcast("signing failure (pre-broadcast): Keystore auth window expired", t)
+        // MO-972: this used to read "Keystore auth window expired", which
+        // ASSERTS a timeout nobody measured. Field log (2026-09-10, testnet
+        // 12000007, HONOR PTP-N49) — biometric at 11:49:16, this at 11:49:17.
+        // One second. The window had not expired; the Keystore simply refused
+        // to treat the auth as satisfying the identity key's gate, which on
+        // that OEM is the same defect family as the false-locked master alias
+        // (dashpay/platform#4643 fixes that one and explicitly does NOT cover
+        // the auth-gated identity alias; #4060's DEVICE_BOUND policy is the
+        // remedy). Report what Keystore said, not a cause we inferred.
+        SdkWriteResult.NotBroadcast(
+            "signing failure (pre-broadcast): Keystore refused the identity key as " +
+                "unauthenticated (auth window may have expired, or the device's " +
+                "auth-bound Keystore gate is defective) — ${t.message}",
+            t
+        )
     // TYPED funding shortfalls — checked BEFORE the message arms because
     // engine message text drifts across AAR lines while the type cannot.
     // CoreInsufficientFunds (FFI 22) is the atomic Core selection;

--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/SdkWalletBinder.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/SdkWalletBinder.kt
@@ -415,6 +415,34 @@ class SdkWalletBinder internal constructor(
             }
             consecutiveBindFailuresCount = 0
             _bindRetryPending.value = false
+            markBindEverSucceeded()
+        }
+    }
+
+    /**
+     * MO-995: durable evidence that this install's Keystore can actually serve
+     * the SDK bind. The UPGRADE cutover seam refuses to hand L1 to the SDK until
+     * this is set, so a device whose Keystore denies the lock-bound master alias
+     * (HONOR PTP-N49, walletB) stays on dashj instead of being left with no L1
+     * engine at all.
+     *
+     * WRITTEN FROM THE SUCCESS SIGNAL, NOT FROM THE BIND CALL. It first lived
+     * inside `bindAppWallet(...).also { }`, which only runs when a NEW SDK
+     * wallet is created — so on every launch that took the "app wallet already
+     * bound" path the marker was never written and the seam declined forever.
+     * Caught on the emulator: launch 2 of a clean run still logged "bind has
+     * never succeeded" while the L1 engine was demonstrably running.
+     *
+     * Best-effort and idempotent: a failed write only delays the next launch's
+     * commit, and re-writing true is free.
+     */
+    private fun markBindEverSucceeded() {
+        scope.launch {
+            runCatching { dashPayConfig.set(DashPayConfig.SDK_BIND_EVER_SUCCEEDED, true) }
+                .onFailure { t ->
+                    if (t is CancellationException) throw t
+                    log.warn("failed to persist the SDK bind-success marker", t)
+                }
         }
     }
 
@@ -1020,17 +1048,6 @@ class SdkWalletBinder internal constructor(
             sdkService.bindAppWallet(words, birthTimeSecs).also {
                 boundWalletIdHex = it
                 boundWalletFingerprint = fingerprint
-                // MO-995: durable evidence that this install's keystore can
-                // actually serve the SDK bind. The UPGRADE cutover seam refuses
-                // to hand L1 to the SDK until this is set, so a device whose
-                // Keystore denies the lock-bound master alias stays on dashj
-                // instead of being left with no engine at all. Best-effort:
-                // a failed write only delays the next launch's commit.
-                runCatching { dashPayConfig.set(DashPayConfig.SDK_BIND_EVER_SUCCEEDED, true) }
-                    .onFailure { t ->
-                        if (t is CancellationException) throw t
-                        log.warn("failed to persist the SDK bind-success marker", t)
-                    }
             }
         }
 

--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/SdkWalletBinder.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/SdkWalletBinder.kt
@@ -1020,6 +1020,17 @@ class SdkWalletBinder internal constructor(
             sdkService.bindAppWallet(words, birthTimeSecs).also {
                 boundWalletIdHex = it
                 boundWalletFingerprint = fingerprint
+                // MO-995: durable evidence that this install's keystore can
+                // actually serve the SDK bind. The UPGRADE cutover seam refuses
+                // to hand L1 to the SDK until this is set, so a device whose
+                // Keystore denies the lock-bound master alias stays on dashj
+                // instead of being left with no engine at all. Best-effort:
+                // a failed write only delays the next launch's commit.
+                runCatching { dashPayConfig.set(DashPayConfig.SDK_BIND_EVER_SUCCEEDED, true) }
+                    .onFailure { t ->
+                        if (t is CancellationException) throw t
+                        log.warn("failed to persist the SDK bind-success marker", t)
+                    }
             }
         }
 

--- a/wallet/src/de/schildbach/wallet/service/platform/work/RestoreIdentityWorker.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/work/RestoreIdentityWorker.kt
@@ -278,10 +278,20 @@ class RestoreIdentityWorker @AssistedInject constructor(
                         // catch below stamps a generic error — NOT "missing domain
                         // document", so the tile shows the retry card, and restoring
                         // stays true so a retry re-runs THIS worker, never a re-fund).
+                        // MO-973: `error(...)` throws WITHOUT a cause, so the
+                        // engine's own message never reached the log — the
+                        // field report showed only our classifier's label and
+                        // the real reason was unrecoverable. Carry the cause.
                         is SdkWriteResult.NotBroadcast ->
-                            error("username registration did not complete (retryable): ${result.reason}")
+                            throw IllegalStateException(
+                                "username registration did not complete (retryable): ${result.reason}",
+                                result.cause
+                            )
                         is SdkWriteResult.Ambiguous ->
-                            error("username registration outcome unconfirmed (retryable): ${result.cause.message}")
+                            throw IllegalStateException(
+                                "username registration outcome unconfirmed (retryable): ${result.cause.message}",
+                                result.cause
+                            )
                     }
                 }
             }

--- a/wallet/src/de/schildbach/wallet/transactions/coinjoin/CoinJoinMixingTxSet.kt
+++ b/wallet/src/de/schildbach/wallet/transactions/coinjoin/CoinJoinMixingTxSet.kt
@@ -1,8 +1,9 @@
 package de.schildbach.wallet.transactions.coinjoin
 
-import de.schildbach.wallet.transactions.dashjTx
 import org.bitcoinj.coinjoin.utils.CoinJoinTransactionType
+import org.bitcoinj.core.Transaction
 import org.bitcoinj.wallet.WalletEx
+import org.slf4j.LoggerFactory
 import org.dash.wallet.common.money.Dash
 import org.dash.wallet.common.transactions.TransactionWrapper
 import org.dash.wallet.common.transactions.TxInfo
@@ -23,11 +24,46 @@ open class CoinJoinMixingTxSet(
             return true
         }
 
-        val type = CoinJoinTransactionType.fromTx(tx.dashjTx, wallet)
+        // MO-995: the classification below is dashj's SHAPE HEURISTIC
+        // (CoinJoinTransactionType.fromTx), evaluated against the DASHJ wallet.
+        // Post-cutover that wallet is held with its balance frozen at the
+        // cutover snapshot, while the transaction itself originates from the
+        // SDK — so a stale wallet is being asked about a new transaction, and
+        // fromTx depends on wallet context (which inputs are mine, input
+        // values, denomination/collateral matching). QA saw an ordinary
+        // 0.0002 DASH send labelled "Mixing" on BOTH the sending and receiving
+        // wallet, with a coinjoin balance of 0 for the whole session — i.e. no
+        // mixing had occurred. 0.0002 DASH is not a CoinJoin denomination, so
+        // amount-matching is not the explanation; wallet context is the
+        // suspect. This log line records what fromTx actually returned so the
+        // next field report settles it.
+        val raw = tx.raw
+        if (raw !is Transaction) {
+            // `TxInfo.raw` is `Any?`, and the old code did `raw as Transaction`
+            // unconditionally — a ClassCastException on null or on any
+            // non-dashj payload. Post-cutover TxInfo can be built from the SDK,
+            // so treat a non-dashj payload as "not CoinJoin" rather than
+            // throwing out of the transaction list.
+            log.info(
+                "coinjoin grouping skipped for {}: TxInfo.raw is {}, not a dashj Transaction",
+                tx.txId, raw?.javaClass?.simpleName ?: "null"
+            )
+            return false
+        }
+
+        val type = CoinJoinTransactionType.fromTx(raw, wallet)
 
         if (type == CoinJoinTransactionType.None || type == CoinJoinTransactionType.Send) {
             return false
         }
+
+        // Only logged when a tx is about to be GROUPED as CoinJoin, so the
+        // volume is bounded by actual (mis)classifications, not by list size.
+        log.info(
+            "coinjoin grouping {} as {} (inputs={} outputs={} dashjCoinJoinBalance={})",
+            tx.txId, type, raw.inputs.size, raw.outputs.size,
+            runCatching { wallet.coinJoinBalance }.getOrNull()
+        )
 
         val txDate = tx.groupDate
 
@@ -40,6 +76,10 @@ open class CoinJoinMixingTxSet(
         transactions[tx.txId] = tx
 
         return true
+    }
+
+    private companion object {
+        private val log = LoggerFactory.getLogger(CoinJoinMixingTxSet::class.java)
     }
 
     override fun getValue(): Dash {

--- a/wallet/src/de/schildbach/wallet/ui/dashpay/CreateIdentityService.kt
+++ b/wallet/src/de/schildbach/wallet/ui/dashpay/CreateIdentityService.kt
@@ -1538,10 +1538,20 @@ class CreateIdentityService : LifecycleService() {
                     identityRepository.updateBlockchainIdentityData(blockchainIdentityData)
                     identityRepository.updateIdentityCreationState(blockchainIdentityData, domainRegistered)
                 }
+                // MO-973: same cause-dropping as RestoreIdentityWorker — `error(...)`
+                // throws without a cause, so the engine's message never reached the
+                // log. The invite path is rarer, so it would have been even harder to
+                // diagnose from a single report.
                 is SdkWriteResult.NotBroadcast ->
-                    error("invite username registration did not complete (retryable): ${result.reason}")
+                    throw IllegalStateException(
+                        "invite username registration did not complete (retryable): ${result.reason}",
+                        result.cause
+                    )
                 is SdkWriteResult.Ambiguous ->
-                    error("invite username registration outcome unconfirmed (retryable): ${result.cause?.message}")
+                    throw IllegalStateException(
+                        "invite username registration outcome unconfirmed (retryable): ${result.cause?.message}",
+                        result.cause
+                    )
             }
             return
         }

--- a/wallet/src/de/schildbach/wallet/ui/dashpay/utils/DashPayConfig.kt
+++ b/wallet/src/de/schildbach/wallet/ui/dashpay/utils/DashPayConfig.kt
@@ -420,11 +420,44 @@ open class DashPayConfig @Inject constructor(
          * [de.schildbach.wallet.service.platform.sdk.CutoverCoordinator
          * .commitForUpgradedWalletAsync] at the moment the state actually
          * moves to CUT_OVER, and cleared when the user acknowledges the
-         * explainer — so the screen shows exactly once, ever, and only on the
-         * upgrade path (a fresh install or a restore commits through
-         * `setWallet` instead and already has its own sync expectation).
+         * explainer — and only on the upgrade path (a fresh install or a
+         * restore commits through `setWallet` instead and already has its own
+         * sync expectation).
+         *
+         * "Exactly once, ever" is NOT a property of this key: acknowledging
+         * clears it back to false, which is indistinguishable from never having
+         * been armed. [CUTOVER_UPGRADE_NOTICE_EVER_ARMED] is what makes the
+         * once-ever guarantee real.
          */
         val CUTOVER_UPGRADE_NOTICE_PENDING = booleanPreferencesKey("cutover_upgrade_notice_pending")
+
+        /**
+         * MO-995 (Andrei, comment 91138 #2): the once-EVER latch behind
+         * [CUTOVER_UPGRADE_NOTICE_PENDING]. Set the first time the upgrade
+         * explainer is armed on this install, and never cleared.
+         *
+         * WHY A SECOND KEY IS NEEDED: `..._PENDING` is a *pending* flag — the
+         * sheet sets it back to false on acknowledgment, which reads exactly
+         * like "never armed". So any later arming re-shows a sheet whose own
+         * copy promises "This happens only once, after this update".
+         *
+         * That is not hypothetical. Field log (2026-09-02, prod, 11.9.1 →
+         * 12.0.0-sync): the notice was pending at the 07:31:54 upgrade launch
+         * and the user acknowledged it, then the upgrade seam committed the
+         * cutover TEN HOURS LATER on the next process start (17:31:54
+         * `cutover state DUAL_RUNNING -> CUT_OVER (upgraded-wallet launch)`)
+         * and armed the very same explainer a second time.
+         *
+         * The ten-hour gap is structural, not a glitch: the seam's bind-evidence
+         * gate can never pass on the upgrade launch itself (the bind runs after
+         * the seam), so the commit — and with it the arming — always lands on
+         * some LATER process start, with no bound on when that is. Combined
+         * with the durable [CUTOVER_UPGRADE_BOUNDARY_CROSSED] latch, a
+         * [de.schildbach.wallet.service.platform.sdk.CutoverCoordinator
+         * .rollbackForFailedBind] → re-commit cycle can arm it again and again.
+         * This latch makes all of those paths idempotent.
+         */
+        val CUTOVER_UPGRADE_NOTICE_EVER_ARMED = booleanPreferencesKey("cutover_upgrade_notice_ever_armed")
 
         /**
          * MO-995: set the first time the SDK wallet bind succeeds on this

--- a/wallet/src/de/schildbach/wallet/ui/dashpay/utils/DashPayConfig.kt
+++ b/wallet/src/de/schildbach/wallet/ui/dashpay/utils/DashPayConfig.kt
@@ -427,6 +427,48 @@ open class DashPayConfig @Inject constructor(
         val CUTOVER_UPGRADE_NOTICE_PENDING = booleanPreferencesKey("cutover_upgrade_notice_pending")
 
         /**
+         * MO-995: set the first time the SDK wallet bind succeeds on this
+         * install, and never cleared except by a wallet wipe. It is the
+         * evidence the UPGRADE cutover seam requires before it will hand L1
+         * to the SDK — see
+         * [de.schildbach.wallet.service.platform.sdk.CutoverCoordinator
+         * .commitForUpgradedWalletAsync].
+         *
+         * WHY PERSISTED and not the binder's in-memory state: the upgrade seam
+         * runs from `finalizeInitialization`, BEFORE the first bind pass of the
+         * process (platform sync starts the binder). An in-process signal is
+         * therefore always false at the seam and would defer every upgrade to
+         * the readiness-gated auto-commit. Persisting it means a device that
+         * has ever bound successfully still commits promptly, while a device
+         * whose keystore denies the bind never commits at all — the difference
+         * between walletC/D (bind fine, cut over) and walletB (16 keystore
+         * denials, cut over anyway, left with NO L1 engine).
+         */
+        val SDK_BIND_EVER_SUCCEEDED = booleanPreferencesKey("sdk_bind_ever_succeeded")
+
+        /**
+         * MO-995: set the first time a launch is seen to have crossed the
+         * cutover boundary (the previous launch ran a pre-11.10 build), and
+         * never cleared except by a wallet wipe.
+         *
+         * WHY THIS EXISTS: `Configuration.lastVersionCode` is "the version the
+         * PREVIOUS LAUNCH ran", not "the version this install upgraded from" —
+         * `updateLastVersionCode` overwrites it on every startup. So the fact
+         * that an install crossed the boundary is visible for exactly ONE
+         * launch, and that is the very launch on which the SDK bind has not
+         * run yet (the seam is in `finalizeInitialization`; the binder starts
+         * with platform sync). Without a durable latch, the upgrade seam's
+         * two conditions could never both hold and it would never commit
+         * again — losing the one-time sync explainer with it.
+         *
+         * Latching it means the commit can land on whichever later launch
+         * first has a working bind, which is what a device like walletB needs:
+         * its keystore may deny the bind for many launches before it heals.
+         */
+        val CUTOVER_UPGRADE_BOUNDARY_CROSSED =
+            booleanPreferencesKey("cutover_upgrade_boundary_crossed")
+
+        /**
          * DIAGNOSTIC toggle (Tools screen, debug instrumentation): un-hold the
          * dashj L1 engine AFTER the Phase 5d cutover has committed, so the
          * legacy peergroup syncs normally alongside the SDK — a backup /

--- a/wallet/test/de/schildbach/wallet/service/CoinsReceivedNotificationGateTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/CoinsReceivedNotificationGateTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.wallet.service
+
+import org.bitcoinj.core.Coin
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Host-JVM tests for the received-coins notification gate
+ * ([shouldAnnounceCoinsReceived]) — "only receives are announced".
+ *
+ * Post-cutover the SDK authors every send and
+ * [de.schildbach.wallet.service.platform.sdk.SdkBridgedTransactionFactory] commits it into the
+ * dashj wallet-of-record, where dashj cannot attribute the SDK-owned inputs: it values the send by
+ * its `+change` output alone and delivers it to `onCoinsReceived`. MO-995: a gift-card purchase was
+ * announced as "Received -0.0x" because the gate and the announced amount each resolved the
+ * SDK-corrected net separately — the gate's lookup ran on the main thread, where Room throws and
+ * the lookup fails soft to dashj's positive misread.
+ */
+class CoinsReceivedNotificationGateTest {
+
+    @Test
+    fun genuineReceiveIsAnnounced() {
+        assertTrue(shouldAnnounceCoinsReceived(walletAuthored = false, correctedNet = Coin.valueOf(1_000_000)))
+    }
+
+    /** The gift-card purchase from MO-995: dashj's +change misread must never announce. */
+    @Test
+    fun selfAuthoredSendIsNotAnnouncedEvenWhenDashjMisreadsItPositive() {
+        assertFalse(shouldAnnounceCoinsReceived(walletAuthored = true, correctedNet = Coin.valueOf(383_000_000)))
+    }
+
+    @Test
+    fun selfAuthoredSendIsNotAnnouncedWithItsCorrectedNegativeNet() {
+        assertFalse(shouldAnnounceCoinsReceived(walletAuthored = true, correctedNet = Coin.valueOf(-1_000_146)))
+    }
+
+    /** No caller may announce a negative "Received" — the value QA actually saw in the push. */
+    @Test
+    fun negativeNetIsNeverAnnounced() {
+        assertFalse(shouldAnnounceCoinsReceived(walletAuthored = false, correctedNet = Coin.valueOf(-1_000_146)))
+    }
+
+    /** A zero-net delivery (a fee-only self-spend dashj values at 0) is not a receive. */
+    @Test
+    fun zeroNetIsNeverAnnounced() {
+        assertFalse(shouldAnnounceCoinsReceived(walletAuthored = false, correctedNet = Coin.ZERO))
+    }
+}

--- a/wallet/test/de/schildbach/wallet/service/ForegroundStartPromiseTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/ForegroundStartPromiseTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.schildbach.wallet.service
+
+import android.os.Bundle
+import de.schildbach.wallet.service.BlockchainServiceImpl.Companion.START_AS_FOREGROUND_EXTRA
+import de.schildbach.wallet.service.BlockchainServiceImpl.Companion.carriesForegroundStartPromise
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * MO-995: `ForegroundServiceDidNotStartInTimeException` killed the process in
+ * the field (2026-09-02 18:48:44, prod 12.0.0-sync).
+ *
+ * A start delivered by `startForegroundService()` arms a system promise —
+ * `startForeground()` within a few seconds or the process dies. The call sat
+ * inside `onStartCommand`'s coroutine behind `onCreateCompleted.await()`, so it
+ * landed only after the service's whole async init, and not at all when the
+ * service was concurrently torn down. An AlarmManager
+ * `PendingIntent.getForegroundService` fired exactly as the idle detector was
+ * stopping the service, and the two interleaved.
+ *
+ * The fix moved the call to run SYNCHRONOUSLY in `onStartCommand`. A missed
+ * call is only testable if the DECISION to make it is separable from making it,
+ * which is why [carriesForegroundStartPromise] is pure — the service lifecycle
+ * itself is not reachable from a host-JVM test.
+ */
+class ForegroundStartPromiseTest {
+
+    private fun extras(vararg keys: String): Bundle = mockk<Bundle> {
+        keys.forEach { every { containsKey(it) } returns true }
+        every { containsKey(not(match<String> { it in keys })) } returns false
+    }
+
+    @Test
+    fun promise_isCarried_whenTheStartCommandIsMarkedAsForeground() {
+        assertTrue(carriesForegroundStartPromise(extras(START_AS_FOREGROUND_EXTRA)))
+    }
+
+    /**
+     * An ordinary `startService()` start carries NO promise, so promoting on it
+     * would put the service in the foreground (and post a sync notification)
+     * for starts that never asked. The condition must stay narrow — this is the
+     * half that keeps the fix from over-promoting.
+     */
+    @Test
+    fun promise_isNotCarried_byAnUnmarkedStartCommand() {
+        assertFalse(carriesForegroundStartPromise(extras("some_other_extra")))
+    }
+
+    /**
+     * Null extras: an intent with no extras at all. Must not promote, and must
+     * not throw — this ran on every plain start before the fix existed.
+     */
+    @Test
+    fun promise_isNotCarried_whenThereAreNoExtras() {
+        assertFalse(carriesForegroundStartPromise(null))
+    }
+
+    /**
+     * A NULL intent is the system re-delivering a start after the process was
+     * killed. No fresh `startForegroundService()` happened, so there is no
+     * promise to satisfy and promoting would be wrong.
+     */
+    @Test
+    fun promise_isNotCarried_byASystemRedeliveryWithNoIntent() {
+        // shouldPromoteToForeground(null) reduces to this — pinned so the null
+        // path cannot regress into a promotion.
+        assertFalse(carriesForegroundStartPromise((null as Bundle?)))
+    }
+}

--- a/wallet/test/de/schildbach/wallet/service/L1SyncStatusServiceTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/L1SyncStatusServiceTest.kt
@@ -871,6 +871,49 @@ class L1SyncStatusServiceTest {
         assertEquals(2_532_259L, detail.headerHeight)
     }
 
+    /**
+     * MO-1022 FOLLOW-UP — the hole in the fix above. The in-process backstop is
+     * empty on a COLD start, which is exactly when QA opens the Network
+     * Monitor. Field log (2026-09-04, prod 12000004, SM-A536B): app opened
+     * 19:13:07, checked immediately —
+     *
+     *     19:13:14  L1Shadow phase=IDLE 0.0% headers 0/0 filters 0/0 wallet 2533349
+     *     19:14:14  L1Shadow phase=SYNCED 100.0% headers 2533366/2533366 filters …
+     *
+     * a full minute of "-". Note `wallet 2533349` on the same line the filters
+     * read 0/0: the committed wallet cursor is seeded from the SDK's durable
+     * watermark at shadow start, so it survives the restart and IS the
+     * filter-scan position. That is the floor a cold start needs.
+     */
+    @Test
+    fun detail_filtersHoldTheDurableWalletCursor_onAColdStart() {
+        val detail = mergeL1SyncDetail(
+            sdkOwnsL1 = true,
+            // The exact field shape, including the populated wallet cursor.
+            progress = progress(
+                phase = ShadowSyncPhase.IDLE,
+                headerHeight = 0, headerTarget = 0,
+                filterHeight = 0, filterTarget = 0,
+                walletSyncedHeight = 2_533_349
+            ),
+            sessionChainLockHeight = 0,
+            state = dashjState(percentageSync = 100, bestChainHeight = 2_533_348),
+            // Cold start: NOTHING seen in this process yet.
+            lastKnownFilterHeight = 0,
+            lastKnownFilterTarget = 0
+        )
+        assertEquals(
+            "a cold start must fall back to the durable wallet cursor, not \"-\"",
+            2_533_349L,
+            detail.filterHeight
+        )
+        // The pair must never render as height > target.
+        assertTrue(
+            "target ${detail.filterTarget} must not trail height ${detail.filterHeight}",
+            detail.filterTarget >= detail.filterHeight
+        )
+    }
+
     @Test
     fun detail_filtersReadUnknown_onAColdStartWithNothingKnownYet() {
         // No reading has been taken in this process, so "-" IS the honest answer.

--- a/wallet/test/de/schildbach/wallet/service/L1SyncStatusServiceTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/L1SyncStatusServiceTest.kt
@@ -836,4 +836,77 @@ class L1SyncStatusServiceTest {
         assertEquals("the ceiling lands one deadline after the FIRST false", true, seen.last())
         job.cancel()
     }
+
+    // ── MO-995: the filters sawtooth guard ────────────────────────────
+
+    /**
+     * QA screenshot: "Synced / Block headers 2,532,259 / Block filters — /
+     * Masternode list 2,532,250 / ChainLock 2,532,258". Every row but filters
+     * held its value.
+     *
+     * `mergeL1SyncDetail` already backstopped percentage, headers, mnlist and
+     * chainlock through the IDLE/CONNECTING window (the engine reports all-zero
+     * heights there for minutes after a restart), but took filters raw — and
+     * `NetworkMonitorActivity.formatHeights` renders "-" exactly when height
+     * AND target are both <= 0.
+     */
+    @Test
+    fun detail_filtersDoNotCollapseToUnknown_whileTheEngineIsIdle() {
+        val detail = mergeL1SyncDetail(
+            sdkOwnsL1 = true,
+            // The exact shape from the field log: IDLE 0.0% headers 0/0 filters 0/0.
+            progress = progress(
+                phase = ShadowSyncPhase.IDLE,
+                headerHeight = 0, headerTarget = 0,
+                filterHeight = 0, filterTarget = 0
+            ),
+            sessionChainLockHeight = 0,
+            state = dashjState(percentageSync = 100, bestChainHeight = 2_532_259),
+            lastKnownFilterHeight = 2_532_258,
+            lastKnownFilterTarget = 2_532_258
+        )
+        assertEquals("filters must hold their last known position", 2_532_258L, detail.filterHeight)
+        assertEquals(2_532_258L, detail.filterTarget)
+        // And the neighbouring rows must still behave as before.
+        assertEquals(2_532_259L, detail.headerHeight)
+    }
+
+    @Test
+    fun detail_filtersReadUnknown_onAColdStartWithNothingKnownYet() {
+        // No reading has been taken in this process, so "-" IS the honest answer.
+        val detail = mergeL1SyncDetail(
+            sdkOwnsL1 = true,
+            progress = progress(
+                phase = ShadowSyncPhase.IDLE,
+                headerHeight = 0, headerTarget = 0, filterHeight = 0, filterTarget = 0
+            ),
+            sessionChainLockHeight = 0,
+            state = null
+        )
+        assertEquals(0L, detail.filterHeight)
+        assertEquals(0L, detail.filterTarget)
+    }
+
+    /**
+     * The guard is deliberately scoped to IDLE/CONNECTING. Outside that window
+     * a filter height that moves BACKWARDS is real — the DashPay coreHeight
+     * backfill legitimately rewinds the scan (observed dropping 1,543,144 ->
+     * 1,252,305 in the field) — and must be reported, not masked by a max()
+     * against a stale high-water mark.
+     */
+    @Test
+    fun detail_aGenuineFilterRewindIsNotMasked() {
+        val detail = mergeL1SyncDetail(
+            sdkOwnsL1 = true,
+            progress = progress(
+                phase = ShadowSyncPhase.FILTERS,
+                filterHeight = 1_252_305, filterTarget = 1_543_144
+            ),
+            sessionChainLockHeight = 0,
+            state = null,
+            lastKnownFilterHeight = 1_543_144,
+            lastKnownFilterTarget = 1_543_144
+        )
+        assertEquals("a real rewind must show honestly", 1_252_305L, detail.filterHeight)
+    }
 }

--- a/wallet/test/de/schildbach/wallet/service/L1SyncStatusServiceTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/L1SyncStatusServiceTest.kt
@@ -952,4 +952,38 @@ class L1SyncStatusServiceTest {
         )
         assertEquals("a real rewind must show honestly", 1_252_305L, detail.filterHeight)
     }
+
+    /**
+     * The height/target pair must hold even when the ENGINE hands us an
+     * inverted one. Both fields are read off the same `data.filters` snapshot
+     * in `L1ShadowSyncService.toShadowSyncProgress`, so they cannot drift
+     * apart — but nothing clamps them either, so a snapshot reporting
+     * currentHeight > targetHeight would arrive here intact.
+     *
+     * Before the fix the target's `maxOf` took every floor the height took
+     * EXCEPT the height's own raw value, so exactly this input rendered as
+     * 2_533_400/2_533_349 — a progress row reading past 100%.
+     */
+    @Test
+    fun detail_filterTargetNeverTrailsTheHeight_onAnInvertedEngineSnapshot() {
+        val detail = mergeL1SyncDetail(
+            sdkOwnsL1 = true,
+            progress = progress(
+                phase = ShadowSyncPhase.IDLE,
+                headerHeight = 0, headerTarget = 0,
+                // The engine reports a scan position AHEAD of its own target.
+                filterHeight = 2_533_400, filterTarget = 2_533_349,
+                walletSyncedHeight = 2_533_349
+            ),
+            sessionChainLockHeight = 0,
+            state = null,
+            lastKnownFilterHeight = 0,
+            lastKnownFilterTarget = 0
+        )
+        assertEquals(2_533_400L, detail.filterHeight)
+        assertTrue(
+            "target ${detail.filterTarget} must not trail height ${detail.filterHeight}",
+            detail.filterTarget >= detail.filterHeight
+        )
+    }
 }

--- a/wallet/test/de/schildbach/wallet/service/TrimMemoryPolicyTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/TrimMemoryPolicyTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.schildbach.wallet.service
+
+import android.content.ComponentCallbacks2
+import de.schildbach.wallet.service.BlockchainServiceImpl.Companion.shouldStopForMemoryPressure
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * MO-995: `onTrimMemory` used `level >= TRIM_MEMORY_BACKGROUND`, which is wrong
+ * in both directions — 40 means "the user left the app", while the real
+ * running-low signals (10, 15) are numerically below it and were ignored.
+ *
+ * Field log (2026-09-06, testnet 12000004, HONOR PTP-N49): the engine was torn
+ * down on every backgrounding, so a from-genesis scan got three restarts in
+ * five minutes, never caught up, and the cutover never committed — Buy Credits
+ * failed as a result.
+ *
+ * These pin EVERY documented level, because the bug was an off-by-threshold on
+ * a scale where the numbers are not ordered by severity.
+ */
+class TrimMemoryPolicyTest {
+
+    /** The levels that mean "you are about to be killed" — tear down. */
+    @Test
+    fun stops_onlyOnImminentDeath() {
+        assertTrue(
+            "COMPLETE (80) is the top of the LRU kill list",
+            shouldStopForMemoryPressure(ComponentCallbacks2.TRIM_MEMORY_COMPLETE)
+        )
+        assertTrue(
+            "RUNNING_CRITICAL (15) means the system is already killing background processes",
+            shouldStopForMemoryPressure(ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL)
+        )
+    }
+
+    /**
+     * THE REGRESSION. 40 is "your process went onto the LRU background list" —
+     * ordinary backgrounding, not memory pressure. A long L1 scan must survive
+     * the user leaving the app.
+     */
+    @Test
+    fun doesNotStop_whenTheUserSimplyBackgroundsTheApp() {
+        assertFalse(
+            "BACKGROUND (40) is backgrounding, not low memory",
+            shouldStopForMemoryPressure(ComponentCallbacks2.TRIM_MEMORY_BACKGROUND)
+        )
+        assertFalse(
+            "UI_HIDDEN (20) is the UI going away",
+            shouldStopForMemoryPressure(ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN)
+        )
+    }
+
+    /**
+     * MODERATE (60) is mid-LRU — not imminent danger, and deliberately excluded:
+     * an hours-long from-genesis scan is exactly the workload that has to ride
+     * it out. Pinned so the choice is explicit rather than incidental.
+     */
+    @Test
+    fun doesNotStop_atMidLruModerate() {
+        assertFalse(shouldStopForMemoryPressure(ComponentCallbacks2.TRIM_MEMORY_MODERATE))
+    }
+
+    /** The milder running-* levels are advisory; trimming caches, not dying. */
+    @Test
+    fun doesNotStop_onTheAdvisoryRunningLevels() {
+        assertFalse(shouldStopForMemoryPressure(ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE))
+        assertFalse(shouldStopForMemoryPressure(ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW))
+    }
+
+    /**
+     * The scale is not ordered by severity (15 is graver than 40), so a plain
+     * `>=` cannot express the policy. Pin the whole documented set at once so a
+     * future `>=` rewrite fails loudly.
+     */
+    @Test
+    fun theFullDocumentedScale_behavesAsSpecified() {
+        val expected = mapOf(
+            ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE to false, // 5
+            ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW to false, // 10
+            ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL to true, // 15
+            ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN to false, // 20
+            ComponentCallbacks2.TRIM_MEMORY_BACKGROUND to false, // 40
+            ComponentCallbacks2.TRIM_MEMORY_MODERATE to false, // 60
+            ComponentCallbacks2.TRIM_MEMORY_COMPLETE to true // 80
+        )
+        expected.forEach { (level, shouldStop) ->
+            org.junit.Assert.assertEquals(
+                "level $level",
+                shouldStop,
+                shouldStopForMemoryPressure(level)
+            )
+        }
+    }
+}

--- a/wallet/test/de/schildbach/wallet/service/platform/PlatformHealthProbeContainmentTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/platform/PlatformHealthProbeContainmentTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.schildbach.wallet.service.platform
+
+import de.schildbach.wallet.Constants
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.runBlocking
+import org.dash.wallet.common.services.BlockchainStateProvider
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * MO-973: the health probe is ADVISORY — it feeds one warning row on the
+ * username screen and its own KDoc says it must never gate the submit button.
+ * It was nonetheless able to kill the process.
+ *
+ * `probe()` caught only `Exception`, but the legacy gRPC stack fails with an
+ * ERROR: `ExceptionInInitializerError` out of `NettyChannelBuilder.<clinit>`
+ * when R8 strips a member its static init reaches by reflection. That sailed
+ * past this catch, past the caller's bare `try/finally`
+ * (`RequestUserNameViewModel.checkNetworkHealth`), out of the coroutine, and
+ * took the app down — 11 times on one HONOR PTP-N49, which QA reported as a
+ * username-creation crash, a username-creation failure, and "the lock screen
+ * appears after clicking Continue" (that being the relaunch).
+ *
+ * The keep rule that stops R8 stripping it is a separate commit. This pins the
+ * containment, so the NEXT thing to break underneath an advisory probe
+ * degrades instead of crashing.
+ */
+class PlatformHealthProbeContainmentTest {
+
+    // SUPPORTS_PLATFORM is a mutable static set from a native-ABI check at
+    // runtime, so it is false under a JVM test. Without forcing it true,
+    // probe() returns UNKNOWN on its first line and every assertion below
+    // would pass vacuously.
+    private var savedSupportsPlatform = false
+
+    @Before
+    fun setUp() {
+        savedSupportsPlatform = Constants.SUPPORTS_PLATFORM
+        Constants.SUPPORTS_PLATFORM = true
+    }
+
+    @After
+    fun tearDown() {
+        Constants.SUPPORTS_PLATFORM = savedSupportsPlatform
+    }
+
+    private fun probeWith(clientFailure: Throwable): PlatformHealthProbe {
+        val platformService = mockk<PlatformService>()
+        // Standing in for DAPIGrpcMasternode.<init> — the first touch of the
+        // legacy client is what detonates the static initializer.
+        every { platformService.client } throws clientFailure
+        val stateProvider = mockk<BlockchainStateProvider>()
+        coEvery { stateProvider.getState() } returns null
+        return PlatformHealthProbe(platformService, stateProvider)
+    }
+
+    /**
+     * THE REGRESSION PIN. The assertion that matters is that `probe()` RETURNS
+     * at all — with `catch (Exception)` this test does not fail an assertion,
+     * it dies with the Error, which is exactly what the app did.
+     */
+    @Test
+    fun probe_degradesToUnknown_whenTheLegacyGrpcStackFailsToInitialize() = runBlocking {
+        val probe = probeWith(ExceptionInInitializerError("NettyChannelBuilder"))
+
+        assertEquals(PlatformHealth.UNKNOWN, probe.probe())
+    }
+
+    /** Any Error, not just the one we happened to hit. */
+    @Test
+    fun probe_degradesToUnknown_onAnyErrorFromTheLegacyStack() = runBlocking {
+        assertEquals(
+            PlatformHealth.UNKNOWN,
+            probeWith(NoClassDefFoundError("io/grpc/netty/shaded/io/grpc/netty/NettyChannelBuilder")).probe()
+        )
+        assertEquals(
+            PlatformHealth.UNKNOWN,
+            probeWith(NoSuchMethodError("NioSocketChannel.<init>")).probe()
+        )
+    }
+
+    /** Ordinary exceptions keep degrading as they always did. */
+    @Test
+    fun probe_degradesToUnknown_onAnOrdinaryException() = runBlocking {
+        assertEquals(PlatformHealth.UNKNOWN, probeWith(IllegalStateException("no live address")).probe())
+    }
+
+    /**
+     * Cancellation is control flow, NOT a probe failure. A `catch (Throwable)`
+     * that swallows it breaks structured concurrency — the screen closing mid
+     * probe would leave the caller's coroutine looking successful.
+     */
+    @Test
+    fun probe_propagatesCancellation_ratherThanReportingUnknown() = runBlocking {
+        val probe = probeWith(CancellationException("screen closed"))
+
+        try {
+            probe.probe()
+            fail("cancellation must propagate, not degrade to UNKNOWN")
+        } catch (expected: CancellationException) {
+            // correct
+        }
+    }
+}

--- a/wallet/test/de/schildbach/wallet/service/platform/PlatformSyncEngineRestartTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/platform/PlatformSyncEngineRestartTest.kt
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.schildbach.wallet.service.platform
+
+import de.schildbach.wallet.service.platform.sdk.L1ShadowSyncService
+import de.schildbach.wallet.service.platform.sdk.ShieldedBalanceService
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+/**
+ * Host-JVM regression tests for the Kotlin-SDK engine RESTART contract on
+ * [PlatformSynchronizationService] — the mirror image of
+ * [PlatformSyncEngineTeardownTest].
+ *
+ * MO-995 / MO-998 (v12.0.0 QA, both networks): the SDK's L1 (SPV) engine
+ * went down on a routine blockchain-service teardown and never came back
+ * for the rest of the process. Symptoms: incoming transactions never
+ * arrived (two Coinbase deposits lost for 2h10m on mainnet), the header
+ * sat at "syncing", and Buy Credits failed with "pre-broadcast: SPV client
+ * not started".
+ *
+ * The call-site half of that bug was in `BlockchainServiceImpl`:
+ * [PlatformSyncService.resume] lived only inside `checkService()`'s
+ * peergroup-start block, BELOW the `!dashjEngineMayStart` early return, so
+ * post-cutover it was unreachable and the engines only ever started from
+ * [PlatformSyncService.init] (once per process, from `WalletApplication`).
+ * That is fixed by calling [PlatformSyncService.resume] from the
+ * post-cutover branch of `BlockchainServiceImpl.onCreate` — a line in an
+ * Android service, not reachable from a host-JVM test.
+ *
+ * What IS testable, and what the fix now depends on, is the contract
+ * underneath it: **resume() must be able to bring the engines back up
+ * after a teardown has taken them down, any number of times.** That is not
+ * a given — [PlatformSyncService.shutdown] cancels the sync scope's
+ * children, and `stopSync()` does the same on a wallet reset. Cancelling
+ * the scope's `SupervisorJob` itself instead (an easy, invisible change:
+ * `syncJob.cancel()` / `syncScope.cancel()` in place of
+ * `cancelChildren()`) would leave every later `resume()` a silent no-op
+ * and reinstate exactly the MO-995 latch one layer down, with the
+ * BlockchainServiceImpl fix still in place and looking correct.
+ */
+class PlatformSyncEngineRestartTest {
+
+    private val l1ShadowSyncService = mockk<L1ShadowSyncService>(relaxed = true)
+    private val shieldedBalanceService = mockk<ShieldedBalanceService>(relaxed = true)
+    private val identityRepository = mockk<IdentityRepository>(relaxed = true)
+
+    /** The engine kick is asynchronous (`syncScope.launch { bindJob.join(); … }`). */
+    private val kickTimeoutMs = 10_000L
+
+    private fun service() = PlatformSynchronizationService(
+        platform = mockk(relaxed = true),
+        platformRepo = mockk(relaxed = true),
+        analytics = mockk(relaxed = true),
+        config = mockk(relaxed = true),
+        walletApplication = mockk(relaxed = true),
+        transactionMetadataProvider = mockk(relaxed = true),
+        transactionMetadataChangeCacheDao = mockk(relaxed = true),
+        transactionMetadataDocumentDao = mockk(relaxed = true),
+        blockchainIdentityDataDao = mockk(relaxed = true),
+        dashPayProfileDao = mockk(relaxed = true),
+        dashPayContactRequestDao = mockk(relaxed = true),
+        dashPayConfig = mockk(relaxed = true),
+        giftCardDao = mockk(relaxed = true),
+        invitationsDao = mockk(relaxed = true),
+        usernameRequestDao = mockk(relaxed = true),
+        usernameVoteDao = mockk(relaxed = true),
+        identityConfig = mockk(relaxed = true),
+        topUpRepository = mockk(relaxed = true),
+        identityRepository = identityRepository,
+        walletDataProvider = mockk(relaxed = true),
+        walletSeam = mockk(relaxed = true),
+        sdkProfileQueries = mockk(relaxed = true),
+        sdkUsernameQueries = mockk(relaxed = true),
+        sdkIdentityVerifyQueries = mockk(relaxed = true),
+        sdkWalletBinder = mockk(relaxed = true),
+        nonInteractiveWalletUnlock = mockk(relaxed = true),
+        l1ShadowSyncService = l1ShadowSyncService,
+        shieldedBalanceService = shieldedBalanceService,
+        cutoverUiDataService = mockk(relaxed = true),
+        sdkBlockchainStateService = mockk(relaxed = true),
+        cutoverTxSeamService = mockk(relaxed = true),
+        cutoverAutoCommitObserver = mockk(relaxed = true),
+        shieldedTransferExecutor = mockk(relaxed = true),
+        contactRequestNotificationService = mockk(relaxed = true),
+        dashPaySyncStatus = de.schildbach.wallet.service.DashPaySyncStatus()
+    )
+
+    @Test
+    fun resume_startsTheL1Engine() = runBlocking {
+        service().resume()
+
+        coVerify(timeout = kickTimeoutMs, exactly = 1) { l1ShadowSyncService.startIfEnabled() }
+        Unit
+    }
+
+    /**
+     * The MO-995 / MO-998 sequence, at this layer: the engines are stopped
+     * by a service teardown, then a later service start calls resume().
+     * `stopSdkEngines()` is used rather than `shutdown()` so the assertion
+     * holds on debug variants too (shutdown() deliberately skips the stops
+     * there — see [PlatformSyncEngineTeardownTest]).
+     */
+    @Test
+    fun resume_afterAnEngineStop_bringsTheL1EngineBackUp() = runBlocking {
+        val service = service()
+
+        service.stopSdkEngines()
+        coVerify(exactly = 1) { l1ShadowSyncService.stop() }
+
+        service.resume()
+
+        coVerify(timeout = kickTimeoutMs, exactly = 1) { l1ShadowSyncService.startIfEnabled() }
+        Unit
+    }
+
+    /**
+     * A teardown that ran the full [PlatformSyncService.shutdown] path — the
+     * one that cancels the sync scope's children — must not disarm resume().
+     * This is the assertion that fails if the scope's job is ever cancelled
+     * outright instead of its children.
+     *
+     * The setup matters: shutdown()'s cancel block is gated on
+     * `platformSyncJob != null && identityRepository.hasBlockchainIdentity`,
+     * so an identity and an armed ticker are both required or shutdown()
+     * skips the cancellation entirely and the test proves nothing. Verified
+     * by mutation: replacing shutdown()'s
+     * `syncScope.coroutineContext.cancelChildren(…)` with
+     * `syncJob.cancel(…)` fails this test and only this test.
+     */
+    @Test
+    fun resume_afterFullShutdown_stillStartsTheL1Engine() = runBlocking {
+        every { identityRepository.hasBlockchainIdentity } returns true
+        val service = service()
+
+        // Arms platformSyncJob in syncScope, so shutdown() below takes the
+        // branch that cancels the scope's children.
+        service.initSync(runFirstUpdateBlocking = false)
+        service.shutdown()
+        service.resume()
+
+        coVerify(timeout = kickTimeoutMs, exactly = 1) { l1ShadowSyncService.startIfEnabled() }
+        Unit
+    }
+
+    /**
+     * Every service restart in a process gets its own kick. A single-shot
+     * guard added to the kick path (or a scope that survives only the first
+     * teardown) reinstates the latch after the second teardown, which is
+     * precisely how MO-995 presented: the first service restart of the
+     * process looked fine, later ones silently had no SPV.
+     */
+    @Test
+    fun resume_isRearmableAcrossRepeatedStopRestartCycles() = runBlocking {
+        val service = service()
+
+        repeat(3) {
+            service.stopSdkEngines()
+            service.resume()
+        }
+
+        coVerify(timeout = kickTimeoutMs, exactly = 3) { l1ShadowSyncService.startIfEnabled() }
+        coVerify(exactly = 3) { l1ShadowSyncService.stop() }
+        Unit
+    }
+}

--- a/wallet/test/de/schildbach/wallet/service/platform/sdk/CutoverCoordinatorTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/platform/sdk/CutoverCoordinatorTest.kt
@@ -353,14 +353,21 @@ class CutoverCoordinatorTest {
     private val pre1110VersionCode = 11090002
 
     /** A previous-launch versionCode already ON the 11.10 line (11.10.1). */
-    private val on1110VersionCode = 11100100
+    /**
+     * A previous-launch versionCode AT/ABOVE the cutover line — i.e. the
+     * previous launch already had the SDK cutover, so this launch did not cross
+     * the boundary. DERIVED from the constant on purpose: this was hardcoded to
+     * 11100100 and silently became a *pre*-cutover value when the boundary moved
+     * from 11100000 to 12000000, inverting what the test asserted.
+     */
+    private val onOrAfterCutoverVersionCode = CutoverCoordinator.FIRST_CUTOVER_VERSION_CODE + 100
 
     /**
      * The versionCode of THIS build — what `lastVersionCode` reads on every
      * launch after the first one. walletB reached the seam with exactly this
      * shape (previous code 12000001 on a 12000001 build).
      */
-    private val sameBuildVersionCode = 12000001
+    private val sameBuildVersionCode = CutoverCoordinator.FIRST_CUTOVER_VERSION_CODE + 1
 
     @Test
     fun upgradeNotice_armed_onAGenuineUpgradeFromPre1110ThatFlipsTheState() = runBlocking {
@@ -378,19 +385,19 @@ class CutoverCoordinatorTest {
     }
 
     @Test
-    fun upgradeNotice_notArmed_whenPreviousVersionIsAlready1110() = runBlocking {
-        // 11.10.x -> 11.10.y update: the state still flips here (e.g. the SDK
-        // L1 flag was off on the earlier 11.10.x launches), but the user is not
-        // crossing the pre-cutover boundary — no explainer.
+    fun upgradeNotice_notArmed_whenPreviousVersionIsAlreadyAtOrAfterCutover() = runBlocking {
+        // An update from a build that ALREADY had the cutover: the user is not
+        // crossing the pre-cutover boundary, so neither the commit nor the
+        // explainer may fire.
         val (coordinator, stored, armed) = noticeCoordinator(stored = null)
-        coordinator.commitForUpgradedWalletAsync(on1110VersionCode)
+        coordinator.commitForUpgradedWalletAsync(onOrAfterCutoverVersionCode)
         // MO-995 GATE 1 (behaviour CHANGE): the version-code test now gates the
         // COMMIT too, not just the explainer. An 11.10+ previous code means this
         // launch did not cross the cutover boundary, so the upgrade seam must
         // leave the state alone — walletB committed here on a same-version
         // relaunch and was left with no L1 engine when its bind then failed.
         assertNull("a non-boundary-crossing launch must not commit", stored())
-        assertFalse("an 11.10.x -> 11.10.y update must not re-explain the resync", armed())
+        assertFalse("an already-cut-over update must not re-explain the resync", armed())
     }
 
     @Test
@@ -408,9 +415,10 @@ class CutoverCoordinatorTest {
     }
 
     @Test
-    fun upgradeNotice_armed_atTheLastPre1110Code_andNotAtTheBoundaryItself() = runBlocking {
-        // Boundary pin: FIRST_CUTOVER_VERSION_CODE (11.10.0 = 11100000) is the
-        // first code that does NOT arm; one below it still does.
+    fun upgradeNotice_armed_atTheLastPreCutoverCode_andNotAtTheBoundaryItself() = runBlocking {
+        // Boundary pin: FIRST_CUTOVER_VERSION_CODE is the first code that does
+        // NOT arm; one below it still does. Expressed relative to the constant
+        // so moving the cutover release cannot invert the assertion.
         val below = CutoverCoordinator.FIRST_CUTOVER_VERSION_CODE - 1
         val (armedCoordinator, _, armedBelow) = noticeCoordinator(stored = null)
         armedCoordinator.commitForUpgradedWalletAsync(below)
@@ -418,7 +426,7 @@ class CutoverCoordinatorTest {
 
         val (boundaryCoordinator, _, armedAt) = noticeCoordinator(stored = null)
         boundaryCoordinator.commitForUpgradedWalletAsync(CutoverCoordinator.FIRST_CUTOVER_VERSION_CODE)
-        assertFalse("previous code 11100000 is already 11.10 — must not arm", armedAt())
+        assertFalse("the boundary code itself is already cut over — must not arm", armedAt())
     }
 
     @Test
@@ -549,7 +557,7 @@ class CutoverCoordinatorTest {
     fun isPreCutoverUpgrade_pinsTheBoundary() {
         assertFalse("0 = fresh install, never ran before", isPreCutoverUpgrade(0))
         assertFalse("negative is nonsense — fail safe", isPreCutoverUpgrade(-1))
-        assertTrue("11.9.0 crossed the boundary", isPreCutoverUpgrade(11090000))
+        assertTrue("a pre-cutover release crossed the boundary", isPreCutoverUpgrade(11090000))
         assertTrue(
             "one below the line still crosses it",
             isPreCutoverUpgrade(CutoverCoordinator.FIRST_CUTOVER_VERSION_CODE - 1)
@@ -558,7 +566,10 @@ class CutoverCoordinatorTest {
             "the line itself is already 11.10",
             isPreCutoverUpgrade(CutoverCoordinator.FIRST_CUTOVER_VERSION_CODE)
         )
-        assertFalse("walletB: a relaunch of the SAME 12.x build is not an upgrade", isPreCutoverUpgrade(12000001))
+        assertFalse(
+            "walletB: a relaunch of the SAME build is not an upgrade",
+            isPreCutoverUpgrade(CutoverCoordinator.FIRST_CUTOVER_VERSION_CODE + 1)
+        )
     }
 
     @Test

--- a/wallet/test/de/schildbach/wallet/service/platform/sdk/CutoverCoordinatorTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/platform/sdk/CutoverCoordinatorTest.kt
@@ -360,10 +360,9 @@ class CutoverCoordinatorTest {
         return Triple(coordinator, { current }, { noticeArmed })
     }
 
-    /** A previous-launch versionCode from BELOW the 11.10 cutover line (v11.9.0). */
+    /** A previous-launch versionCode from BELOW the cutover line (v11.9.0). */
     private val pre1110VersionCode = 11090002
 
-    /** A previous-launch versionCode already ON the 11.10 line (11.10.1). */
     /**
      * A previous-launch versionCode AT/ABOVE the cutover line — i.e. the
      * previous launch already had the SDK cutover, so this launch did not cross

--- a/wallet/test/de/schildbach/wallet/service/platform/sdk/CutoverCoordinatorTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/platform/sdk/CutoverCoordinatorTest.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -779,16 +780,62 @@ class CutoverCoordinatorTest {
         assertEquals(CutoverState.CUT_OVER.name, stored())
     }
 
+    /**
+     * MO-995 REGRESSION PIN. This test previously asserted the OPPOSITE — that
+     * a fresh wallet must NOT commit without bind evidence — and that
+     * assertion was wrong, so the guard it protected shipped in 12000003 and
+     * broke every newly created or restored wallet.
+     *
+     * On a fresh install there is no bind evidence by construction: the commit
+     * is what routes the launch, the first bind pass runs after it. Field log
+     * (2026-09-03, prod, brand-new wallet) — the bind succeeded three seconds
+     * AFTER the refusal:
+     *
+     *     09:29:06  declining to commit the cutover: the SDK wallet bind has
+     *               never succeeded on this install
+     *     09:29:09  app wallet bound to new SDK wallet d992760a…
+     *
+     * QA reported it as "one time sync not started": dashj took L1 and the
+     * SDK's fast initial sync never ran. The unbindable-SDK exposure the old
+     * assertion was reaching for is real, but [rollbackForFailedBind] is what
+     * covers it — deferring cannot, because a deferred commit lands mid-launch
+     * with the dashj peergroup already up (two live SPV engines).
+     */
     @Test
-    fun freshWalletCommit_refusesWithoutBindEvidence() = runBlocking {
-        // The clean-install exposure: committing here would hold dashj while the
-        // SDK cannot bind, leaving a brand-new wallet with no L1 engine at all.
+    fun freshWalletCommit_commitsWithoutBindEvidence_becauseTheBindRunsAfterIt() = runBlocking {
         val (coordinator, stored) = coordinator(stored = null, bindEverSucceeded = false)
 
         val status = coordinator.commitForFreshWalletSetup()
 
-        assertNull("a fresh wallet must not be handed to an unbindable SDK", stored())
-        assertEquals(CutoverState.DUAL_RUNNING, status.state)
-        assertTrue(coordinator.dashjEngineMayStart())
+        assertEquals(
+            "a fresh wallet must commit immediately — the bind cannot have happened yet",
+            CutoverState.CUT_OVER,
+            status.state
+        )
+        assertEquals(CutoverState.CUT_OVER.name, stored())
+        assertFalse("the SDK owns L1 from the start on a fresh wallet", coordinator.dashjEngineMayStart())
+    }
+
+    /**
+     * The guard still holds where it CAN be satisfied. Same absent bind
+     * evidence as the test above, opposite outcome — this is the asymmetry the
+     * fix introduces, so pin both halves together.
+     */
+    @Test
+    fun upgradeSeamAndAutoCommit_stillRefuseWithoutBindEvidence() = runBlocking {
+        val (seam, seamStored, _) = noticeCoordinator(stored = null, bindEverSucceeded = false)
+        seam.commitForUpgradedWalletAsync(pre1110VersionCode)
+        assertNull("the upgrade seam must still refuse — walletB's engine-less state", seamStored())
+
+        // NB: the advisory leg legitimately reaches READY_OBSERVED — the guard
+        // only refuses transitions INTO CutOver — so assert on CUT_OVER, not
+        // on "unchanged".
+        val (auto, autoStored) = coordinator(stored = null, bindEverSucceeded = false)
+        auto.autoAdvanceToCutover()
+        assertNotEquals(
+            "the readiness auto-commit must still refuse to hand L1 over",
+            CutoverState.CUT_OVER.name,
+            autoStored()
+        )
     }
 }

--- a/wallet/test/de/schildbach/wallet/service/platform/sdk/CutoverCoordinatorTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/platform/sdk/CutoverCoordinatorTest.kt
@@ -326,11 +326,13 @@ class CutoverCoordinatorTest {
         stored: String? = null,
         flag: Boolean? = true,
         bindEverSucceeded: Boolean? = true,
-        boundaryAlreadyLatched: Boolean = false
+        boundaryAlreadyLatched: Boolean = false,
+        noticeAlreadyArmedEver: Boolean = false
     ): Triple<CutoverCoordinator, () -> String?, () -> Boolean> {
         var current = stored
         var noticeArmed = false
         var boundaryLatched = boundaryAlreadyLatched
+        var noticeEverArmed = noticeAlreadyArmedEver
         val config = mockk<DashPayConfig>()
         coEvery { config.get(DashPayConfig.CUTOVER_STATE) } answers { current }
         coEvery { config.get(DashPayConfig.USE_KOTLIN_SDK_L1_SHADOW) } returns flag
@@ -346,6 +348,11 @@ class CutoverCoordinatorTest {
         }
         coEvery { config.set(DashPayConfig.CUTOVER_UPGRADE_NOTICE_PENDING, any<Boolean>()) } answers {
             noticeArmed = secondArg()
+            Unit
+        }
+        coEvery { config.get(DashPayConfig.CUTOVER_UPGRADE_NOTICE_EVER_ARMED) } answers { noticeEverArmed }
+        coEvery { config.set(DashPayConfig.CUTOVER_UPGRADE_NOTICE_EVER_ARMED, any<Boolean>()) } answers {
+            noticeEverArmed = secondArg()
             Unit
         }
         val collector = mockk<CutoverEvidenceCollector>()
@@ -379,6 +386,118 @@ class CutoverCoordinatorTest {
         coordinator.commitForUpgradedWalletAsync(pre1110VersionCode)
         assertEquals(CutoverState.CUT_OVER.name, stored())
         assertTrue("an upgrade from below 11.10 arriving pre-commit is exactly the case worth explaining", armed())
+    }
+
+    /**
+     * MO-995 (Andrei, comment 91138 #2) — THE REPORTED BUG.
+     *
+     * The explainer's own copy says "This happens only once, after this
+     * update", but CUTOVER_UPGRADE_NOTICE_PENDING is a *pending* flag that the
+     * sheet sets back to false on acknowledgment — indistinguishable from
+     * never-armed. Field log, 2026-09-02 prod, 11.9.1 -> 12.0.0-sync: the
+     * notice was pending and acknowledged on the 07:31:54 upgrade launch, then
+     * the seam committed at 17:31:54 (`cutover state DUAL_RUNNING -> CUT_OVER
+     * (upgraded-wallet launch)`) and armed the same explainer a second time,
+     * ten hours later.
+     *
+     * Two launches, both reaching the seam legitimately: the second one passes
+     * GATE 1 on the durable boundary latch. So the arming — not the commit —
+     * has to be the thing that is idempotent.
+     */
+    @Test
+    fun upgradeNotice_notArmedASecondTime_afterTheUserAlreadyAcknowledgedIt() = runBlocking {
+        // Launch 1: the genuine upgrade. Arms, and latches "ever armed".
+        val (first, _, armedFirst) = noticeCoordinator(stored = null)
+        first.commitForUpgradedWalletAsync(pre1110VersionCode)
+        assertTrue("the upgrade launch must arm the explainer", armedFirst())
+
+        // Launch 2: same install, state back at DUAL_RUNNING (a bind-failure
+        // rollback), boundary latched, notice already armed once and
+        // acknowledged (PENDING is back to false — which is why it cannot be
+        // the guard).
+        val (second, stored, armedSecond) = noticeCoordinator(
+            stored = CutoverState.DUAL_RUNNING.name,
+            boundaryAlreadyLatched = true,
+            noticeAlreadyArmedEver = true
+        )
+        second.commitForUpgradedWalletAsync(sameBuildVersionCode)
+
+        assertEquals(
+            "the commit itself must still happen — only the explainer is suppressed",
+            CutoverState.CUT_OVER.name,
+            stored()
+        )
+        assertFalse("a \"happens only once\" sheet must not be armed twice", armedSecond())
+    }
+
+    /**
+     * The latch is written BEFORE the pending flag, so a first arming leaves
+     * BOTH set. Pins that ordering: without the latch write, the guard above
+     * has nothing to read on the next launch.
+     */
+    @Test
+    fun upgradeNotice_firstArming_alsoLatchesTheOnceEverMarker() = runBlocking {
+        var everArmed: Boolean? = null
+        var pending: Boolean? = null
+        var current: String? = null
+        val config = mockk<DashPayConfig>()
+        coEvery { config.get(DashPayConfig.CUTOVER_STATE) } answers { current }
+        coEvery { config.get(DashPayConfig.USE_KOTLIN_SDK_L1_SHADOW) } returns true
+        coEvery { config.get(DashPayConfig.SDK_BIND_EVER_SUCCEEDED) } returns true
+        coEvery { config.get(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED) } returns false
+        coEvery { config.set(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED, any<Boolean>()) } returns Unit
+        coEvery { config.set(DashPayConfig.CUTOVER_STATE, any<String>()) } answers {
+            current = secondArg(); Unit
+        }
+        coEvery { config.get(DashPayConfig.CUTOVER_UPGRADE_NOTICE_EVER_ARMED) } answers { everArmed }
+        coEvery { config.set(DashPayConfig.CUTOVER_UPGRADE_NOTICE_EVER_ARMED, any<Boolean>()) } answers {
+            everArmed = secondArg(); Unit
+        }
+        coEvery { config.set(DashPayConfig.CUTOVER_UPGRADE_NOTICE_PENDING, any<Boolean>()) } answers {
+            // Reading the latch here proves it was written FIRST.
+            assertEquals("the once-ever latch must be set before the pending flag", true, everArmed)
+            pending = secondArg(); Unit
+        }
+        val coordinator = CutoverCoordinator(
+            config, mockk<CutoverEvidenceCollector>(), CoroutineScope(Dispatchers.Unconfined)
+        )
+
+        coordinator.commitForUpgradedWalletAsync(pre1110VersionCode)
+
+        assertEquals(true, pending)
+        assertEquals(true, everArmed)
+    }
+
+    /**
+     * An unreadable latch must SUPPRESS, not arm. Re-showing a "happens only
+     * once" sheet is the user-visible defect; a missed explainer is not.
+     */
+    @Test
+    fun upgradeNotice_notArmed_whenTheOnceEverLatchCannotBeRead() = runBlocking {
+        var pending: Boolean? = null
+        var current: String? = null
+        val config = mockk<DashPayConfig>()
+        coEvery { config.get(DashPayConfig.CUTOVER_STATE) } answers { current }
+        coEvery { config.get(DashPayConfig.USE_KOTLIN_SDK_L1_SHADOW) } returns true
+        coEvery { config.get(DashPayConfig.SDK_BIND_EVER_SUCCEEDED) } returns true
+        coEvery { config.get(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED) } returns false
+        coEvery { config.set(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED, any<Boolean>()) } returns Unit
+        coEvery { config.set(DashPayConfig.CUTOVER_STATE, any<String>()) } answers {
+            current = secondArg(); Unit
+        }
+        coEvery { config.get(DashPayConfig.CUTOVER_UPGRADE_NOTICE_EVER_ARMED) } throws
+            IllegalStateException("DataStore read failed")
+        coEvery { config.set(DashPayConfig.CUTOVER_UPGRADE_NOTICE_PENDING, any<Boolean>()) } answers {
+            pending = secondArg(); Unit
+        }
+        val coordinator = CutoverCoordinator(
+            config, mockk<CutoverEvidenceCollector>(), CoroutineScope(Dispatchers.Unconfined)
+        )
+
+        coordinator.commitForUpgradedWalletAsync(pre1110VersionCode)
+
+        assertEquals("the commit must not be blocked by an unreadable latch", CutoverState.CUT_OVER.name, current)
+        assertNull("an unreadable latch must suppress the explainer", pending)
     }
 
     @Test

--- a/wallet/test/de/schildbach/wallet/service/platform/sdk/CutoverCoordinatorTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/platform/sdk/CutoverCoordinatorTest.kt
@@ -357,6 +357,10 @@ class CutoverCoordinatorTest {
             Unit
         }
         val collector = mockk<CutoverEvidenceCollector>()
+        // Ready evidence, so the READINESS auto-commit path can be driven
+        // through this helper too — that is the path that actually commits on
+        // a real upgrade (MO-1022), and it must be able to arm the explainer.
+        coEvery { collector.collect() } returns readyEvidence()
         val coordinator = CutoverCoordinator(config, collector, CoroutineScope(Dispatchers.Unconfined))
         return Triple(coordinator, { current }, { noticeArmed })
     }
@@ -386,6 +390,59 @@ class CutoverCoordinatorTest {
         coordinator.commitForUpgradedWalletAsync(pre1110VersionCode)
         assertEquals(CutoverState.CUT_OVER.name, stored())
         assertTrue("an upgrade from below 11.10 arriving pre-commit is exactly the case worth explaining", armed())
+    }
+
+    /**
+     * MO-1022 — THE BUG QA ACTUALLY HIT: on a real upgrade the explainer was
+     * never armed AT ALL. Not late; never.
+     *
+     * Two facts combine. The upgrade seam cannot commit on the upgrade launch
+     * (GATE 2 wants bind evidence, and the bind lands seconds later), so it
+     * returns before any arming. The commit then happens on the READINESS
+     * auto-commit path — which had no arming logic whatsoever.
+     *
+     * Field log (2026-09-04, prod 12000004, SM-A536B), the whole story:
+     *
+     *     17:10:59  declining to commit (upgraded-wallet launch): bind has never succeeded
+     *     17:11:02  app wallet bound to new SDK wallet a60ed232…
+     *     18:06:02  cutover state DUAL_RUNNING -> READY_OBSERVED on OBSERVE_READINESS
+     *     18:06:02  cutover state READY_OBSERVED -> CUT_OVER on COMMIT_CUTOVER
+     *     18:06:02  cutover auto-commit: SDK is now L1-primary (dashj held)
+     *
+     * — committed, and no explainer. So the arming belongs to the COMMIT, not
+     * to one particular caller.
+     */
+    @Test
+    fun upgradeNotice_isArmed_whenTheReadinessAutoCommitIsWhatCommits() = runBlocking {
+        // The upgrade launch already latched the boundary; this is the later
+        // commit, and it does NOT come through the seam.
+        val (coordinator, stored, armed) = noticeCoordinator(
+            stored = null,
+            boundaryAlreadyLatched = true
+        )
+
+        coordinator.autoAdvanceToCutover()
+
+        assertEquals(CutoverState.CUT_OVER.name, stored())
+        assertTrue("the path that actually commits must arm the explainer", armed())
+    }
+
+    /**
+     * The counterpart: a FRESH install that never crossed the boundary must
+     * not be told its wallet was upgraded, no matter which path commits. The
+     * boundary latch is what separates the two, so pin it here.
+     */
+    @Test
+    fun upgradeNotice_isNotArmed_byAnAutoCommitOnAnInstallThatNeverUpgraded() = runBlocking {
+        val (coordinator, stored, armed) = noticeCoordinator(
+            stored = null,
+            boundaryAlreadyLatched = false
+        )
+
+        coordinator.autoAdvanceToCutover()
+
+        assertEquals("the commit itself still happens", CutoverState.CUT_OVER.name, stored())
+        assertFalse("a fresh install has no upgrade to explain", armed())
     }
 
     /**
@@ -444,8 +501,14 @@ class CutoverCoordinatorTest {
         coEvery { config.get(DashPayConfig.CUTOVER_STATE) } answers { current }
         coEvery { config.get(DashPayConfig.USE_KOTLIN_SDK_L1_SHADOW) } returns true
         coEvery { config.get(DashPayConfig.SDK_BIND_EVER_SUCCEEDED) } returns true
-        coEvery { config.get(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED) } returns false
-        coEvery { config.set(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED, any<Boolean>()) } returns Unit
+        // Stateful: GATE 1 writes this latch BEFORE attempting the commit, and
+        // the arming re-reads it. A constant-false stub models neither.
+        var boundaryLatched = false
+        coEvery { config.get(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED) } answers { boundaryLatched }
+        coEvery { config.set(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED, any<Boolean>()) } answers {
+            boundaryLatched = secondArg()
+            Unit
+        }
         coEvery { config.set(DashPayConfig.CUTOVER_STATE, any<String>()) } answers {
             current = secondArg(); Unit
         }
@@ -480,8 +543,14 @@ class CutoverCoordinatorTest {
         coEvery { config.get(DashPayConfig.CUTOVER_STATE) } answers { current }
         coEvery { config.get(DashPayConfig.USE_KOTLIN_SDK_L1_SHADOW) } returns true
         coEvery { config.get(DashPayConfig.SDK_BIND_EVER_SUCCEEDED) } returns true
-        coEvery { config.get(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED) } returns false
-        coEvery { config.set(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED, any<Boolean>()) } returns Unit
+        // Stateful: GATE 1 writes this latch BEFORE attempting the commit, and
+        // the arming re-reads it. A constant-false stub models neither.
+        var boundaryLatched = false
+        coEvery { config.get(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED) } answers { boundaryLatched }
+        coEvery { config.set(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED, any<Boolean>()) } answers {
+            boundaryLatched = secondArg()
+            Unit
+        }
         coEvery { config.set(DashPayConfig.CUTOVER_STATE, any<String>()) } answers {
             current = secondArg(); Unit
         }

--- a/wallet/test/de/schildbach/wallet/service/platform/sdk/CutoverCoordinatorTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/platform/sdk/CutoverCoordinatorTest.kt
@@ -296,6 +296,10 @@ class CutoverCoordinatorTest {
         val config = mockk<DashPayConfig>()
         coEvery { config.get(DashPayConfig.CUTOVER_STATE) } answers { current }
         coEvery { config.get(DashPayConfig.USE_KOTLIN_SDK_L1_SHADOW) } returns true
+        // This test is about WHICH SCOPE the commit runs on, not about gating —
+        // give it the bind evidence every commit path now requires.
+        coEvery { config.get(DashPayConfig.SDK_BIND_EVER_SUCCEEDED) } returns true
+        coEvery { config.get(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED) } returns true
         coEvery { config.set(DashPayConfig.CUTOVER_STATE, any<String>()) } answers {
             current = secondArg()
             Unit
@@ -618,5 +622,55 @@ class CutoverCoordinatorTest {
         val (coordinator, stored, _) = noticeCoordinator(stored = null, bindEverSucceeded = true)
         coordinator.commitForUpgradedWalletAsync(sameBuildVersionCode)
         assertNull("no crossing ever seen — the seam stays out of it", stored())
+    }
+
+    /**
+     * MO-995: the readiness-driven path must ALSO refuse to commit onto an SDK
+     * that has never bound.
+     *
+     * REGRESSION THIS PINS: the bind-evidence gate first lived only in
+     * `commitForUpgradedWalletAsync`, leaving `autoAdvanceToCutover` wide open.
+     * On the emulator, with every bind failing on a real
+     * `KeystoreDeviceLockedException`, CutoverAutoCommitObserver still committed
+     * FOUR separate times — "READY_OBSERVED -> CUT_OVER on COMMIT_CUTOVER
+     * (ready=true)" then "SDK is now L1-primary (dashj held)" — reaching
+     * walletB's engine-less end state through a different door. The readiness
+     * evaluator has no notion of whether the wallet is bound.
+     */
+    @Test
+    fun autoAdvance_refusesToCommit_whenTheSdkBindHasNeverSucceeded() = runBlocking {
+        val (coordinator, stored) = coordinator(stored = null, bindEverSucceeded = false)
+
+        val status = coordinator.autoAdvanceToCutover()
+
+        assertFalse(
+            "readiness must not be able to hand L1 to an SDK that cannot bind",
+            stored() == CutoverState.CUT_OVER.name
+        )
+        assertFalse("and dashj must stay available as the only engine", !coordinator.dashjEngineMayStart())
+        assertFalse("the state must not report CUT_OVER", status.state == CutoverState.CUT_OVER)
+    }
+
+    @Test
+    fun autoAdvance_commits_onceTheBindHasSucceeded() = runBlocking {
+        // Same evidence, same readiness — only the bind marker differs.
+        val (coordinator, stored) = coordinator(stored = null, bindEverSucceeded = true)
+
+        coordinator.autoAdvanceToCutover()
+
+        assertEquals(CutoverState.CUT_OVER.name, stored())
+    }
+
+    @Test
+    fun freshWalletCommit_refusesWithoutBindEvidence() = runBlocking {
+        // The clean-install exposure: committing here would hold dashj while the
+        // SDK cannot bind, leaving a brand-new wallet with no L1 engine at all.
+        val (coordinator, stored) = coordinator(stored = null, bindEverSucceeded = false)
+
+        val status = coordinator.commitForFreshWalletSetup()
+
+        assertNull("a fresh wallet must not be handed to an unbindable SDK", stored())
+        assertEquals(CutoverState.DUAL_RUNNING, status.state)
+        assertTrue(coordinator.dashjEngineMayStart())
     }
 }

--- a/wallet/test/de/schildbach/wallet/service/platform/sdk/CutoverCoordinatorTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/platform/sdk/CutoverCoordinatorTest.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -78,12 +79,20 @@ class CutoverCoordinatorTest {
     private fun coordinator(
         stored: String? = null,
         flag: Boolean? = true,
-        evidence: CutoverEvidence = readyEvidence()
+        evidence: CutoverEvidence = readyEvidence(),
+        // MO-995 GATE 2: the UPGRADE seam refuses to commit until the SDK bind
+        // has succeeded at least once on this install. Defaults to true so the
+        // pre-existing cases keep exercising what they were written for; the
+        // gate itself has its own tests below.
+        bindEverSucceeded: Boolean? = true
     ): Pair<CutoverCoordinator, () -> String?> {
         var current = stored
         val config = mockk<DashPayConfig>()
         coEvery { config.get(DashPayConfig.CUTOVER_STATE) } answers { current }
         coEvery { config.get(DashPayConfig.USE_KOTLIN_SDK_L1_SHADOW) } returns flag
+        coEvery { config.get(DashPayConfig.SDK_BIND_EVER_SUCCEEDED) } returns bindEverSucceeded
+        coEvery { config.get(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED) } returns false
+        coEvery { config.set(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED, any<Boolean>()) } just Runs
         coEvery { config.set(DashPayConfig.CUTOVER_STATE, any<String>()) } answers {
             current = secondArg()
             Unit
@@ -311,13 +320,22 @@ class CutoverCoordinatorTest {
      */
     private fun noticeCoordinator(
         stored: String? = null,
-        flag: Boolean? = true
+        flag: Boolean? = true,
+        bindEverSucceeded: Boolean? = true,
+        boundaryAlreadyLatched: Boolean = false
     ): Triple<CutoverCoordinator, () -> String?, () -> Boolean> {
         var current = stored
         var noticeArmed = false
+        var boundaryLatched = boundaryAlreadyLatched
         val config = mockk<DashPayConfig>()
         coEvery { config.get(DashPayConfig.CUTOVER_STATE) } answers { current }
         coEvery { config.get(DashPayConfig.USE_KOTLIN_SDK_L1_SHADOW) } returns flag
+        coEvery { config.get(DashPayConfig.SDK_BIND_EVER_SUCCEEDED) } returns bindEverSucceeded
+        coEvery { config.get(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED) } answers { boundaryLatched }
+        coEvery { config.set(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED, any<Boolean>()) } answers {
+            boundaryLatched = secondArg()
+            Unit
+        }
         coEvery { config.set(DashPayConfig.CUTOVER_STATE, any<String>()) } answers {
             current = secondArg()
             Unit
@@ -336,6 +354,13 @@ class CutoverCoordinatorTest {
 
     /** A previous-launch versionCode already ON the 11.10 line (11.10.1). */
     private val on1110VersionCode = 11100100
+
+    /**
+     * The versionCode of THIS build — what `lastVersionCode` reads on every
+     * launch after the first one. walletB reached the seam with exactly this
+     * shape (previous code 12000001 on a 12000001 build).
+     */
+    private val sameBuildVersionCode = 12000001
 
     @Test
     fun upgradeNotice_armed_onAGenuineUpgradeFromPre1110ThatFlipsTheState() = runBlocking {
@@ -359,7 +384,12 @@ class CutoverCoordinatorTest {
         // crossing the pre-cutover boundary — no explainer.
         val (coordinator, stored, armed) = noticeCoordinator(stored = null)
         coordinator.commitForUpgradedWalletAsync(on1110VersionCode)
-        assertEquals("the commit itself must be unaffected by the notice gate", CutoverState.CUT_OVER.name, stored())
+        // MO-995 GATE 1 (behaviour CHANGE): the version-code test now gates the
+        // COMMIT too, not just the explainer. An 11.10+ previous code means this
+        // launch did not cross the cutover boundary, so the upgrade seam must
+        // leave the state alone — walletB committed here on a same-version
+        // relaunch and was left with no L1 engine when its bind then failed.
+        assertNull("a non-boundary-crossing launch must not commit", stored())
         assertFalse("an 11.10.x -> 11.10.y update must not re-explain the resync", armed())
     }
 
@@ -371,7 +401,9 @@ class CutoverCoordinatorTest {
         // e.g. any future path reaching this seam without setWallet).
         val (coordinator, stored, armed) = noticeCoordinator(stored = null)
         coordinator.commitForUpgradedWalletAsync(0)
-        assertEquals(CutoverState.CUT_OVER.name, stored())
+        // GATE 1 again: a fresh install did not cross the boundary either, and
+        // the fresh-wallet seam owns that commit.
+        assertNull("a fresh install must not commit through the UPGRADE seam", stored())
         assertFalse("a fresh install has nothing to explain", armed())
     }
 
@@ -423,6 +455,9 @@ class CutoverCoordinatorTest {
         val config = mockk<DashPayConfig>()
         coEvery { config.get(DashPayConfig.CUTOVER_STATE) } answers { current }
         coEvery { config.get(DashPayConfig.USE_KOTLIN_SDK_L1_SHADOW) } answers { sdkL1Enabled }
+        coEvery { config.get(DashPayConfig.SDK_BIND_EVER_SUCCEEDED) } returns true
+        coEvery { config.get(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED) } returns true
+        coEvery { config.set(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED, any<Boolean>()) } just Runs
         coEvery { config.set(DashPayConfig.CUTOVER_STATE, any<String>()) } answers {
             current = secondArg()
             Unit
@@ -476,5 +511,101 @@ class CutoverCoordinatorTest {
         val status = coordinator.rollbackForFailedBind(consecutiveFailures = 5)
         assertEquals(CutoverState.SETTLED, status.state)
         assertEquals(CutoverState.SETTLED.name, stored())
+    }
+
+    // ── MO-995: the UPGRADE seam's commit gates ───────────────────────
+
+    @Test
+    fun upgradeSeam_doesNotCommit_whenTheSdkBindHasNeverSucceeded() = runBlocking {
+        // walletB, exactly: a genuine pre-11.10 upgrade, but this install's
+        // Keystore keeps denying the lock-bound master alias so the SDK has
+        // never bound. Committing would hold dashj and leave NO L1 engine —
+        // no sync, no incoming transactions, "setup is incomplete".
+        val (coordinator, stored, armed) = noticeCoordinator(stored = null, bindEverSucceeded = false)
+        coordinator.commitForUpgradedWalletAsync(pre1110VersionCode)
+        assertNull("a never-bound SDK must not be handed L1", stored())
+        assertFalse("nothing committed, so nothing to explain", armed())
+        assertTrue("dashj must stay available as the only engine", coordinator.dashjEngineMayStart())
+    }
+
+    @Test
+    fun upgradeSeam_doesNotCommit_whenTheBindMarkerIsAbsent() = runBlocking {
+        // An absent key reads as "never bound" — fail safe, not fail open.
+        val (coordinator, stored, _) = noticeCoordinator(stored = null, bindEverSucceeded = null)
+        coordinator.commitForUpgradedWalletAsync(pre1110VersionCode)
+        assertNull("an absent bind marker must be treated as never-bound", stored())
+    }
+
+    @Test
+    fun upgradeSeam_commits_onAGenuineUpgradeOnceTheBindHasSucceeded() = runBlocking {
+        // walletC/D: same seam, same version-code path, but the bind works.
+        val (coordinator, stored, armed) = noticeCoordinator(stored = null, bindEverSucceeded = true)
+        coordinator.commitForUpgradedWalletAsync(pre1110VersionCode)
+        assertEquals(CutoverState.CUT_OVER.name, stored())
+        assertTrue("a genuine boundary-crossing upgrade still explains the resync", armed())
+    }
+
+    @Test
+    fun isPreCutoverUpgrade_pinsTheBoundary() {
+        assertFalse("0 = fresh install, never ran before", isPreCutoverUpgrade(0))
+        assertFalse("negative is nonsense — fail safe", isPreCutoverUpgrade(-1))
+        assertTrue("11.9.0 crossed the boundary", isPreCutoverUpgrade(11090000))
+        assertTrue(
+            "one below the line still crosses it",
+            isPreCutoverUpgrade(CutoverCoordinator.FIRST_CUTOVER_VERSION_CODE - 1)
+        )
+        assertFalse(
+            "the line itself is already 11.10",
+            isPreCutoverUpgrade(CutoverCoordinator.FIRST_CUTOVER_VERSION_CODE)
+        )
+        assertFalse("walletB: a relaunch of the SAME 12.x build is not an upgrade", isPreCutoverUpgrade(12000001))
+    }
+
+    @Test
+    fun upgradeSeam_latchesTheBoundary_thenCommitsOnALaterLaunchOnceTheBindWorks() = runBlocking {
+        // The two-launch sequence a healthy upgrade actually takes.
+        //
+        // LAUNCH 1: previous launch ran 11.9.0, so the boundary is crossed —
+        // but the bind has not run yet (this seam is in finalizeInitialization;
+        // the binder starts with platform sync). Latch, do not commit.
+        val (l1, storedL1, armedL1) = noticeCoordinator(stored = null, bindEverSucceeded = false)
+        l1.commitForUpgradedWalletAsync(pre1110VersionCode)
+        assertNull("launch 1 must not commit — no bind yet", storedL1())
+        assertFalse(armedL1())
+
+        // LAUNCH 2: lastVersionCode now reads THIS build, so the live version
+        // test fails; only the latch keeps the seam alive. The bind succeeded
+        // during launch 1, so it commits and explains.
+        val (l2, storedL2, armedL2) = noticeCoordinator(
+            stored = null,
+            bindEverSucceeded = true,
+            boundaryAlreadyLatched = true
+        )
+        l2.commitForUpgradedWalletAsync(sameBuildVersionCode)
+        assertEquals("the latch must carry the crossing past launch 1", CutoverState.CUT_OVER.name, storedL2())
+        assertTrue("the one-time explainer must survive the deferral", armedL2())
+    }
+
+    @Test
+    fun upgradeSeam_neverCommits_whenTheBindNeverWorks_evenWithTheBoundaryLatched() = runBlocking {
+        // walletB: latched on its upgrade launch, but 16 keystore denials later
+        // the bind has still never succeeded. It must stay on dashj forever
+        // rather than be handed an L1 it cannot serve.
+        val (coordinator, stored, _) = noticeCoordinator(
+            stored = null,
+            bindEverSucceeded = false,
+            boundaryAlreadyLatched = true
+        )
+        coordinator.commitForUpgradedWalletAsync(sameBuildVersionCode)
+        assertNull("a latched boundary must not override a broken bind", stored())
+        assertTrue(coordinator.dashjEngineMayStart())
+    }
+
+    @Test
+    fun upgradeSeam_doesNotLatch_whenNoBoundaryWasCrossed() = runBlocking {
+        // A same-build relaunch that never had a crossing must not invent one.
+        val (coordinator, stored, _) = noticeCoordinator(stored = null, bindEverSucceeded = true)
+        coordinator.commitForUpgradedWalletAsync(sameBuildVersionCode)
+        assertNull("no crossing ever seen — the seam stays out of it", stored())
     }
 }

--- a/wallet/test/de/schildbach/wallet/service/platform/sdk/CutoverCoordinatorTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/platform/sdk/CutoverCoordinatorTest.kt
@@ -40,6 +40,7 @@ import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.io.IOException
 
 /**
  * Host-JVM tests for the [CutoverCoordinator] transitions added for the
@@ -328,18 +329,27 @@ class CutoverCoordinatorTest {
         flag: Boolean? = true,
         bindEverSucceeded: Boolean? = true,
         boundaryAlreadyLatched: Boolean = false,
-        noticeAlreadyArmedEver: Boolean = false
+        noticeAlreadyArmedEver: Boolean = false,
+        // The first N attempts to persist the boundary latch throw, the way a
+        // DataStore write does on a full or corrupt store. Int.MAX_VALUE makes
+        // the key permanently unwritable.
+        boundaryWriteFailures: Int = 0
     ): Triple<CutoverCoordinator, () -> String?, () -> Boolean> {
         var current = stored
         var noticeArmed = false
         var boundaryLatched = boundaryAlreadyLatched
         var noticeEverArmed = noticeAlreadyArmedEver
+        var boundaryWritesLeftToFail = boundaryWriteFailures
         val config = mockk<DashPayConfig>()
         coEvery { config.get(DashPayConfig.CUTOVER_STATE) } answers { current }
         coEvery { config.get(DashPayConfig.USE_KOTLIN_SDK_L1_SHADOW) } returns flag
         coEvery { config.get(DashPayConfig.SDK_BIND_EVER_SUCCEEDED) } returns bindEverSucceeded
         coEvery { config.get(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED) } answers { boundaryLatched }
         coEvery { config.set(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED, any<Boolean>()) } answers {
+            if (boundaryWritesLeftToFail > 0) {
+                boundaryWritesLeftToFail--
+                throw IOException("datastore write failed")
+            }
             boundaryLatched = secondArg()
             Unit
         }
@@ -383,6 +393,53 @@ class CutoverCoordinatorTest {
      * shape (previous code 12000001 on a 12000001 build).
      */
     private val sameBuildVersionCode = CutoverCoordinator.FIRST_CUTOVER_VERSION_CODE + 1
+
+    /**
+     * A DROPPED boundary-latch write must not cost the user the explainer.
+     *
+     * The crossing is computable on exactly one launch —
+     * `Configuration.lastVersionCode` is overwritten at every startup — so if
+     * GATE 1's `set(CUTOVER_UPGRADE_BOUNDARY_CROSSED, true)` throws and nothing
+     * else remembers it, the explainer is lost for good: this launch's
+     * `armUpgradeNoticeIfUpgraded` reads the store and sees `false`, and every
+     * later launch computes `crossedNow == false` with nothing on disk to
+     * recover from. Before the fix that is exactly what happened.
+     *
+     * Here the write fails once and the retry at arm time succeeds, so both the
+     * explainer AND the durable latch come out right.
+     */
+    @Test
+    fun upgradeNotice_survivesADroppedBoundaryLatchWrite_andRepersistsIt() = runBlocking {
+        val (coordinator, stored, armed) = noticeCoordinator(
+            stored = null,
+            boundaryWriteFailures = 1
+        )
+        coordinator.commitForUpgradedWalletAsync(pre1110VersionCode)
+        assertEquals(CutoverState.CUT_OVER.name, stored())
+        assertTrue(
+            "a dropped latch write must not cost the user the one-time explainer",
+            armed()
+        )
+    }
+
+    /**
+     * The same dropped write, but the store NEVER accepts the key. The
+     * in-memory record still carries this launch, which is all that can be
+     * salvaged: if the store is permanently unwritable then the explainer's own
+     * flags cannot be written either, so there is no durable outcome to assert.
+     * What must NOT happen is silently skipping the explainer while the cutover
+     * commits anyway.
+     */
+    @Test
+    fun upgradeNotice_armedFromMemory_whenTheBoundaryLatchNeverPersists() = runBlocking {
+        val (coordinator, stored, armed) = noticeCoordinator(
+            stored = null,
+            boundaryWriteFailures = Int.MAX_VALUE
+        )
+        coordinator.commitForUpgradedWalletAsync(pre1110VersionCode)
+        assertEquals(CutoverState.CUT_OVER.name, stored())
+        assertTrue("the launch that observed the crossing must still arm", armed())
+    }
 
     @Test
     fun upgradeNotice_armed_onAGenuineUpgradeFromPre1110ThatFlipsTheState() = runBlocking {

--- a/wallet/test/de/schildbach/wallet/service/platform/sdk/L1ShadowSyncServiceTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/platform/sdk/L1ShadowSyncServiceTest.kt
@@ -1467,6 +1467,41 @@ class L1ShadowSyncServiceTest {
         service.stop()
     }
 
+    // ── Engine loop-lifecycle reporting ───────────────────────────────
+
+    /**
+     * MO-995: the outage this instruments was 5h28m, reconstructed by hand
+     * from two timestamps 12,000 log lines apart. These are the shapes that
+     * have to read correctly at a glance in a field log.
+     */
+    @Test
+    fun humanDuration_readsAtAGlance() {
+        assertEquals("0s", L1ShadowSyncService.humanDuration(0))
+        assertEquals("47s", L1ShadowSyncService.humanDuration(47_000))
+        assertEquals("3m12s", L1ShadowSyncService.humanDuration(192_000))
+        // The field outage: 10:38:00 -> 16:06:27.
+        assertEquals("5h28m", L1ShadowSyncService.humanDuration(19_707_000))
+        // Sub-second rounds down rather than printing an empty string.
+        assertEquals("0s", L1ShadowSyncService.humanDuration(999))
+    }
+
+    /**
+     * The WARN threshold has to separate a ROUTINE idle-detector bounce from
+     * an OUTAGE, because a WARN on every bounce is a WARN nobody reads. Pinned
+     * against the three real teardowns in the MO-995 log: two bounces (~30s
+     * and ~3min, both recovered) and one outage (5h28m, never recovered until
+     * the process died).
+     */
+    @Test
+    fun longEngineDowntimeThreshold_separatesARoutineBounceFromAnOutage() {
+        val threshold = L1ShadowSyncService.LONG_ENGINE_DOWNTIME_MS
+        // 07:35:00 -> 07:35:26 and 07:38:00 -> 07:38:03: routine, must stay INFO.
+        assertTrue("a ~26s bounce must not warn", 26_000 < threshold)
+        assertTrue("a ~3min bounce must not warn", 180_000 < threshold)
+        // 10:38:00 -> 16:06:27: the outage, must warn.
+        assertTrue("a 5h28m outage must warn", 19_707_000 >= threshold)
+    }
+
     // ── Probe watchdog ────────────────────────────────────────────────
 
     @Test

--- a/wallet/test/de/schildbach/wallet/service/platform/sdk/SdkBindRetryServiceTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/platform/sdk/SdkBindRetryServiceTest.kt
@@ -486,4 +486,71 @@ class SdkBindRetryServiceTest {
         assertFalse(binder.bindRetryPending.value)
         assertEquals(0, binder.consecutiveBindFailures)
     }
+
+    /**
+     * MO-995: the durable bind-success marker must be written on EVERY
+     * successful pass, including the "app wallet already bound" path — not only
+     * when a new SDK wallet is created.
+     *
+     * REGRESSION: the marker first lived inside `bindAppWallet(...).also { }`,
+     * which only runs on a fresh bind. On any launch that found the SDK wallet
+     * already bound, the marker was never written, so
+     * `CutoverCoordinator.commitForUpgradedWalletAsync` declined forever and
+     * the cutover never committed. Caught on the emulator: launch 2 of a clean
+     * run still logged "bind has never succeeded" while the L1 engine was
+     * demonstrably running.
+     */
+    @Test
+    fun binder_persistsTheBindSuccessMarker_evenWhenTheWalletWasAlreadyBound() = runBlocking {
+        val config = mockk<DashPayConfig>()
+        coEvery { config.get(DashPayConfig.USE_KOTLIN_SDK_DPNS_READS) } returns false
+        coEvery { config.get(DashPayConfig.USE_KOTLIN_SDK_DASHPAY_WRITES) } returns false
+        coEvery { config.get(DashPayConfig.USE_KOTLIN_SDK_SHIELDED) } returns false
+        coEvery { config.get(DashPayConfig.USE_KOTLIN_SDK_L1_SHADOW) } returns true
+        coEvery { config.get(DashPayConfig.SDK_GAP_WIDENED_VERSION) } returns
+            SdkWalletBinder.GAP_WIDEN_HEAL_VERSION
+        var markerWritten = false
+        coEvery { config.set(DashPayConfig.SDK_BIND_EVER_SUCCEEDED, any<Boolean>()) } answers {
+            markerWritten = secondArg()
+            Unit
+        }
+        val walletId = "cd".repeat(32)
+        val sdk = mockk<DashSdkService>(relaxed = true)
+        coEvery { sdk.bindAppWallet(any(), any()) } returns walletId
+        // The ALREADY-BOUND path: the SDK reports the wallet is already loaded,
+        // so a fresh bindAppWallet() is not what establishes it.
+        coEvery { sdk.loadedWalletIds() } returns setOf(walletId)
+        val identityConfig = mockk<de.schildbach.wallet.database.entity.BlockchainIdentityConfig> {
+            coEvery { loadBase() } returns de.schildbach.wallet.database.entity.BlockchainIdentityBaseData(
+                creationState = de.schildbach.wallet.database.entity.IdentityCreationState.NONE,
+                creationStateErrorMessage = null,
+                username = null,
+                usernameSecondary = null,
+                userId = null,
+                restoring = false
+            )
+        }
+        val binder = SdkWalletBinder(
+            sdkService = sdk,
+            mnemonicProvider = object : PlatformMnemonicProvider {
+                override suspend fun getMnemonicWords(unlock: WalletUnlock) =
+                    listOf("abandon", "abandon", "about")
+            },
+            identityConfig = identityConfig,
+            dashPayConfig = config,
+            walletData = mockk { io.mockk.every { wallet } returns null },
+            blockchainServiceConfig = mockk { coEvery { getWalletCreationDate() } returns null },
+            scope = kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.Unconfined),
+            supportsPlatform = { true },
+            backfillGate = DashPayBackfillGate.ALWAYS_RUN
+        )
+
+        binder.bindIfEnabled { WalletUnlock.Unencrypted }
+
+        assertTrue(
+            "a successful pass must persist SDK_BIND_EVER_SUCCEEDED regardless of which " +
+                "path established the bind — otherwise the upgrade seam declines forever",
+            markerWritten
+        )
+    }
 }

--- a/wallet/test/de/schildbach/wallet/service/platform/sdk/SdkBindRetryServiceTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/platform/sdk/SdkBindRetryServiceTest.kt
@@ -302,6 +302,14 @@ class SdkBindRetryServiceTest {
         val config = mockk<DashPayConfig>()
         coEvery { config.get(DashPayConfig.CUTOVER_STATE) } answers { storedState }
         coEvery { config.get(DashPayConfig.USE_KOTLIN_SDK_L1_SHADOW) } returns true
+        // "Has EVER bound" is true here on purpose: this models a wallet that
+        // bound successfully at some point and whose Keystore then started
+        // denying (e.g. the device locked). The commit is therefore legal, and
+        // the rollback is exactly the safety net under test. A never-bound
+        // wallet is refused up front instead — see
+        // CutoverCoordinatorTest.autoAdvance_refusesToCommit_*.
+        coEvery { config.get(DashPayConfig.SDK_BIND_EVER_SUCCEEDED) } returns true
+        coEvery { config.get(DashPayConfig.CUTOVER_UPGRADE_BOUNDARY_CROSSED) } returns true
         coEvery { config.get(DashPayConfig.USE_KOTLIN_SDK_DPNS_READS) } returns false
         coEvery { config.get(DashPayConfig.USE_KOTLIN_SDK_DASHPAY_WRITES) } returns false
         coEvery { config.get(DashPayConfig.USE_KOTLIN_SDK_SHIELDED) } returns false

--- a/wallet/test/de/schildbach/wallet/service/platform/sdk/SdkBindRetryServiceTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/platform/sdk/SdkBindRetryServiceTest.kt
@@ -177,7 +177,7 @@ class SdkBindRetryServiceTest {
     }
 
     @Test
-    fun noteAppForeground_collapsesTheBackoffWindow() = runTest {
+    fun noteAppForeground_drivesARetryImmediately() = runTest {
         val h = Harness()
         h.signal.primeFailed()
         val service = h.service(backgroundScope)
@@ -194,10 +194,19 @@ class SdkBindRetryServiceTest {
         service.maybeRetry("poll")
         assertEquals(5, h.signal.passes)
 
-        // …until the app foregrounds, which resets the ladder.
+        // …until the app foregrounds, which now DRIVES a pass itself rather than
+        // only resetting the ladder for some other trigger to notice.
+        //
+        // MO-995: the old state-only behaviour depended on `maybeRetry` being
+        // called by CutoverUiDataService's bound-wallet wait loop — a loop that
+        // only runs while the cutover holds dashj with NO bound wallet. Once the
+        // coordinator refuses to commit onto an unbindable SDK that state never
+        // happens, so nothing ever polled and nothing ever retried (emulator S3:
+        // unlock + foreground produced zero binder activity; only an app restart
+        // healed it).
         service.noteAppForeground()
-        service.maybeRetry("poll")
-        assertEquals(6, h.signal.passes)
+        runCurrent()
+        assertEquals("foregrounding must itself run a bind pass", 6, h.signal.passes)
     }
 
     // ── The unlock heal receiver ──────────────────────────────────────
@@ -560,5 +569,46 @@ class SdkBindRetryServiceTest {
                 "path established the bind — otherwise the upgrade seam declines forever",
             markerWritten
         )
+    }
+
+    /**
+     * The emulator S3 scenario, reduced: a pending retry, and NOTHING polling.
+     *
+     * This is the state the wallet is actually in after the coordinator
+     * declines to commit onto an unbindable SDK — CutoverUiDataService's
+     * bound-wallet wait loop (the sole caller of [SdkBindRetryService.maybeRetry])
+     * never runs, so no poll ever arrives. Foregrounding the app must be
+     * sufficient on its own, with no `maybeRetry` call anywhere in the test.
+     */
+    @Test
+    fun noteAppForeground_recoversWithNoPollingTriggerAtAll() = runTest {
+        val h = Harness()
+        h.signal.primeFailed()
+        val service = h.service(backgroundScope)
+
+        assertEquals("no poll has happened", 0, h.signal.passes)
+
+        service.noteAppForeground()
+        runCurrent()
+
+        assertEquals("a foreground visit alone must retry the bind", 1, h.signal.passes)
+    }
+
+    /**
+     * Foregrounding also ARMS the unlock receiver. Arming used to happen only
+     * inside [SdkBindRetryService.maybeRetry], so in the no-polling state above
+     * the receiver was never registered either — walletB logged
+     * "unlock-heal receiver registered" zero times.
+     */
+    @Test
+    fun noteAppForeground_armsTheUnlockReceiver() = runTest {
+        val h = Harness()
+        h.signal.primeFailed()
+        val service = h.service(backgroundScope)
+
+        service.noteAppForeground()
+        runCurrent()
+
+        assertEquals("the unlock-heal receiver must be armed by a foreground visit", 1, h.registrations)
     }
 }

--- a/wallet/test/de/schildbach/wallet/service/platform/sdk/SdkDashPayWritesTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/platform/sdk/SdkDashPayWritesTest.kt
@@ -164,6 +164,84 @@ class SdkDashPayWritesTest {
         assertSame(liveShape, (result as SdkWriteResult.NotBroadcast).cause)
     }
 
+    /**
+     * MO-973: the reason string must carry the ENGINE's message, because
+     * "Invalid identity data" is overloaded and the classifier cannot tell
+     * which one it has.
+     *
+     * The old reason stopped at "pre-broadcast identity-key validation
+     * failure" — the contact-request reading — and that label was then
+     * reported verbatim for a DPNS name registration, which needs no
+     * encryption key at all. The field report (2026-09-10, testnet 12000007,
+     * SM-A536B) therefore showed only our gloss, and because
+     * `RestoreIdentityWorker` also threw via `error(...)` (no cause), the real
+     * reason was unrecoverable from the log.
+     *
+     * That the message is overloaded is not a guess: the invitation
+     * amount-cap rejection arrives with the same "Invalid identity data"
+     * prefix (see InviteCreationFailureTest). Two different failures must not
+     * produce the same reason.
+     */
+    @Test
+    fun classify_invalidIdentityData_reasonCarriesTheEngineMessage() {
+        val missingEncryptionKey = DashSdkError.PlatformWallet.Generic(
+            5000,
+            "Invalid identity data: Identity has no enabled ECDSA_SECP256K1 encryption key"
+        )
+        val amountCap = DashSdkError.PlatformWallet.Generic(
+            5000,
+            "Invalid identity data: invitation amount 25000000 exceeds the cap 5000000 duffs"
+        )
+
+        val a = classifyBroadcastFailure(missingEncryptionKey) as SdkWriteResult.NotBroadcast
+        val b = classifyBroadcastFailure(amountCap) as SdkWriteResult.NotBroadcast
+
+        assertTrue(
+            "the reason must name the actual engine failure, got: ${a.reason}",
+            a.reason.contains("no enabled ECDSA_SECP256K1 encryption key")
+        )
+        assertTrue(
+            "the reason must name the actual engine failure, got: ${b.reason}",
+            b.reason.contains("exceeds the cap")
+        )
+        assertFalse(
+            "two different invalid-identity-data failures must not read alike",
+            a.reason == b.reason
+        )
+    }
+
+    /**
+     * MO-972: the reason must not ASSERT an expiry nobody measured. Field log
+     * (2026-09-10, testnet 12000007, HONOR PTP-N49): biometric authentication
+     * at 11:49:16, this failure at 11:49:17 — one second — reported as
+     * "Keystore auth window expired". On that OEM the auth-bound Keystore gate
+     * is defective, the same defect family as the false-locked master alias;
+     * the window was not the problem and the label sent diagnosis the wrong
+     * way.
+     */
+    @Test
+    fun classify_userNotAuthenticated_doesNotClaimTheWindowExpired() {
+        val liveShape = DashSdkError.PlatformWallet.Generic(
+            5000,
+            "SDK error: Protocol error: Generic Error: User not authenticated"
+        )
+
+        val result = classifyBroadcastFailure(liveShape) as SdkWriteResult.NotBroadcast
+
+        assertFalse(
+            "must not state an expiry as fact, got: ${result.reason}",
+            result.reason.contains("auth window expired")
+        )
+        assertTrue(
+            "must still be recognisable as the auth-gate refusal, got: ${result.reason}",
+            result.reason.contains("unauthenticated")
+        )
+        assertTrue(
+            "must carry the engine message, got: ${result.reason}",
+            result.reason.contains("User not authenticated")
+        )
+    }
+
     @Test
     fun classify_keystoreAuthWindowExpiry_isNotBroadcast() {
         // The live S22 failure: the SDK's AUTH_GATED Keystore threw

--- a/wallet/test/de/schildbach/wallet/transactions/coinjoin/CoinJoinMixingTxSetTest.kt
+++ b/wallet/test/de/schildbach/wallet/transactions/coinjoin/CoinJoinMixingTxSetTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.schildbach.wallet.transactions.coinjoin
+
+import io.mockk.mockk
+import org.bitcoinj.wallet.WalletEx
+import org.dash.wallet.common.transactions.TxInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * MO-995: QA saw an ordinary 0.0002 DASH send labelled "CoinJoin Mixing" on
+ * BOTH the sending and the receiving wallet, while the coinjoin balance was 0
+ * for the entire session — no mixing had occurred. 0.0002 DASH is not a
+ * CoinJoin denomination, so amount-matching does not explain it.
+ *
+ * The label comes from [CoinJoinMixingTxSet.tryInclude], which groups a
+ * transaction as CoinJoin unless dashj's shape heuristic
+ * `CoinJoinTransactionType.fromTx` returns `None` or `Send`. That heuristic is
+ * evaluated against the DASHJ wallet, which post-cutover is held with its
+ * balance frozen at the cutover snapshot — while the transaction itself comes
+ * from the SDK.
+ *
+ * WHAT THIS FILE CAN AND CANNOT COVER: the misclassification itself lives
+ * inside dashj's `fromTx` and depends on real wallet/UTXO context, which cannot
+ * be assembled here (there is no `WalletEx` fixture, and `fromTx` reads input
+ * values and script ownership). That half is answered by the diagnostic log
+ * line added alongside these tests, from the next field report.
+ *
+ * What IS covered here is the payload contract that must hold regardless of
+ * how `fromTx` behaves — and which used to be an outright crash.
+ */
+class CoinJoinMixingTxSetTest {
+
+    // groupDate is derived from updateTimeMillis, not a constructor arg.
+    private fun txInfo(txId: String, raw: Any?): TxInfo = TxInfo(
+        txId = txId,
+        updateTimeMillis = 1_756_400_000_000L,
+        raw = raw
+    )
+
+    /**
+     * REGRESSION: `tryInclude` did `tx.raw as Transaction` unconditionally, but
+     * `TxInfo.raw` is `Any?`. Post-cutover a TxInfo can be built from the SDK
+     * rather than from dashj, so a non-dashj payload — or null — threw a
+     * ClassCastException straight out of the transaction-list grouping.
+     *
+     * A payload the CoinJoin heuristic cannot even read is, by definition, not
+     * a transaction we can call CoinJoin: exclude it and keep the list alive.
+     */
+    @Test
+    fun tryInclude_excludesANonDashjPayload_insteadOfThrowing() {
+        val set = CoinJoinMixingTxSet(mockk<WalletEx>(relaxed = true))
+
+        assertFalse(
+            "a non-dashj payload must not be grouped as CoinJoin",
+            set.tryInclude(txInfo("aa".repeat(32), raw = "not a dashj Transaction"))
+        )
+        assertTrue("and nothing must be added to the group", set.transactions.isEmpty())
+    }
+
+    @Test
+    fun tryInclude_excludesANullPayload_insteadOfThrowing() {
+        val set = CoinJoinMixingTxSet(mockk<WalletEx>(relaxed = true))
+
+        assertFalse(set.tryInclude(txInfo("bb".repeat(32), raw = null)))
+        assertTrue(set.transactions.isEmpty())
+    }
+
+    /**
+     * The already-present short circuit must keep working: an update for a txId
+     * already in the group is accepted without consulting the classifier at all
+     * (the mock WalletEx would otherwise be asked, and on a real frozen wallet
+     * the answer could differ from the one that put it here).
+     */
+    @Test
+    fun tryInclude_updatesAnAlreadyGroupedTxWithoutReclassifying() {
+        val set = CoinJoinMixingTxSet(mockk<WalletEx>(relaxed = true))
+        val txId = "cc".repeat(32)
+        // Seed it directly: the classifier cannot be driven from a unit test.
+        set.transactions[txId] = txInfo(txId, raw = null)
+
+        val updated = txInfo(txId, raw = "replacement payload")
+        assertTrue("an already-grouped txId must be accepted", set.tryInclude(updated))
+        // NB: TxInfo.equals compares txId only, so asserting equality here would
+        // pass trivially. Check the payload actually swapped.
+        assertEquals("replacement payload", set.transactions[txId]?.raw)
+        assertEquals(1, set.transactions.size)
+    }
+}

--- a/wallet/test/de/schildbach/wallet/ui/invite/InviteCreationFailureTest.kt
+++ b/wallet/test/de/schildbach/wallet/ui/invite/InviteCreationFailureTest.kt
@@ -43,8 +43,14 @@ class InviteCreationFailureTest {
     fun amountCapRejection_isRejected_andBlocksRetryImmediately() {
         // The exact live shape: classifyBroadcastFailure matched the FFI's
         // "Invalid identity data" message and produced this NotBroadcast.
+        // The reason text mirrors what classifyBroadcastFailure now produces
+        // (MO-973: it carries the engine message instead of glossing every
+        // "Invalid identity data" as an identity-key check). This classifier
+        // reads the reason AND the cause chain, so it still lands on REJECTED
+        // either way — pinned here because that coupling is easy to break.
         val result = SdkWriteResult.NotBroadcast(
-            "pre-broadcast identity-key validation failure",
+            "pre-broadcast identity data rejected by the FFI — " +
+                "Invalid identity data: invitation amount 25000000 exceeds the cap 5000000 duffs",
             RuntimeException(
                 "Invalid identity data: invitation amount 25000000 exceeds the cap 5000000 duffs"
             )
@@ -123,7 +129,10 @@ class InviteCreationFailureTest {
             "SDK bootstrap/bind lookup failed",
             "app wallet not bound to the SDK",
             "cutover state read failed",
-            "signing failure (pre-broadcast): Keystore auth window expired"
+            // MO-972: no longer claims an expiry as fact.
+            "signing failure (pre-broadcast): Keystore refused the identity key as " +
+                "unauthenticated (auth window may have expired, or the device's " +
+                "auth-bound Keystore gate is defective) — User not authenticated"
         )) {
             val kind = classifyInviteCreationFailure(SdkWriteResult.NotBroadcast(reason))
             assertEquals(reason, InviteCreationFailureKind.UNREACHABLE, kind)


### PR DESCRIPTION
Fixes the MO-995 sync failures reported on the 12.0.0 QA builds, plus several defects found while retesting them. Base is `feat/kotlin-sdk-phase-1` (36 commits — see the second-round section below).

## The reported bug

**No L1 sync after a memory trim** — `b994bb6a1`. `platformSyncService.resume()`, the only in-process path that restarts the SDK's L1 engine, sat below the `!dashjEngineMayStart` early return in `checkService()`. Post-cutover that return always fires, so the engine only ever started once per process from `WalletApplication`. Any teardown that stopped it — `onTrimMemory`, the idle detector, the Android 15 FGS timeout — killed L1 sync permanently. Andrei's mainnet log: engine stopped 13:37:38, service recreated five times, **2h10m with no sync**, two Coinbase deposits invisible. Only reproduces on release builds, because `shutdown()` deliberately keeps the engines warm on debug.

**Crash tapping the fiat option on the Coinbase transfer screen** — `ce0bc1551`. `setSpan(12 … 7)`: the span was bounded by `inputValue.length`, but `fiatBalance` is the 2-dp formatted figure and is shorter whenever the input has more than two decimals.

## Found while retesting — walletB had *no* L1 engine at all

A HONOR PTP-N49 upgraded, ran fine on dashj all morning, then at 18:20 lost sync entirely. Root cause chain: an Android Keystore denial on the lock-bound master alias (MO-1022) meant the SDK could not bind — and the cutover committed anyway, holding dashj and leaving zero engines.

- `5cbffa897` / `2f574b8a1` — no path into `CUT_OVER` without durable SDK bind evidence. Both write sites (`commitLocked` **and** `transition`) now consult it, because the readiness-driven auto-commit was bypassing the seam gate entirely — reproduced committing four times with every bind failing.
- `93795401b` — the bind marker is written on every successful bind, not only a newly created one.
- `1b25d6e45` — an app-foreground visit now *drives* a bind retry instead of only resetting a backoff that nothing read.
- `984ca67ee` / `5d89950bc` — **`ProcessLifecycleOwner` has never fired in this app.** `AndroidManifest.xml` removes `androidx.startup.InitializationProvider`, so `lifecycle-process`'s initializer never runs. Across a 27,000-line log with 36 service `onCreate`s, "App moved to foreground" appears **zero** times — so `isAppInBackground` was frozen and the foreground hook was dead code. Signal now comes from `WalletActivityTracker`, keeping the cold-start optimisation.

## Other defects found

- `ad66c6718` — **Uphold portal crashes on release builds.** `integrations/uphold` was the only module minifying its own library output; R8 strips `hilt_aggregated_deps/` (5 entries in debug, 0 in release), so the app component never implements `UpholdPortalFragment_GeneratedInjector`. Present on master too, so likely shipping broken.
- `091c2bae3` — `onStoppedLast()` never ran (override missing `super`), so auto-logout was never told the app backgrounded.
- `c41b7a134` — diagnostic for the CoinJoin mislabel, plus a latent `ClassCastException` from `tx.raw as Transaction` on an `Any?` documented as opaque.

## Verification

Emulator harness (`scripts/cutover-emulator-test.sh`), release build, real Keystore denials:

| scenario | result |
|---|---|
| S1 upgrade, working bind | 5/5 |
| S2 upgrade, denied bind | 5/5 — declines, dashj live, never engine-less |
| S3 in-session recovery | 7/7 — heals on foreground, same process |
| S3b next launch commits | 2/2 |
| S4 trim → SPV restart | pass |

Uphold fix measured on the generated component: `_testNet3Release` uphold injectors **0 → 2**.

## Not fixed / known

- **The Keystore denial itself (MO-1022) is untouched** — an OEM defect (Google Issue Tracker 506989112). Of walletB's 16 denials, 9 were genuinely-locked and heal on a foreground retry; **7 were FALSE-LOCKED** and cannot. Those devices run on dashj and never activate the SDK.
- **This blocks dashj removal.** Every gate here degrades to "keep dashj". Once dashj is gone that has no second half, so MO-992/MO-993 need the SDK keystore fix first, and `SDK_BIND_EVER_SUCCEEDED` is the natural per-install gate for retiring dashj.
- FALSE-LOCKED cannot be reproduced on an emulator; that branch is unit-tested only.
- Real upgrade mechanics (Room migrations, protobuf) untested — only gate logic.
- `e4993d240` was already on the branch and is included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transfer-screen crashes caused by invalid currency positions.
  * Corrected received-coin notifications for self-authored sends and non-positive amounts.
  * Improved CoinJoin handling for unsupported transaction data.
  * Prevented release-build networking crashes and premature service shutdowns.
  * Preserved accurate synchronization progress during temporary engine interruptions.

* **Improvements**
  * Foregrounding the app now actively retries wallet connection and recovery.
  * Improved wallet upgrade safeguards, cutover reliability, and service restarts.
  * Enhanced diagnostics and error messages for identity registration and transaction failures.

* **Testing**
  * Added regression coverage across transfers, notifications, upgrades, synchronization, retries, and CoinJoin handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

# Second round — defects found retesting 12000001 → 12000006

The 20 commits after `ad66c6718`. Every one came from a QA field log; three of them are regressions from earlier commits **in this PR**, called out as such.

## MO-973 — username creation crash-looped on release builds

One crash explains three separate QA reports: the crash, the "cannot create a username" failure, and "the lock screen appears after clicking Continue".

`NettyChannelBuilder`'s static initializer wires its transport entirely by **reflection**, so R8 sees no reference to the members it needs and strips them. Each strip becomes `ExceptionInInitializerError` the first time anything constructs a `DAPIGrpcMasternode`:

1. `accbd2997` — `Utils.isEpollAvailable()` does `getDeclaredMethod("isAvailable")`; class kept, method stripped, so the probe threw instead of returning false (12000005).
2. `e9f178e15` — with epoll then correctly false, `<clinit>` falls through to `new ReflectiveChannelFactory<>(NioSocketChannel.class)` on the **next** line, whose no-arg constructor had been stripped (12000006). Targeted rules only reveal the next stripped member, so the whole shaded package is now kept: 26,542 methods / 1.9 MB of dex against a 233 MB APK. Verified by building the release variant and reading the dex back with `apkanalyzer`, not by reasoning about R8.
3. `962d4de5d` — `PlatformHealthProbe.probe()` caught only `Exception`, and this fails with an **Error**. It sailed past that catch, past the caller's bare `try/finally`, out of the coroutine, and killed the process — 11 times on one HONOR PTP-N49. An advisory row that feeds one warning must never be able to do that. `CancellationException` is rethrown so structured concurrency still works, and a non-Exception logs at ERROR **with the full stack** — degrading silently would trade a loud crash for an invisible one.

The lock screen was Android relaunching the killed process: seven times, `CreateUsernameActivity created` → crash 3–4 s later → `WalletApplication.onCreate()` in the same second → `show lock screen true`.

Netty is present only because the legacy Java dapi-client uses it for transport; the Kotlin SDK does not. It stays reachable from `TopUpRepository.getTransaction`, `IdentityRepository`'s credit balance and `PlatformSyncService.reportNetworkStatus`, which is why this is a keep rule rather than a fix to the probe alone.

## MO-995 — the L1 engine died whenever the user left the app

`0b31e7980`. `onTrimMemory` used `level >= TRIM_MEMORY_BACKGROUND`, which is wrong in **both** directions. 40 does not mean low memory — it means the process went onto the LRU background list, i.e. the user left the app. And the signals that do mean running-low, `RUNNING_LOW` (10) and `RUNNING_CRITICAL` (15), are numerically *below* 40 and were ignored entirely. The scale is not ordered by severity, so `>=` cannot express the policy at all; the log line called it "low memory detected" throughout.

Field log, HONOR PTP-N49 (384/512 MB heap) mid from-genesis scan: three engine restarts in five minutes, `scanCaughtUpToTip` never held, the cutover never committed, and Buy Credits failed for want of an SDK-owned L1. Now stops only on `TRIM_MEMORY_COMPLETE` (80) and `RUNNING_CRITICAL` (15).

## Regressions from this PR's own earlier commits

- `21748def0` — `2f574b8a1` put the bind-evidence guard inside `commitLocked`, which the **fresh-wallet** commit shares with the upgrade seam. A new install has no bind evidence by construction: the commit is what routes the launch, the bind runs after it. So every newly created or restored wallet silently fell back to dashj and the SDK's fast initial sync never ran. The bind succeeding three seconds *after* the refusal is the whole bug in one log line. `commitLocked` now takes `requireBindEvidence` explicitly — true for the seam, false for fresh setup, where `rollbackForFailedBind` was always the designed escape hatch.
- `497dec7df` — the explainer was never armed on a real upgrade. The seam cannot commit on the upgrade launch, and the path that *does* commit (the readiness auto-commit in `transition`) had no arming logic. Arming now belongs to the commit, gated on the durable boundary latch. This also supersedes the framing of `cdb17f3a2`, which fixed a double-arm on a path that in the normal flow never fires.
- `4f74977a2` — `fba24cbfb`'s filter backstop was held **in memory**, so it was empty on a cold start, which is exactly when the Network Monitor gets opened. Now floors on the engine's committed wallet cursor, seeded from the SDK's durable watermark. ChainLock deliberately left alone: the provider already max-guards it and QA's own earlier screenshot shows it populated while only filters read "—".

## Also

- `5d5e59d92` — `startForeground()` sat inside `onStartCommand`'s coroutine behind `onCreateCompleted.await()`, conflating the framework's `onCreate` (which has returned by then) with this service's async init (which the FGS deadline does not wait for). An alarm-triggered start raced the idle detector's shutdown and the process was killed with `ForegroundServiceDidNotStartInTimeException`. Now synchronous.
- `ea513d474` — `startIfEnabled`/`stop` tear down four long-lived loops and nothing recorded how long the engine was down; reconstructing a 5h28m outage meant diffing timestamps 12,000 log lines apart. Reports the gap on the start that ends it — no timer needed, and it outlives the dashj retirement, where these become *the* engine's loops.
- `fddb0e244` — the emulator harness printed FAIL and exited 0, and kept a second copy of the cutover boundary that disagreed with the app's.

## Review follow-ups

`82969ccc6` — two CodeRabbit findings, both confirmed against the code.

- **The upgrade explainer could be lost to a single dropped write.** The cutover boundary crossing is computable on exactly one launch (`Configuration.lastVersionCode` is overwritten at every startup), so when GATE 1's `set(CUTOVER_UPGRADE_BOUNDARY_CROSSED)` threw, the crossing existed only as a local `val`. `armUpgradeNoticeIfUpgraded` reads the *store*, not that value, so it saw `false` and returned — and every later launch computed `crossedNow == false` with nothing on disk to recover from. The commit still happened, so the symptom is MO-1022's (no one-time sync explanation) reached by a different route. Now held in memory for the launch that observed it, with the persist retried at commit time; if the store never accepts the key, arming proceeds from memory, which is all that can be salvaged — the explainer's own flags need that same store.
- **`filterTarget` could trail `filterHeight`.** The IDLE/CONNECTING target took every floor the height took *except* the height's own raw value, so an inverted engine snapshot rendered as `2533400/2533349` — a row past 100%. Minor, and the non-idle branch passes such a snapshot through unchanged regardless, but the comment directly above asserted the pair "can never render as height > target", which was not true. Worth noting the review's stated mechanism is wrong: both fields are read off the same `data.filters` snapshot in `toShadowSyncProgress`, so they cannot drift apart — this needs an already-inverted snapshot, not a partial update. Comment corrected to say what actually holds.

Three regression tests, each verified to fail against the unfixed code.

`517f201bd` — KDoc for `armUpgradeNoticeOnce`, the one function this PR adds without one. CodeRabbit's docstring-coverage check flags 54% against an 80% threshold, but it scores every function *touched* by the diff; the files changed here sit at ~57% against a 28% baseline for `wallet/src` on the base branch, so the gap is pre-existing code this PR barely edits, not new code.

`39d188d94` — S4 in the emulator harness was left behind by two commits in this same PR and would have reported FAIL against correct code: it fired `TRIM_MEMORY_BACKGROUND`, which `0b31e7980` deliberately stopped treating as pressure, and grepped for `low memory detected, stopping service` and `L1 shadow sync stopped` — renamed to `memory pressure (onTrimMemory level N), stopping service` and `L1ShadowLifecycle STOPPED`. S4 now drives both halves of the policy: BACKGROUND must be ignored (refuted explicitly, since a regression to `level >= TRIM_MEMORY_BACKGROUND` would otherwise still pass on the COMPLETE leg alone), and COMPLETE must stop the service. Found by thepastaclaw. `45c83c8e7` then pinned that leg's assertion to level 80: `refute_log` does not advance `LOG_MARK`, so a level-40 teardown arriving just after the refute sampled would have satisfied the COMPLETE assertion meant to catch exactly that regression. Re-marking the log would also close it but would drop the cold-launch start out of the window and break the `>= 2` restart count. Found by CodeRabbit.

`21ce82628` — the boundary-latch retry in `82969ccc6` was on a path the upgrade launch never takes. `armUpgradeNoticeIfUpgraded` is reached only via a successful commit, but on a real upgrade the seam declines (the bind runs after it), so the retry never ran on the one launch that can observe the crossing — the defect was moved, not closed. `persistBoundaryCrossingIfPending()` now runs on the decline path and on every readiness evaluation. Same review also fixed the `log` diagnostic helper's stale filters and made the `CUTOVER_UPGRADE_BOUNDARY_CROSSED` KDoc refer to `FIRST_CUTOVER_VERSION_CODE` instead of a release name. Found by thepastaclaw (Phase 1 + Phase 2).

`215fd6691` — reattaches three KDoc blocks this branch had separated from the members they document: inserting a new member directly after an existing KDoc leaves that KDoc describing the newcomer. `armUpgradeNoticeIfUpgraded` lost its ~40-line KDoc to `persistBoundaryCrossingIfPending` one commit earlier; `L1SyncStatusService.details` and `L1ShadowSyncService.logCompletion` had the same shape; `commitLocked`'s description and `@param` were split into two adjacent blocks. Two orphaned KDocs that predate the branch are left alone, since reattaching them means guessing the original author's intent. Note this does NOT clear CodeRabbit's 80% docstring threshold — coverage on changed files moves 40.2% to 41.5%, and the remainder is pre-existing functions in files this PR barely touches.

`c77b5e86e` — **rotating a screen could lock the wallet**, a regression this PR introduced. `091c2bae3` re-enabled `onStoppedLast()`, dead code since before the class existed (the override never calls `super`, so `ActivitiesTracker.numStarted` never advanced). Waking it woke a hazard that could not bite while it was dead: Android stops the outgoing activity before starting its replacement on a configuration change, so `visibleActivityCount` touches zero during a rotation and ran the "app went away" path — `setAppWentBackground(true)`, which `AutoLogout.shouldLogout()` returns outright on a zero-minute timeout, plus a `FORCE_FINISH_ACTION` broadcast. Nine activities neither pin portrait nor handle orientation (`MainActivity`, `AddressBookActivity`, `NetworkMonitorActivity`, `BlockInfoActivity` among them), so rotating any of them dropped the user on the lock screen without leaving the wallet. Guarded on `isChangingConfigurations()`, covering `AppForegroundMonitor.noteBackground()` too. Three lifecycle tests, mutation-verified. Found by thepastaclaw.

## Not fixed here

- The HONOR cutover is still blocked by a legacy identity parked at `USERNAME_REGISTERING`, which makes `IDENTITY_OPERATION_IN_FLIGHT` permanent. Not a keystore problem — the keystore fix is verified working on that device.
- The cutover still commits on a launch *after* the upgrade, so the explainer can appear late (MO-1022 comment 91177).
- `ProbeWatchdogDecider` allows one parity-loop restart per **process** while the shadow restarts several times per process.
- The `stopSelf()`/`onStartCommand` race (survivable now, but `stopSelfResult(startId)` is the answer), and the ~4 h from-genesis scan when `birthHeight` clamps to 0.

## Testing

`:wallet` and `:common` unit suites green. Eight test files added on the branch — `PlatformSyncEngineRestartTest`, `TrimMemoryPolicyTest`, `ForegroundStartPromiseTest`, `PlatformHealthProbeContainmentTest`, `CoinsReceivedNotificationGateTest`, `CoinJoinMixingTxSetTest`, `AmountCurrencySpanTest`, plus `scripts/cutover-emulator-test.sh` — and six existing suites extended: `CutoverCoordinatorTest`, `SdkBindRetryServiceTest`, `L1SyncStatusServiceTest`, `L1ShadowSyncServiceTest`, `SdkDashPayWritesTest`, `InviteCreationFailureTest`.

```bash
./gradlew :wallet:test_testNet3DebugUnitTest :common:test
```

Every fix in this round is mutation-verified: the change is reverted and the suite must fail the specific pinning test. Two caveats worth stating plainly — the R8 keep rule has **no** unit test, because R8 does not run for the JVM test variant, so the release-build dex read is the only check; and `PlatformHealthProbeContainmentTest` forces `Constants.SUPPORTS_PLATFORM` true, without which `probe()` returns on its first line and every assertion passes vacuously.

Device-verified on the emulator against real Keystore denials (release build), and the HONOR keystore fix confirmed on hardware: 23 denials and no successful bind before, zero denials and a bind in ~1 s after. Still unproven there: the **decrypt** path on an existing lock-bound alias.








