### PR TITLE
fix(dash-dex): Max enters the sendable amount, not the gross balance

### DIFF
--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/MayaConvertCryptoFragment.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/MayaConvertCryptoFragment.kt
@@ -94,6 +94,12 @@ class MayaConvertCryptoFragment : Fragment() {
         }
     private var canContinue: Boolean = false
 
+    // The screen's busy state has two independent sources — a quote in flight and the Max
+    // sendable estimate — so each is tracked separately and combined by [updateProcessing];
+    // mirroring one straight into uiState let the other clear it.
+    private var quoteInFlight: Boolean = false
+    private var maxEstimateInFlight: Boolean = false
+
     // Hard gate on Get quote independent of the entered value — false when the wallet has no
     // DASH to convert, so the button stays disabled no matter what the user types. Derived
     // from the ViewModel so the gate survives a configuration change.
@@ -232,8 +238,8 @@ class MayaConvertCryptoFragment : Fragment() {
         // While the quote is being fetched, block all amount input so a late key press
         // can't alter the value carried to the preview.
         viewModel.showLoading.observe(viewLifecycleOwner) { loading ->
-            uiState = uiState.copy(isProcessing = loading == true)
-            updateContinueEnabled()
+            quoteInFlight = loading == true
+            updateProcessing()
         }
 
         viewModel.swapTradeOrder.observe(viewLifecycleOwner) { swapTrade ->
@@ -243,11 +249,11 @@ class MayaConvertCryptoFragment : Fragment() {
                 // navigating. Keep Get quote disabled for that whole stretch (it happens in the
                 // same frame as the showLoading=false observer, so the button never flashes
                 // enabled); re-enable only on the error paths that keep the user on this screen.
-                uiState = uiState.copy(isProcessing = true)
-                updateContinueEnabled()
+                quoteInFlight = true
+                updateProcessing()
                 fun failToRetry() {
-                    uiState = uiState.copy(isProcessing = false)
-                    updateContinueEnabled()
+                    quoteInFlight = false
+                    updateProcessing()
                 }
 
                 val dashInbound = try {
@@ -394,10 +400,15 @@ class MayaConvertCryptoFragment : Fragment() {
             )
             applyNewValue(convertViewModel.enteredConvertAmount, pickedCurrencyType, isLocalized = true)
             // The value re-applied above comes from the formatted display string, which for fiat
-            // is rounded to the currency's 2 decimals — so a restored Max needs the exact balance
-            // pinned back on, taken from the balance as it stands now.
+            // is rounded to the currency's 2 decimals — so a restored Max needs the exact figure
+            // pinned back on. selectMaxAmount re-derives it from the balance as it stands now, so
+            // a balance that moved while this screen was away is picked up rather than restored.
             if (maxAmountSelected) {
-                convertViewModel.selectMaxAmount(pickedCurrencyType)
+                val type = pickedCurrencyType
+                lifecycleScope.launch {
+                    convertViewModel.selectMaxAmount(type)
+                    showPinnedMaxAmount(type)
+                }
             }
         }
     }
@@ -421,17 +432,45 @@ class MayaConvertCryptoFragment : Fragment() {
 
     private fun onMaxClick() {
         if (uiState.isProcessing) return
-        convertViewModel.selectedCryptoCurrencyAccount.value?.let { _ ->
-            convertViewModel.getMaxAmount()?.let { maxAmount ->
-                // Enter the balance in whichever currency the picker is on.
-                val type = pickedCurrencyType
-                applyNewValue(maxAmount.getValue(type).toString(), type, isLocalized = false)
-                // Flag it as a Max and re-pin the exact balance: the line above re-anchors the
-                // amount on the displayed currency, so for fiat/crypto the DASH value it derives
-                // back is a satoshi or two short of the balance.
-                convertViewModel.selectMaxAmount(type)
+        if (convertViewModel.selectedCryptoCurrencyAccount.value == null) return
+
+        // Enter what the wallet can actually send, not its balance — a max sell is a sweep and
+        // the miner fee comes out of the sweep's own output. Working that out means building a
+        // candidate sweep, so it can't be done on the main thread; the screen shows its busy
+        // state for the (usually pre-warmed, so instant) wait rather than ignoring the tap.
+        val type = pickedCurrencyType
+        maxEstimateInFlight = true
+        updateProcessing()
+        lifecycleScope.launch {
+            val maxAmount = try {
+                convertViewModel.getMaxAmount()
+            } finally {
+                maxEstimateInFlight = false
+                updateProcessing()
             }
+
+            if (maxAmount == null) {
+                // Nothing left once the fee is taken out — say so rather than entering zero.
+                showSwapValueErrorView(SwapValueErrorType.NotEnoughBalance)
+                return@launch
+            }
+
+            applyNewValue(maxAmount.getValue(type).toString(), type, isLocalized = false)
+            // Flag it as a Max and re-pin the exact figure: the line above re-anchors the amount
+            // on the displayed currency, so for fiat/crypto the DASH value it derives back is a
+            // satoshi or two short of what was entered.
+            convertViewModel.selectMaxAmount(type)
         }
+    }
+
+    /**
+     * Mirrors a Max figure pinned by the ViewModel back into the display, which otherwise still
+     * shows the value that was entered before the pin (for fiat, rounded to the currency's digits).
+     */
+    private fun showPinnedMaxAmount(type: CurrencyInputType) {
+        setAmountValue(type)
+        canContinue = convertViewModel.enteredConvertDashAmount.value?.isZero == false
+        updateContinueEnabled()
     }
 
     // ── Keypad input (ported from the old NumericKeyboardView listener) ───────────
@@ -574,6 +613,12 @@ class MayaConvertCryptoFragment : Fragment() {
         )
     }
 
+    /** Recomputes the busy state from its two sources; see [quoteInFlight]/[maxEstimateInFlight]. */
+    private fun updateProcessing() {
+        uiState = uiState.copy(isProcessing = quoteInFlight || maxEstimateInFlight)
+        updateContinueEnabled()
+    }
+
     // ── Derived display blocks ────────────────────────────────────────────────────
 
     /** Dash wallet balance row of the direction card: "Balance: 0.05 (Dash logo)" + fiat equivalent. */
@@ -624,8 +669,10 @@ class MayaConvertCryptoFragment : Fragment() {
             return
         }
 
-        val swapValueErrorType = convertViewModel.checkEnteredAmountValue(checkSendingConditions)
         lifecycleScope.launch {
+            // Suspends: the entry bound is the max sendable figure, which may still need its
+            // sweep estimate. Normally pre-warmed and cached, so this doesn't stall the tap.
+            val swapValueErrorType = convertViewModel.checkEnteredAmountValue(checkSendingConditions)
             if (swapValueErrorType == SwapValueErrorType.NOError) {
                 if (!request.dashToCrypto && convertViewModel.dashToCrypto.value == true) {
                     if (viewModel.getLastBalance() < (request.dashAmount ?: Coin.ZERO)) {
@@ -674,12 +721,14 @@ class MayaConvertCryptoFragment : Fragment() {
 
     private fun maxAmountErrorMessage(): String? {
         if (convertViewModel.dashToCrypto.value == true) {
-            viewModel.dashWalletBalance.value?.let { dash ->
-                convertViewModel.selectedLocalExchangeRate.value?.let { rate ->
-                    val currencyRate = ExchangeRate(Coin.COIN, rate.fiat)
-                    val fiatAmount = currencyRate.coinToFiat(dash).toFormattedString()
-                    return "${getString(R.string.maya_max_amount_error)} $fiatAmount"
-                }
+            // The limit that was just enforced is what the wallet can send, not its balance —
+            // quoting the balance here would name a figure the check itself rejects.
+            convertViewModel.selectedLocalExchangeRate.value?.let { rate ->
+                val currencyRate = ExchangeRate(Coin.COIN, rate.fiat)
+                val fiatAmount = currencyRate
+                    .coinToFiat(convertViewModel.lastMaxSendableAmount)
+                    .toFormattedString()
+                return "${getString(R.string.maya_max_amount_error)} $fiatAmount"
             }
         } else {
             convertViewModel.selectedLocalExchangeRate.value?.let { rate ->

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/convert_currency/ConvertViewViewModel.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/ui/convert_currency/ConvertViewViewModel.kt
@@ -19,15 +19,18 @@ package org.dash.wallet.integrations.maya.ui.convert_currency
 
 import androidx.lifecycle.*
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import org.bitcoinj.core.Coin
 import org.bitcoinj.utils.Fiat
-import org.bitcoinj.utils.MonetaryFormat
 import org.bitcoinj.wallet.Wallet
 import org.dash.wallet.common.WalletDataProvider
 import org.dash.wallet.common.data.SingleLiveEvent
@@ -35,6 +38,7 @@ import org.dash.wallet.common.data.WalletUIConfig
 import org.dash.wallet.common.data.entity.ExchangeRate
 import org.dash.wallet.common.services.ExchangeRatesProvider
 import org.dash.wallet.common.services.LeftoverBalanceException
+import org.dash.wallet.common.services.SendPaymentService
 import org.dash.wallet.common.services.analytics.AnalyticsConstants
 import org.dash.wallet.common.services.analytics.AnalyticsService
 import org.dash.wallet.common.util.Constants
@@ -48,6 +52,7 @@ import org.dash.wallet.integrations.maya.model.CurrencyInputType
 import org.dash.wallet.integrations.maya.ui.convert_currency.model.MayaTransactionParams
 import org.dash.wallet.integrations.maya.ui.convert_currency.model.SwapRequest
 import org.dash.wallet.integrations.maya.ui.convert_currency.model.SwapValueErrorType
+import org.dash.wallet.integrations.maya.utils.MaxSendable
 import org.dash.wallet.integrations.maya.utils.MayaConstants
 import org.slf4j.LoggerFactory
 import java.math.BigDecimal
@@ -64,6 +69,8 @@ class ConvertViewViewModel @Inject constructor(
     private val walletDataProvider: WalletDataProvider,
     private val analyticsService: AnalyticsService,
     private val swapProvider: SwapProvider,
+    // Sole source of the "max sendable" figure — see [maxSendableAmount].
+    private val sendPaymentService: SendPaymentService,
     private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
     companion object {
@@ -119,8 +126,6 @@ class ConvertViewViewModel @Inject constructor(
     var destinationAddress: String? = null
     lateinit var account: AccountDataUIModel
     val amount = Amount()
-    private val dashFormat = MonetaryFormat().withLocale(GenericUtils.getDeviceLocale())
-        .noCode().minDecimals(6).optionalDecimals()
     val cryptoFormat: DecimalFormat = DecimalFormat(
         "0.########",
         DecimalFormatSymbols(GenericUtils.getDeviceLocale())
@@ -145,8 +150,22 @@ class ConvertViewViewModel @Inject constructor(
 
     var minAllowedSwapAmount: String = MayaConstants.MIN_USD_AMOUNT
 
-    var maxForDashWalletAmount: String = "0"
     val onContinueEvent = SingleLiveEvent<SwapRequest>()
+
+    /**
+     * Last successfully computed [maxSendableAmount], readable without suspending so the screen
+     * can name the real limit in its "more than max" message. [Coin.ZERO] until the first
+     * estimate lands.
+     */
+    @Volatile
+    var lastMaxSendableAmount: Coin = Coin.ZERO
+        private set
+
+    // Sweep estimate paired with the balance it was computed from; invalidated by any other
+    // balance turning up. Guarded by [maxSendableMutex], which also keeps two callers from
+    // paying for the same estimate concurrently.
+    private var maxSendableCache: Pair<Coin, Coin>? = null
+    private val maxSendableMutex = Mutex()
 
     private var minAllowedSwapDashCoin: Coin = Coin.ZERO
     private var maxForDashCoinBaseAccount: Coin = Coin.ZERO
@@ -199,7 +218,6 @@ class ConvertViewViewModel @Inject constructor(
     val validSwapValue = SingleLiveEvent<String>()
 
     init {
-        updateDashWalletBalance()
         // do we need this?
         walletUIConfig.observe(WalletUIConfig.SELECTED_CURRENCY)
             .filterNotNull()
@@ -320,15 +338,16 @@ class ConvertViewViewModel @Inject constructor(
         validSwapValue.call()
     }
 
-    fun checkEnteredAmountValue(checkSendingConditions: Boolean): SwapValueErrorType {
-        val coin = try {
-            if (dashToCrypto.value == true) {
-                Coin.parseCoin(maxForDashWalletAmount.replace(',', '.'))
-            } else {
-                maxForDashCoinBaseAccount
-            }
-        } catch (x: Exception) {
-            Coin.ZERO
+    /**
+     * Bounds the entry by what can actually be sent, not by the gross balance: an amount above
+     * [maxSendableAmount] can't be delivered, and bounding by the balance let the user carry it
+     * all the way to the preview before finding out.
+     */
+    suspend fun checkEnteredAmountValue(checkSendingConditions: Boolean): SwapValueErrorType {
+        val coin = if (dashToCrypto.value == true) {
+            maxSendableAmount()
+        } else {
+            maxForDashCoinBaseAccount
         }
 
         _enteredConvertDashAmount.value?.let {
@@ -361,6 +380,13 @@ class ConvertViewViewModel @Inject constructor(
             maxAmountSelected = false
         }
         _dashToCrypto.value = dashToCrypto
+
+        if (dashToCrypto) {
+            // A non-zero balance isn't the same as having something to sell — the fee may eat all
+            // of it. Warm the estimate now so Max is instant, and let it close the gate if what
+            // is left after the sweep fee is nothing.
+            refreshMaxSendable()
+        }
     }
 
     fun clear() {
@@ -377,18 +403,19 @@ class ConvertViewViewModel @Inject constructor(
             analyticsService.logEvent(AnalyticsConstants.Coinbase.CONVERT_CONTINUE, mapOf())
             // What the user typed in is exactly what [amount] is anchored on.
             logEnteredAmountCurrency(amount.anchoredType)
+            // A sweep is what the Max button asked for, so take it from that intent
+            // ([maxAmountSelected]) rather than inferring it: a fiat- or crypto-anchored Max
+            // doesn't survive the round trip back to DASH as an exact match. The comparison
+            // stays as a fallback for a max the user typed in by hand — measured against the
+            // sendable figure, since that is what Max itself now enters, and evaluated only
+            // when the flag is unset so the estimate is skipped on the common path.
+            val isMaxSwap = maxAmountSelected ||
+                MaxSendable.isTypedMax(amount.dash.toCoin(), maxSendableAmount())
             onContinueEvent.value = selectedCryptoCurrencyAccount.value?.coinbaseAccount?.let {
                 destinationAddress?.let { address ->
                     SwapRequest(
                         amount,
-                        // A sweep is what the Max button asked for, so take it from that intent
-                        // ([maxAmountSelected]) rather than inferring it: a fiat- or
-                        // crypto-anchored Max doesn't survive the round trip back to DASH as an
-                        // exact match. The comparison stays as a fallback for a full balance the
-                        // user typed in by hand.
-                        maxAmountSelected ||
-                            amount.dash.toCoin() ==
-                            walletDataProvider.wallet!!.getBalance(Wallet.BalanceType.ESTIMATED),
+                        isMaxSwap,
                         address,
                         it.currency,
                         it.asset,
@@ -451,32 +478,114 @@ class ConvertViewViewModel @Inject constructor(
         return convertedValue
     }
 
-    private fun updateDashWalletBalance(balance: Coin = walletDataProvider.getWalletBalance()) {
-        maxForDashWalletAmount = dashFormat.minDecimals(0)
-            .optionalDecimals(0, 8).format(balance).toString()
-    }
+    /**
+     * The largest DASH amount this wallet can actually deliver in a max sell, and the single
+     * figure every Max path is driven from — the button's entered value, the entry bound in
+     * [checkEnteredAmountValue] and the hand-typed-max fallback in [continueSwap].
+     *
+     * A max sell is a sweep and the miner fee comes out of the sweep's single output, so the
+     * deliverable amount is `balance − fee`, not the balance. This is deliberately the same call
+     * `SwapKitApiAggregator.getSwapInfo` makes to quote a maximum, so entry, quote and deposit all
+     * agree on one number; reading the gross `Wallet.BalanceType.ESTIMATED` here instead is what
+     * made Max show an amount the swap would never use (MO-997).
+     *
+     * Estimation is not cheap — it builds and signs a candidate sweep, which derives the wallet
+     * key — so the result is cached against the balance it was computed from and recomputed only
+     * once that balance moves. Serialized so a pre-warm and a Max tap can't both pay for it.
+     */
+    suspend fun maxSendableAmount(): Coin = estimateMaxSendable() ?: Coin.ZERO
 
-    fun getMaxAmount(): Amount? {
-        return walletDataProvider.wallet?.let {
-            val balance = it.getBalance(Wallet.BalanceType.ESTIMATED)
-            amount.copy().apply { dash = balance.toBigDecimal() }
+    /**
+     * [maxSendableAmount], but distinguishing "this wallet can send nothing" ([Coin.ZERO]) from
+     * "the estimate failed" (null), which callers must not act on: a transient failure would
+     * otherwise read as an empty wallet and wipe a pinned Max.
+     */
+    private suspend fun estimateMaxSendable(): Coin? = withContext(Dispatchers.IO) {
+        // Off the main thread deliberately: unlike its neighbours in SendCoinsTaskRunner,
+        // estimateNetworkFee runs on the caller's dispatcher, and it derives the wallet key and
+        // completes a candidate transaction — every entry point here is a Main-dispatched
+        // viewModelScope/lifecycleScope coroutine, which would make that an ANR.
+        maxSendableMutex.withLock {
+            val wallet = walletDataProvider.wallet ?: return@withLock null
+            val balance = wallet.getBalance(Wallet.BalanceType.ESTIMATED)
+            maxSendableCache?.let { (cachedForBalance, cachedSendable) ->
+                if (cachedForBalance == balance) {
+                    return@withLock cachedSendable
+                }
+            }
+
+            val sendable = try {
+                MaxSendable.coerceSendable(
+                    sendPaymentService.estimateNetworkFee(
+                        walletDataProvider.currentReceiveAddress(),
+                        balance,
+                        emptyWallet = true
+                    ).amountToSend
+                )
+            } catch (e: Exception) {
+                // Insufficient funds for the fee lands here too, but so does a genuine failure,
+                // and the two aren't worth telling apart: leave the cache alone so the next Max
+                // tap retries rather than pinning a wrong figure until the balance happens to
+                // move.
+                log.warn("max sell: sweep estimate failed for balance {}", balance.toFriendlyString(), e)
+                return@withLock null
+            }
+
+            log.info(
+                "max sell: sendable {} of balance {}",
+                sendable.toFriendlyString(),
+                balance.toFriendlyString()
+            )
+            maxSendableCache = balance to sendable
+            lastMaxSendableAmount = sendable
+            sendable
         }
     }
 
     /**
-     * Records that the entered amount is the whole wallet ([maxAmountSelected]) and re-pins
-     * [amount]'s DASH component to the exact balance.
+     * Computes [maxSendableAmount] ahead of the user reaching for Max, so the button doesn't have
+     * to wait on the estimate, and closes the Get-quote gate on a wallet whose whole balance is
+     * eaten by the fee — for this flow that is as empty as a zero balance.
+     */
+    private fun refreshMaxSendable() {
+        viewModelScope.launch {
+            val sendable = estimateMaxSendable() ?: return@launch
+            if (_dashToCrypto.value == true && !sendable.isPositive && !userDashAccountEmpty) {
+                userDashAccountEmpty = true
+                userDashAccountEmptyError.call()
+            }
+        }
+    }
+
+    /** The Max entry in every currency, or null when there is nothing this wallet can send. */
+    suspend fun getMaxAmount(): Amount? {
+        val sendable = maxSendableAmount()
+        if (!sendable.isPositive) {
+            return null
+        }
+        return amount.copy().apply { dash = sendable.toBigDecimal() }
+    }
+
+    /**
+     * Records that the entered amount is a max ([maxAmountSelected]) and re-pins [amount]'s DASH
+     * component to the exact [maxSendableAmount].
      *
      * Call it right after the Max value has been entered in [displayType]: entering it re-anchors
      * [amount] on the picker's currency, and for fiat or crypto the DASH value is then a rounded
-     * back-conversion rather than the balance (see [maxAmountSelected]) — which the Maya quote and
-     * the amount checks both read. Assigning [Amount.dash] recomputes fiat and crypto from the
-     * exact balance; the anchor is restored to [displayType] afterwards (that setter doesn't
+     * back-conversion rather than the sendable amount (see [maxAmountSelected]) — which the quote
+     * and the amount checks both read. Assigning [Amount.dash] recomputes fiat and crypto from the
+     * exact figure; the anchor is restored to [displayType] afterwards (that setter doesn't
      * recompute) so the picker's currency still drives what's displayed and logged.
      */
-    fun selectMaxAmount(displayType: CurrencyInputType) {
-        val balance = walletDataProvider.wallet?.getBalance(Wallet.BalanceType.ESTIMATED) ?: return
-        amount.dash = balance.toBigDecimal()
+    suspend fun selectMaxAmount(displayType: CurrencyInputType) {
+        // A failed estimate leaves the entry exactly as it was; only a real zero — the fee has
+        // caught up with the balance — retracts the Max, since there is no longer a max to pin.
+        val sendable = estimateMaxSendable() ?: return
+        if (!sendable.isPositive) {
+            maxAmountSelected = false
+            return
+        }
+        amount.dash = sendable.toBigDecimal()
         amount.anchoredType = displayType
         savedStateHandle[KEY_AMOUNT] = amount.copy()
         maxAmountSelected = true

--- a/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/utils/MaxSendable.kt
+++ b/integrations/maya/src/main/java/org/dash/wallet/integrations/maya/utils/MaxSendable.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.dash.wallet.integrations.maya.utils
+
+import org.bitcoinj.core.Coin
+
+/**
+ * The arithmetic behind the sell flow's Max button.
+ *
+ * A max sell is carried out as a sweep ("empty wallet"), and the miner fee comes out of the
+ * sweep's single output — so what the swap actually delivers is `balance − fee`, never the whole
+ * balance. Entering the gross balance is what made Max "show unreal value, that exceed the real
+ * balance" (MO-997): the quote and the deposit were both computed from the sweep output while the
+ * enter-amount screen displayed a figure the swap could never use.
+ *
+ * Kept free of Android and wallet types so the rules can be exercised on the host JVM.
+ */
+object MaxSendable {
+    /**
+     * What a sweep of [balance] delivers once [fee] is taken out of its single output, floored at
+     * zero: a wallet whose fee is at or above its balance can send nothing, and a negative amount
+     * would otherwise flow into the entered value. Mirrors the coercion
+     * `de.schildbach.wallet.payments.MaxOutputAmountCoinSelector` applies on the send screen.
+     */
+    fun sendableFromBalance(balance: Coin, fee: Coin): Coin =
+        balance.subtract(fee).coerceAtLeast(Coin.ZERO)
+
+    /**
+     * Floors an estimator's already-netted sweep output at zero.
+     * `SendPaymentService.estimateNetworkFee(…, emptyWallet = true).amountToSend` is
+     * `balance − fee` and can come back non-positive for a dust-level wallet.
+     */
+    fun coerceSendable(sweepOutput: Coin): Coin = sweepOutput.coerceAtLeast(Coin.ZERO)
+
+    /**
+     * Whether an amount the user typed by hand should still be treated as a max (sweep) rather
+     * than a partial swap. This is the fallback for someone who types the full sendable figure
+     * instead of pressing Max — the button's own intent is tracked explicitly, because a
+     * fiat-anchored Max doesn't survive the round trip back to DASH as an exact match.
+     *
+     * Compares with `>=` rather than `==`: anything strictly above [maxSendable] is rejected by
+     * the entry bound before it can be swapped, so the only entries that reach a swap through
+     * this path are exactly the sendable amount. A wallet that can send nothing is never a max.
+     */
+    fun isTypedMax(enteredDash: Coin, maxSendable: Coin): Boolean =
+        maxSendable.isPositive && enteredDash >= maxSendable
+
+    /** The combined rule: the Max button was used, or the typed amount amounts to the same thing. */
+    fun isMaxSwap(maxButtonUsed: Boolean, enteredDash: Coin, maxSendable: Coin): Boolean =
+        maxButtonUsed || isTypedMax(enteredDash, maxSendable)
+}

--- a/integrations/maya/src/test/java/org/dash/wallet/integrations/maya/utils/MaxSendableTest.kt
+++ b/integrations/maya/src/test/java/org/dash/wallet/integrations/maya/utils/MaxSendableTest.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.dash.wallet.integrations.maya.utils
+
+import org.bitcoinj.core.Coin
+import org.dash.wallet.common.util.toBigDecimal
+import org.dash.wallet.common.util.toCoin
+import org.dash.wallet.integrations.maya.model.Amount
+import org.dash.wallet.integrations.maya.model.CurrencyInputType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+/**
+ * The Max button's arithmetic (MO-997): a max sell is a sweep, so what it can enter is
+ * `balance − fee`, never the balance.
+ */
+class MaxSendableTest {
+
+    private val oneDash: Coin = Coin.COIN
+    private val sweepFee: Coin = Coin.valueOf(1930) // ~193 byte 1-in/1-out sweep
+
+    // ── sendable = balance − fee ────────────────────────────────────────────────
+
+    @Test
+    fun feeBelowBalance_sendableIsBalanceMinusFee() {
+        val sendable = MaxSendable.sendableFromBalance(oneDash, sweepFee)
+
+        assertEquals(Coin.valueOf(99998070), sendable)
+        assertTrue(sendable.isLessThan(oneDash))
+    }
+
+    @Test
+    fun feeEqualToBalance_sendableIsZero() {
+        assertEquals(Coin.ZERO, MaxSendable.sendableFromBalance(sweepFee, sweepFee))
+    }
+
+    @Test
+    fun feeAboveBalance_isCoercedAtZeroRatherThanGoingNegative() {
+        val sendable = MaxSendable.sendableFromBalance(Coin.valueOf(500), sweepFee)
+
+        assertEquals(Coin.ZERO, sendable)
+        assertFalse(sendable.isNegative)
+    }
+
+    @Test
+    fun emptyWallet_sendsNothing() {
+        assertEquals(Coin.ZERO, MaxSendable.sendableFromBalance(Coin.ZERO, sweepFee))
+    }
+
+    @Test
+    fun negativeSweepOutputFromTheEstimator_isCoercedAtZero() {
+        assertEquals(Coin.ZERO, MaxSendable.coerceSendable(Coin.valueOf(-1430)))
+    }
+
+    @Test
+    fun positiveSweepOutputFromTheEstimator_isPassedThrough() {
+        assertEquals(Coin.valueOf(99998070), MaxSendable.coerceSendable(Coin.valueOf(99998070)))
+    }
+
+    // ── Max entered in fiat, read back as DASH ──────────────────────────────────
+
+    /**
+     * Entering the Max in fiat and converting back loses satoshis twice (the fiat value is
+     * rounded to the currency's digits, then truncated back to a Coin), which is why the DASH
+     * component is re-pinned afterwards. Without the pin the swap is quietly downgraded to a
+     * partial one — and a half-satoshi short of a sweep is a deposit NEAR Intents refunds.
+     */
+    @Test
+    fun maxEnteredInFiat_roundTripFallsShortOfSendable() {
+        val sendable = MaxSendable.sendableFromBalance(Coin.valueOf(50_000_000), sweepFee)
+        val amount = amountAtRate("125.37").apply { dash = sendable.toBigDecimal() }
+
+        // What the picker shows in fiat, rounded to the currency's 2 digits, and then re-entered
+        // the way setEnteredAmount does it — GenericUtils.toScaledBigDecimal at 8 decimals, which
+        // is also the scale the fiat-to-DASH division inherits.
+        val displayedFiat = amount.fiat.setScale(2, RoundingMode.HALF_UP)
+        val reEntered = amountAtRate("125.37").apply {
+            fiat = displayedFiat.setScale(8, RoundingMode.HALF_UP)
+        }
+
+        assertTrue(reEntered.dash.toCoin().isLessThan(sendable))
+        assertFalse(MaxSendable.isTypedMax(reEntered.dash.toCoin(), sendable))
+    }
+
+    @Test
+    fun maxPinnedAfterFiatEntry_readsBackAsExactlySendable() {
+        val sendable = MaxSendable.sendableFromBalance(oneDash, sweepFee)
+        val amount = amountAtRate("125.37")
+
+        // What selectMaxAmount does: pin the exact DASH figure, then restore the picker's anchor.
+        amount.dash = sendable.toBigDecimal()
+        amount.anchoredType = CurrencyInputType.Fiat
+
+        assertEquals(CurrencyInputType.Fiat, amount.anchoredType)
+        assertEquals(sendable, amount.dash.toCoin())
+        assertTrue(MaxSendable.isTypedMax(amount.dash.toCoin(), sendable))
+    }
+
+    // ── Hand-typed max still counts as a max ────────────────────────────────────
+
+    @Test
+    fun typedSendableAmount_isTreatedAsMax() {
+        val sendable = MaxSendable.sendableFromBalance(oneDash, sweepFee)
+
+        assertTrue(MaxSendable.isTypedMax(sendable, sendable))
+        assertTrue(MaxSendable.isMaxSwap(false, sendable, sendable))
+    }
+
+    @Test
+    fun typedAmountBelowSendable_isNotAMax() {
+        val sendable = MaxSendable.sendableFromBalance(oneDash, sweepFee)
+
+        assertFalse(MaxSendable.isTypedMax(sendable.subtract(Coin.SATOSHI), sendable))
+        assertFalse(MaxSendable.isMaxSwap(false, sendable.subtract(Coin.SATOSHI), sendable))
+    }
+
+    /**
+     * The gross balance is above the sendable figure, so it is rejected by the entry bound
+     * before it can be swapped — but if it ever does get through it is still a sweep, not a
+     * partial swap for more than the wallet can deliver.
+     */
+    @Test
+    fun typedGrossBalance_isTreatedAsMax() {
+        val sendable = MaxSendable.sendableFromBalance(oneDash, sweepFee)
+
+        assertTrue(MaxSendable.isTypedMax(oneDash, sendable))
+    }
+
+    @Test
+    fun maxButtonIntent_survivesAnAmountThatNoLongerMatches() {
+        val sendable = MaxSendable.sendableFromBalance(oneDash, sweepFee)
+        val roundedDown = sendable.subtract(Coin.valueOf(2))
+
+        assertFalse(MaxSendable.isTypedMax(roundedDown, sendable))
+        assertTrue(MaxSendable.isMaxSwap(true, roundedDown, sendable))
+    }
+
+    @Test
+    fun walletThatCanSendNothing_isNeverAMax() {
+        assertFalse(MaxSendable.isTypedMax(Coin.ZERO, Coin.ZERO))
+        assertFalse(MaxSendable.isTypedMax(oneDash, Coin.ZERO))
+        assertFalse(MaxSendable.isMaxSwap(false, Coin.ZERO, Coin.ZERO))
+    }
+
+    private fun amountAtRate(dashFiatRate: String) = Amount().apply {
+        dashFiatExchangeRate = BigDecimal(dashFiatRate)
+        cryptoFiatExchangeRate = BigDecimal("65000")
+    }
+}


### PR DESCRIPTION
Fixes [MO-1036](https://dashpay.atlassian.net/browse/MO-1036). Reported by QA on MO-997 (comment 91128): *"sometimes max show unreal value, that exceed the real balance"*.

## Problem

On the Dash DEX **sell** enter-amount screen, **Max** enters the wallet's **gross balance**. A max sell is carried out as a sweep and the miner fee comes out of the sweep's single output, so what the swap can actually deliver is `balance − fee`. Max entered a figure the swap would never use, and the quote and preview then showed a different, lower number than the one the user just entered.

The buy flow isn't involved — `DEXEnterAmountScreen` passes `showMaxButton = false`.

## Root cause

Three Max paths in `ConvertViewViewModel` each read `wallet.getBalance(ESTIMATED)` independently — `getMaxAmount()`, `selectMaxAmount()`, and the hand-typed-max fallback in `continueSwap()` — and `checkEnteredAmountValue()` bounded entry by the same gross figure, so an unsendable typed amount was only discovered at the preview.

The wallet's own send screen never makes this mistake: it caps against `observeBalance(ESTIMATED, MaxOutputAmountCoinSelector())` (`SendCoinsViewModel.kt:160`). Dash DEX bypassed that entirely.

**The backends already had it right.** `SwapKitApiAggregator.getSwapInfo` ignores the passed amount for a `maximum` request and re-derives the post-fee sweep output — it has to, since NEAR Intents refuses any deposit below the quoted amount (#1519 / MO-984). Only the UI disagreed.

## Fix

One max-sendable figure in `ConvertViewViewModel`, driving every Max path:

- `maxSendableAmount()` computes it from `estimateNetworkFee(currentReceiveAddress(), balance, emptyWallet = true).amountToSend` — deliberately the same call `getSwapInfo` makes, so entry, quote and deposit finally agree on one number. Cached against the balance it was computed from and mutex-serialized, since the estimate builds and signs a candidate sweep (which derives the wallet key).
- `getMaxAmount()` / `selectMaxAmount()` take that figure instead of reading the balance themselves; a failed estimate stays distinct from a genuine zero so a transient failure can't wipe a pinned Max.
- `checkEnteredAmountValue()` bounds entry by it.
- `continueSwap()`'s typed-max fallback compares against it, so a max typed by hand still sets `SwapRequest.maximum`.
- The sell direction pre-warms the estimate (so Max is instant) and treats a wallet whose balance the fee eats as empty for this flow.

On screen: Max is async against the existing busy state rather than a dead tap, a restored Max re-pins a freshly recomputed value, and the "more than max" message names the sendable limit instead of the balance the check just rejected.

**Sweep semantics are unchanged** — the send still empties the wallet; only the entered and displayed amount changes.

## Worth a look in review

- **`estimateNetworkFee` runs on the caller's dispatcher.** Unlike its neighbours in `SendCoinsTaskRunner`, it has no `withContext` of its own (`SendCoinsTaskRunner.kt:151`) and it derives the wallet key via scrypt. Every call site here is a Main-dispatched coroutine, so the estimate is wrapped in `Dispatchers.IO`. Other callers may have the same exposure — out of scope here, but worth someone's time.
- **The preview needed no change.** `MayaConversionPreviewFragment` reads `SwapTradeUIModel.amount`, not the entered amount. On the SwapKit/NEAR route that was already the sweep output; the inflated Total came only from the Maya-native route, where `MayaWebApi.getSwapInfo` passes `swapRequest.amount` straight through. Correcting entry corrects that Total too.
- **CoinJoin needs no special-casing** — with CoinJoin on, `createSendRequest` selects with `CoinJoinCoinSelector` (mixed-only), so the estimate already follows the same rules the real send will.
- **`MaxOutputAmountCoinSelector` would not have matched the quote** — it prices at `Transaction.DEFAULT_TX_FEE` (10000 duff/kB) vs `Constants.ECONOMIC_FEE` (1000), 10× apart. That's why this uses the `SendPaymentService` route.
- **The exact intermittency isn't reproduced.** Both the "Balance:" row and Max read ESTIMATED, so Max equalled the displayed balance rather than visibly exceeding it. The gap is always present but small (~0.00002 DASH for a one-input sweep), growing with UTXO count — the leading explanation for "sometimes", but unconfirmed.

## Testing

- `:integrations:maya:compileDebugKotlin`, `:wallet:compile_testNet3DebugKotlin`, `:wallet:compile_testNet3DebugJavaWithJavac` (forces Dagger component generation, confirming the new `SendPaymentService` injection resolves) — all pass.
- `:integrations:maya:testDebugUnitTest` — 94 tests, 0 failures. New `MaxSendableTest` adds 13: fee below / equal to / above balance, empty wallet, negative estimator output, a Max entered in fiat and read back as DASH, the pin restoring the exact figure, and a hand-typed max still flagged as a maximum.
- `:integrations:maya:ktlintCheck` — clean.

**Not yet done, needs a device and testnet funds:** tap Max with a fully confirmed balance, and again with an unconfirmed incoming tx pending — in both cases the entered amount must not exceed what the wallet can send. Then complete one NEAR-route sell with Max and confirm it isn't refunded (MO-984 regression check).

To be merged into the kotlin-sdk branches later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Max conversion amounts now account for network fees, helping prevent attempts to send more than the wallet can deliver.
  * Maximum amounts are estimated asynchronously and remain accurate after balance or quote recalculations.
  * Improved handling for insufficient balances and cases where fees consume the entire available balance.
  * Maximum-amount errors now display the wallet’s sendable amount rather than its total balance.

* **Tests**
  * Added coverage for fee calculations, zero or negative sendable amounts, currency precision, and maximum-amount selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->