### PR TITLE
fix(coinbase): correct amount entry, auth persistence and API amount format

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/ui/components/ActionItem.kt
+++ b/common/src/main/java/org/dash/wallet/common/ui/components/ActionItem.kt
@@ -92,6 +92,11 @@ fun ActionItem(
     /** One-line secondary text under [title] (`Action item / Var 3`); null renders `Var 1`. */
     subtitle: String? = null,
     /**
+     * Lines [subtitle] may wrap to before it ellipsizes. Defaults to the one-line contract
+     * above; ignored when [subtitleMiddleEllipsis] is set, which is single-line by nature.
+     */
+    subtitleMaxLines: Int = 1,
+    /**
      * Truncates [subtitle] from the middle to fit the available width (e.g. for addresses,
      * where both the start and end need to stay checkable) instead of the standard end-ellipsis.
      * Width-measured so it stays correct at any font scale, unlike a fixed character count.
@@ -167,7 +172,7 @@ fun ActionItem(
                         text = it,
                         style = MyTheme.Typography.Footnote,
                         color = colors.textSecondary,
-                        maxLines = 1,
+                        maxLines = subtitleMaxLines,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier.fillMaxWidth()
                     )

--- a/common/src/main/java/org/dash/wallet/common/ui/components/MenuItem.kt
+++ b/common/src/main/java/org/dash/wallet/common/ui/components/MenuItem.kt
@@ -40,7 +40,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
-import android.content.res.Configuration
 import androidx.compose.ui.text.TextMeasurer
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.rememberTextMeasurer

--- a/common/src/main/java/org/dash/wallet/common/util/GenericUtils.kt
+++ b/common/src/main/java/org/dash/wallet/common/util/GenericUtils.kt
@@ -72,28 +72,55 @@ object GenericUtils {
         return Locale.US
     }
 
+    /** Characters any supported locale may use as a decimal or grouping mark. */
+    private const val SEPARATORS = ".,٫"
+
     /**
-     * To perform some operations on our fiat values (ex: parse to double, convert fiat to Coin), it needs to be properly formatted
-     * In case our fiat value is in a currency that has a comma, we need to strip it away so as to have our value as a decimal
-     * @param fiatValue
-     * @return
+     * Normalises a human-formatted amount into one BigDecimal, Coin.parseCoin and
+     * Fiat.parseFiat will accept: a single '.' decimal mark and no grouping marks.
+     *
+     * Which mark is the decimal one is decided, never guessed. The decimal mark can occur
+     * at most once in a number, so the LAST separator is the decimal mark precisely when
+     * that character appears exactly once; every other separator is grouping and is
+     * dropped. When a character repeats it cannot be a decimal mark, so all its
+     * occurrences are grouping.
+     *
+     * This used to test only "contains a dot AND a comma" and then strip the commas, which
+     * silently mangled every European-formatted amount: "1.234,56" became "1.23456", a
+     * thousandfold error in a value on its way to being parsed and sent. A single
+     * separator is genuinely ambiguous ("1,234" is 1.234 in one locale and 1234 in
+     * another), so that case is left reading as a decimal mark, exactly as before.
      */
     fun formatFiatWithoutComma(fiatValue: String): String {
-        val fiatValueContainsCommaWithDecimal = fiatValue.contains(".") && fiatValue.contains(",")
+        val cleaned = normalizeSeparators(fiatValue)
 
-        val cleaned = if (fiatValueContainsCommaWithDecimal) {
-            fiatValue.replace(",", "")
-        } else {
-            fiatValue.replace(",", ".")
-                .replace("٫", ".")
-        }
-        
         // Limit to 8 decimal places to prevent rounding errors in Coin.parseCoin
         val decimalIndex = cleaned.indexOf('.')
         return if (decimalIndex != -1 && cleaned.length > decimalIndex + 9) {
             cleaned.substring(0, decimalIndex + 9)
         } else {
             cleaned
+        }
+    }
+
+    private fun normalizeSeparators(value: String): String {
+        val lastSeparator = value.indexOfLast { it in SEPARATORS }
+
+        if (lastSeparator < 0) {
+            return value
+        }
+
+        // A repeated character cannot be the decimal mark, so it is grouping throughout.
+        val decimalIndex = if (value.count { it == value[lastSeparator] } == 1) lastSeparator else -1
+
+        return buildString(value.length) {
+            value.forEachIndexed { index, character ->
+                when {
+                    index == decimalIndex -> append('.')
+                    character in SEPARATORS -> Unit // grouping mark: drop it
+                    else -> append(character)
+                }
+            }
         }
     }
 

--- a/common/src/test/java/org/dash/wallet/common/util/FormatFiatWithoutCommaTest.kt
+++ b/common/src/test/java/org/dash/wallet/common/util/FormatFiatWithoutCommaTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.dash.wallet.common.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import java.math.BigDecimal
+
+/**
+ * [GenericUtils.formatFiatWithoutComma] normalises a human-formatted amount into something
+ * BigDecimal, Coin.parseCoin and Fiat.parseFiat accept. Everything it returns is parsed and
+ * a good deal of it is then sent to an exchange, so a mis-read separator is a wrong amount,
+ * not a cosmetic glitch.
+ */
+class FormatFiatWithoutCommaTest {
+    private fun format(value: String) = GenericUtils.formatFiatWithoutComma(value)
+
+    // ------------------------------------------------ unambiguous: two kinds of separator
+
+    @Test
+    fun `european grouping with a comma decimal reads as one number`() {
+        // The regression this test exists for: the old rule was "contains a dot AND a
+        // comma, so strip the commas", turning 1234.56 into 1.23456 -- off by 1000x.
+        assertEquals("1234.56", format("1.234,56"))
+        assertEquals("1234567.89", format("1.234.567,89"))
+    }
+
+    @Test
+    fun `us grouping with a dot decimal reads as one number`() {
+        assertEquals("1234.56", format("1,234.56"))
+        assertEquals("1234567.89", format("1,234,567.89"))
+    }
+
+    @Test
+    fun `the later separator is the decimal mark`() {
+        // Grouping marks always precede the decimal mark, so position decides it.
+        assertEquals("1234.5", format("1,234.5"))
+        assertEquals("1234.5", format("1.234,5"))
+    }
+
+    // ------------------------------------------- unambiguous: one kind, repeated = grouping
+
+    @Test
+    fun `a repeated separator is grouping, since a number has at most one decimal mark`() {
+        assertEquals("1234567", format("1,234,567"))
+        assertEquals("1234567", format("1.234.567"))
+    }
+
+    // -------------------------------------------------- ambiguous: one kind, one occurrence
+
+    @Test
+    fun `a single separator still reads as a decimal mark`() {
+        // "1,234" is 1.234 in one locale and 1234 in another; nothing here can tell them
+        // apart, so this keeps the long-standing reading rather than guessing a new one.
+        assertEquals("12.34", format("12,34"))
+        assertEquals("12.34", format("12.34"))
+        assertEquals("1.234", format("1,234"))
+        assertEquals("1.234", format("1.234"))
+    }
+
+    @Test
+    fun `the arabic decimal separator is still handled`() {
+        assertEquals("12.34", format("12٫34"))
+    }
+
+    // ---------------------------------------------------------------------- edge cases
+
+    @Test
+    fun `values without separators are untouched`() {
+        assertEquals("", format(""))
+        assertEquals("0", format("0"))
+        assertEquals("1234567", format("1234567"))
+    }
+
+    @Test
+    fun `a trailing separator is preserved so partial input keeps rendering`() {
+        assertEquals("0.", format("0."))
+        assertEquals("0.", format("0,"))
+    }
+
+    @Test
+    fun `the eight-decimal cap still applies`() {
+        assertEquals("12.34567890", format("12.3456789012"))
+        assertEquals("1234.56789012", format("1.234,56789012345"))
+    }
+
+    @Test
+    fun `every result parses`() {
+        val inputs = listOf(
+            "1.234,56", "1,234.56", "1.234.567,89", "1,234,567.89",
+            "1,234,567", "1.234.567", "12,34", "12.34", "0", "1234567"
+        )
+        for (input in inputs) {
+            assertNotNull("[$input] must produce a parseable number", BigDecimal(format(input)))
+        }
+    }
+}

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/CoinbaseConstants.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/CoinbaseConstants.kt
@@ -17,6 +17,7 @@
 package org.dash.wallet.integrations.coinbase
 
 import android.content.Context
+import org.bitcoinj.utils.MonetaryFormat
 import org.dash.wallet.integrations.coinbase.service.CoinBaseClientConstants
 import java.io.File
 import java.net.URLEncoder
@@ -38,6 +39,20 @@ object CoinbaseConstants {
     const val MIN_USD_COINBASE_AMOUNT = "2"
     const val BASE_IDS_REQUEST_URL = "v2/assets/prices?filter=holdable&resolution=latest"
     const val BUY_FEE = 0.006
+
+    /**
+     * Amount format for Coinbase request bodies: two decimals, plain ASCII digits and a
+     * dot.
+     *
+     * Deliberately NOT locale-aware. `Constants.SEND_PAYMENT_LOCAL_FORMAT`, which the buy
+     * flow used to format these with, calls `withLocale(deviceLocale)` and so renders
+     * "12,34" on every comma-decimal locale (de, fr, es, it, pt, nl, pl, ru, be_BY ...).
+     * That string is not a number Coinbase will accept on a deposit or a buy order.
+     */
+    val API_AMOUNT_FORMAT: MonetaryFormat = MonetaryFormat()
+        .noCode()
+        .minDecimals(2)
+        .optionalDecimals()
     const val REDIRECT_URL = "dashwallet://brokers/coinbase/connect"
     const val AUTH_RESULT_ACTION = "Coinbase.AUTH_RESULT"
     val LINK_URL get() = "https://login.coinbase.com/oauth2/auth?response_type=code" +

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/repository/CoinBaseRepository.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/repository/CoinBaseRepository.kt
@@ -18,6 +18,9 @@ package org.dash.wallet.integrations.coinbase.repository
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.bitcoinj.core.Coin
@@ -45,7 +48,22 @@ import javax.inject.Inject
 
 interface CoinBaseRepositoryInt {
     val hasValidCredentials: Boolean
+
+    /**
+     * Last known auth state, safe to read from any thread.
+     *
+     * This is a cache of [isAuthenticatedFlow] and can still be `false` in the window
+     * before the stored token has been read back from disk, so prefer
+     * [isAuthenticatedFlow] where the caller can react to a change, or
+     * [isUserAuthenticated] where it can suspend.
+     */
     val isAuthenticated: Boolean
+
+    /** Emits the auth state, starting with the current one and again on every change. */
+    val isAuthenticatedFlow: StateFlow<Boolean>
+
+    /** Authoritative auth state, read straight from storage -- never a startup-race `false`. */
+    suspend fun isUserAuthenticated(): Boolean
 
     suspend fun getUserAccount(): CoinbaseAccount
     suspend fun getUserAccount(cryptoCurrency: String): CoinbaseAccount?
@@ -95,12 +113,22 @@ class CoinBaseRepository @Inject constructor(
         get() = CoinBaseClientConstants.CLIENT_ID.isNotEmpty() &&
             CoinBaseClientConstants.CLIENT_SECRET.isNotEmpty()
 
-    override var isAuthenticated: Boolean = false
-        private set
+    // Backed by a StateFlow rather than a plain var: the write happens on Dispatchers.IO
+    // and every read is on another thread, so a non-volatile field gave readers no
+    // guarantee they would ever observe the value that was stored (MO-995).
+    private val _isAuthenticated = MutableStateFlow(false)
+
+    override val isAuthenticated: Boolean
+        get() = _isAuthenticated.value
+
+    override val isAuthenticatedFlow: StateFlow<Boolean> = _isAuthenticated.asStateFlow()
+
+    override suspend fun isUserAuthenticated(): Boolean =
+        !config.get(CoinbaseConfig.LAST_ACCESS_TOKEN).isNullOrEmpty()
 
     init {
         config.observe(CoinbaseConfig.LAST_ACCESS_TOKEN)
-            .onEach { isAuthenticated = !it.isNullOrEmpty() }
+            .onEach { _isAuthenticated.value = !it.isNullOrEmpty() }
             .launchIn(configScope)
     }
 

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/repository/remote/TokenAuthenticator.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/repository/remote/TokenAuthenticator.kt
@@ -28,12 +28,23 @@ import org.dash.wallet.common.data.safeApiCall
 import org.dash.wallet.integrations.coinbase.model.TokenResponse
 import org.dash.wallet.integrations.coinbase.service.CoinBaseTokenRefreshApi
 import org.dash.wallet.integrations.coinbase.utils.CoinbaseConfig
+import org.slf4j.LoggerFactory
 import javax.inject.Inject
 
 class TokenAuthenticator @Inject constructor(
     private val tokenApi: CoinBaseTokenRefreshApi,
     private val config: CoinbaseConfig
 ) : Authenticator {
+    companion object {
+        private val log = LoggerFactory.getLogger(TokenAuthenticator::class.java)
+
+        /**
+         * The only codes on which Coinbase has definitively rejected the refresh token: 400
+         * for an `invalid_grant` (revoked or expired), 401 for credentials it will not
+         * accept. Per OAuth2 these are verdicts on the grant itself.
+         */
+        private val AUTH_REJECTION_CODES = setOf(400, 401)
+    }
 
     // For multiple call to refresh token sync
     private val tokenMutex = Mutex()
@@ -52,9 +63,23 @@ class TokenAuthenticator @Inject constructor(
                         }
                     }
 
-                    else -> {
-                        config.set(CoinbaseConfig.LAST_ACCESS_TOKEN, "")
-                        config.set(CoinbaseConfig.LAST_REFRESH_TOKEN, "")
+                    is ResponseResource.Failure -> {
+                        if (isAuthRejection(tokenResponse)) {
+                            log.info(
+                                "coinbase rejected the refresh token (code {}); clearing credentials",
+                                tokenResponse.errorCode
+                            )
+                            config.set(CoinbaseConfig.LAST_ACCESS_TOKEN, "")
+                            config.set(CoinbaseConfig.LAST_REFRESH_TOKEN, "")
+                        } else {
+                            // A transport failure says nothing about whether the token is
+                            // still good. Clearing here de-authenticated the user and forced
+                            // a re-link on a single network blip (MO-995).
+                            log.warn(
+                                "coinbase token refresh failed with no verdict on the token; keeping credentials",
+                                tokenResponse.throwable
+                            )
+                        }
                         null
                     }
                 }
@@ -62,11 +87,14 @@ class TokenAuthenticator @Inject constructor(
         }
     }
 
+    /** True only when the failure is Coinbase rejecting the grant, not the network failing. */
+    private fun isAuthRejection(failure: ResponseResource.Failure): Boolean {
+        val code = failure.errorCode
+        return !failure.isNetworkError && code != null && code in AUTH_REJECTION_CODES
+    }
+
     private suspend fun getUpdatedToken(): ResponseResource<TokenResponse?> {
-        val accessToken = config.get(CoinbaseConfig.LAST_ACCESS_TOKEN) ?: ""
         val refreshToken = config.get(CoinbaseConfig.LAST_REFRESH_TOKEN) ?: ""
-        println(" --- lastCoinbaseAccessToken --- $accessToken")
-        println(" === lastCoinbaseRefreshToken === $refreshToken")
         return safeApiCall { tokenApi.refreshToken(refreshToken = refreshToken) }
     }
 }

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/ui/EnterAmountToTransferFragment.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/ui/EnterAmountToTransferFragment.kt
@@ -41,12 +41,13 @@ import org.dash.wallet.common.ui.segmented_picker.SegmentedPickerStyle
 import org.dash.wallet.common.ui.viewBinding
 import org.dash.wallet.common.util.Constants
 import org.dash.wallet.common.util.GenericUtils
-import org.dash.wallet.common.util.isCurrencyFirst
 import org.dash.wallet.integrations.coinbase.CoinbaseConstants
 import org.dash.wallet.integrations.coinbase.R
 import org.dash.wallet.integrations.coinbase.databinding.EnterAmountToTransferFragmentBinding
 import org.dash.wallet.integrations.coinbase.viewmodels.EnterAmountToTransferViewModel
+import org.dash.wallet.integrations.coinbase.viewmodels.CANONICAL_SEPARATOR
 import org.dash.wallet.integrations.coinbase.viewmodels.coinbaseViewModels
+import org.dash.wallet.integrations.coinbase.viewmodels.wouldExceedDecimals
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -62,7 +63,6 @@ import org.dash.wallet.common.ui.segmented_picker.SegmentedOption
 class EnterAmountToTransferFragment : Fragment(R.layout.enter_amount_to_transfer_fragment) {
 
     companion object {
-        private const val DECIMAL_SEPARATOR = '.'
         fun newInstance() = EnterAmountToTransferFragment()
     }
 
@@ -71,12 +71,6 @@ class EnterAmountToTransferFragment : Fragment(R.layout.enter_amount_to_transfer
     private var exchangeRate: ExchangeRate? = null
     private var pickedCurrencyIndex by mutableIntStateOf(0)
     private var currencyOptions by mutableStateOf(listOf<SegmentedOption>())
-    private val pickedCurrencyOption: String
-        get() = if (currencyOptions.size > pickedCurrencyIndex) {
-            currencyOptions[pickedCurrencyIndex].title
-        } else {
-            ""
-        }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -93,10 +87,6 @@ class EnterAmountToTransferFragment : Fragment(R.layout.enter_amount_to_transfer
 
         binding.currencyOptions.setViewCompositionStrategy(
             ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
-        )
-        currencyOptions = listOf(
-            SegmentedOption(Constants.DASH_CURRENCY),
-            SegmentedOption(viewModel.localCurrencyCode)
         )
         binding.currencyOptions.setContent {
             DashWalletTheme {
@@ -150,6 +140,17 @@ class EnterAmountToTransferFragment : Fragment(R.layout.enter_amount_to_transfer
             formatTransferredAmount(viewModel.maxValue)
         }
 
+        // The selected currency loads asynchronously. Rebuilding on every emission is what
+        // keeps the fiat option off the seeded USD default (MO-995 C) -- and the amount text
+        // carries the same currency's symbol, so it has to be re-rendered alongside it.
+        viewModel.localCurrencyCodeState.observe(viewLifecycleOwner) { currencyCode ->
+            currencyOptions = listOf(
+                SegmentedOption(Constants.DASH_CURRENCY),
+                SegmentedOption(currencyCode)
+            )
+            formatTransferredAmount(viewModel.inputValue)
+        }
+
         viewModel.localCurrencyExchangeRate.observe(viewLifecycleOwner) {
             exchangeRate = it?.let { ExchangeRate(Coin.COIN, it.fiat) }
         }
@@ -160,17 +161,11 @@ class EnterAmountToTransferFragment : Fragment(R.layout.enter_amount_to_transfer
     }
 
     private fun formatTransferredAmount(value: String) {
-        val text = viewModel.applyNewValue(value, pickedCurrencyOption)
+        // One call produces the text, the bounds of its currency label and the keypad's
+        // decimal limit together, so they cannot describe different amounts (MO-995).
+        val text = viewModel.applyNewValue(value, viewModel.isFiatSelected)
         val spannableString = SpannableString(text).apply {
-            if (pickedCurrencyIndex == 0) {
-                spanAmount(this, viewModel.formattedValue.length, text.length)
-            } else {
-                if (viewModel.fiatAmount?.isCurrencyFirst() == true && text.length - viewModel.fiatBalance.length > 0) {
-                    spanAmount(this, 0, text.length - viewModel.fiatBalance.length)
-                } else {
-                    spanAmount(this, viewModel.inputValue.length, text.length)
-                }
-            }
+            viewModel.currencySpan?.let { span -> spanAmount(this, span.from, span.to) }
         }
 
         binding.inputAmount.text = spannableString
@@ -203,15 +198,10 @@ class EnterAmountToTransferFragment : Fragment(R.layout.enter_amount_to_transfer
 
         private fun refreshValue() {
             value.clear()
-            val inputValue = if (pickedCurrencyIndex == 1) {
-                val localCurrencySymbol =
-                    GenericUtils.getLocalCurrencySymbol(viewModel.localCurrencyCode)
-                binding.inputAmount.text.split(" ")
-                    .first { it != localCurrencySymbol }
-            } else {
-                binding.inputAmount.text.split(" ")
-                    .first { it != pickedCurrencyOption }
-            }
+            // Read the digits back from the same field that produced them rather than
+            // splitting the rendered text on spaces -- a grouping separator or a symbol
+            // containing a space would otherwise hand back the wrong slice.
+            val inputValue = viewModel.amountPart
             if (inputValue != CoinbaseConstants.VALUE_ZERO) {
                 value.append(inputValue)
             }
@@ -231,19 +221,13 @@ class EnterAmountToTransferFragment : Fragment(R.layout.enter_amount_to_transfer
 
         override fun onNumber(number: Int) {
             refreshValue()
-            if (value.toString() == CoinbaseConstants.VALUE_ZERO && !value.toString().contains(DECIMAL_SEPARATOR)) {
+            if (value.toString() == CoinbaseConstants.VALUE_ZERO && !value.toString().contains(CANONICAL_SEPARATOR)) {
                 value.clear()
             }
-            val formattedValue = value.toString()
-            val isFraction = formattedValue.indexOf(viewModel.decimalSeparator) > -1
-
-            if (isFraction) {
-                val lengthOfDecimalPart = formattedValue.length - formattedValue.indexOf(viewModel.decimalSeparator)
-                val decimalsThreshold = if (pickedCurrencyIndex == 1) 2 else 8
-
-                if (lengthOfDecimalPart > decimalsThreshold) {
-                    return
-                }
+            // viewModel.maxDecimals belongs to the mode that formatted the text now on
+            // screen, so the gate can't disagree with it (MO-995 B).
+            if (wouldExceedDecimals(value.toString(), CANONICAL_SEPARATOR, viewModel.maxDecimals)) {
+                return
             }
 
             if (!viewModel.isMaxAmountSelected) {
@@ -266,11 +250,11 @@ class EnterAmountToTransferFragment : Fragment(R.layout.enter_amount_to_transfer
         override fun onFunction() {
             if (viewModel.isMaxAmountSelected) return
             refreshValue()
-            if (value.indexOf(DECIMAL_SEPARATOR) < 0) {
+            if (value.indexOf(CANONICAL_SEPARATOR) < 0) {
                 if (value.isEmpty()) {
                     value.append(CoinbaseConstants.VALUE_ZERO)
                 }
-                value.append(DECIMAL_SEPARATOR)
+                value.append(CANONICAL_SEPARATOR)
             }
             formatTransferredAmount(value.toString())
         }

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/ui/convert_currency/ConvertViewFragment.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/ui/convert_currency/ConvertViewFragment.kt
@@ -55,6 +55,7 @@ import org.dash.wallet.integrations.coinbase.R
 import org.dash.wallet.integrations.coinbase.databinding.FragmentConvertCurrencyBinding
 import org.dash.wallet.integrations.coinbase.model.CoinBaseUserAccountDataUIModel
 import org.dash.wallet.integrations.coinbase.viewmodels.ConvertViewViewModel
+import org.dash.wallet.integrations.coinbase.viewmodels.amountCurrencySpan
 import org.dash.wallet.integrations.coinbase.viewmodels.coinbaseViewModels
 import java.math.BigDecimal
 import java.math.RoundingMode
@@ -383,10 +384,12 @@ class ConvertViewFragment : Fragment(R.layout.fragment_convert_currency) {
                 "$faitBalance $localCurrencySymbol"
             }
             SpannableString(text).apply {
-                if (fiatAmount.isCurrencyFirst() && text.length - faitBalance.length > 0) {
-                    setAmountFormat(this, 0, text.length - faitBalance.length)
-                } else {
-                    setAmountFormat(this, balance.length, text.length)
+                // Bounds come from faitBalance -- the figure actually rendered -- not from
+                // the raw `balance`. A converted value carries 8 decimals while faitBalance
+                // is rounded to 2, so `balance.length` overshot the text and setSpan threw
+                // (the same defect as MO-995 A on the transfer screen).
+                amountCurrencySpan(text, faitBalance, fiatAmount.isCurrencyFirst())?.let {
+                    setAmountFormat(this, it.from, it.to)
                 }
             }
         } else {
@@ -399,7 +402,9 @@ class ConvertViewFragment : Fragment(R.layout.fragment_convert_currency) {
             val text = "$formattedValue $currencyCode"
 
             SpannableString(text).apply {
-                setAmountFormat(this, formattedValue.length, text.length)
+                amountCurrencySpan(text, formattedValue, isCurrencyFirst = false)?.let {
+                    setAmountFormat(this, it.from, it.to)
+                }
             }
         }
 

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/viewmodels/CoinbaseBuyDashViewModel.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/viewmodels/CoinbaseBuyDashViewModel.kt
@@ -114,8 +114,13 @@ class CoinbaseBuyDashViewModel @Inject constructor(
         val amount = uiState.value.order ?: return
 
         analyticsService.logEvent(AnalyticsConstants.Coinbase.QUOTE_CONFIRM, mapOf())
-        val format = Constants.SEND_PAYMENT_LOCAL_FORMAT.noCode().roundingMode(RoundingMode.UP)
-        val amountStr = format.format(amount).toString()
+        // Locale-independent on purpose -- this string goes into the deposit and buy-order
+        // request bodies. The device-locale format this used renders "12,34" on any
+        // comma-decimal locale, which Coinbase will not accept as an amount.
+        val amountStr = CoinbaseConstants.API_AMOUNT_FORMAT
+            .roundingMode(RoundingMode.UP)
+            .format(amount)
+            .toString()
 
         if (uiState.value.paymentMethod?.paymentMethodType == PaymentMethodType.BankAccount) {
             coinBaseRepository.depositToFiatAccount(

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/viewmodels/CoinbaseServicesViewModel.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/viewmodels/CoinbaseServicesViewModel.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.bitcoinj.core.Coin
 import org.bitcoinj.utils.Fiat
@@ -73,6 +74,12 @@ class CoinbaseServicesViewModel @Inject constructor(
         get() = preferences.format.noCode()
 
     init {
+        // The seed above can be a startup-race `false`, and the state can change under us
+        // while the screen is open, so track it rather than sampling it once (MO-995).
+        coinBaseRepository.isAuthenticatedFlow
+            .onEach { isLoggedIn -> _uiState.update { it.copy(isLoggedIn = isLoggedIn) } }
+            .launchIn(viewModelScope)
+
         config.observe(CoinbaseConfig.LAST_BALANCE)
             .map { uiState.value.copy(balance = Coin.valueOf(it ?: 0)) }
             .filterNotNull()

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/viewmodels/ConvertViewViewModel.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/viewmodels/ConvertViewViewModel.kt
@@ -266,9 +266,17 @@ class ConvertViewViewModel @Inject constructor(
                 }
             }
 
-            val bd = toDashValue(enteredConvertAmount, account)
+            // The DASH leg has to switch on the same input type as the fiat leg above. It
+            // used to call toDashValue unconditionally, which only yielded DASH when the
+            // entry was the account's crypto: a fiat entry was scaled by DASH-per-crypto,
+            // and a DASH entry -- already DASH -- was scaled a second time.
+            val dashAmount = when (currencyInputType) {
+                CurrencyInputType.Crypto -> toDashValue(enteredConvertAmount, account, fromCrypto = true).toString()
+                CurrencyInputType.Fiat -> toDashValue(enteredConvertAmount, account).toString()
+                else -> GenericUtils.formatFiatWithoutComma(enteredConvertAmount)
+            }
             val coin = try {
-                Coin.parseCoin(bd.toString())
+                Coin.parseCoin(dashAmount)
             } catch (x: Exception) {
                 Coin.ZERO
             }
@@ -278,17 +286,31 @@ class ConvertViewViewModel @Inject constructor(
         return Pair(null, null)
     }
 
+    /**
+     * Converts [valueToBind] into DASH.
+     *
+     * [fromCrypto] picks the rate: the value is either an amount of the Coinbase account's
+     * crypto, or an amount of the user's local currency. Coinbase quotes both rates per one
+     * unit of the local currency, so DASH-per-crypto is the ratio of the two and
+     * DASH-per-local-currency is the raw rate.
+     *
+     * Both branches used to read `getCryptoToDashExchangeRate()` -- the `if` and the `else`
+     * were the same expression -- so a local-currency amount was scaled by DASH-per-crypto
+     * and came out wrong by the entire crypto/fiat price ratio.
+     */
     fun toDashValue(
         valueToBind: String,
         userAccountData: CoinBaseUserAccountDataUIModel,
         fromCrypto: Boolean = false
     ): BigDecimal {
-        val convertedValue = if (fromCrypto) {
-            valueToBind.toBigDecimal() * userAccountData.getCryptoToDashExchangeRate()
+        val amount = GenericUtils.formatFiatWithoutComma(valueToBind).toBigDecimalOrNull()
+            ?: return BigDecimal.ZERO
+        val rate = if (fromCrypto) {
+            userAccountData.getCryptoToDashExchangeRate() // DASH per unit of the account's crypto
         } else {
-            valueToBind.toBigDecimal() * userAccountData.getCryptoToDashExchangeRate()
-        }.setScale(8, RoundingMode.HALF_UP)
-        return convertedValue
+            userAccountData.currencyToDashExchangeRate // DASH per unit of local currency
+        }
+        return (amount * rate).setScale(8, RoundingMode.HALF_UP)
     }
 
     private fun setDashWalletBalance() {

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/viewmodels/EnterAmountToTransferViewModel.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/viewmodels/EnterAmountToTransferViewModel.kt
@@ -41,7 +41,6 @@ import org.dash.wallet.integrations.coinbase.CoinbaseConstants
 import org.dash.wallet.integrations.coinbase.model.CoinbaseToDashExchangeRateUIModel
 import java.math.BigDecimal
 import java.math.RoundingMode
-import java.text.DecimalFormat
 import java.text.DecimalFormatSymbols
 import javax.inject.Inject
 
@@ -57,18 +56,43 @@ class EnterAmountToTransferViewModel @Inject constructor(
 
     var coinbaseExchangeRate: CoinbaseToDashExchangeRateUIModel? = null
     private var maxAmountInDashWalletFormatted: String = CoinbaseConstants.VALUE_ZERO
-    private val dashFormat = MonetaryFormat().withLocale(GenericUtils.getDeviceLocale())
+    // Not locale-aware: every value this produces is an INPUT -- to maxValue, to
+    // applyCoinbaseExchangeRate, to BigDecimal -- never something shown to the user.
+    // withLocale() gave it the device's decimal mark, so on a comma-decimal locale MAX
+    // handed "1,5" to a pipeline that can only read "1.5": the DASH branch left it
+    // unparseable and the transfer button never enabled.
+    private val dashFormat = MonetaryFormat()
         .noCode().minDecimals(6).optionalDecimals()
     val decimalSeparator =
         DecimalFormatSymbols.getInstance(GenericUtils.getDeviceLocale()).decimalSeparator
     private val format = Constants.SEND_PAYMENT_LOCAL_FORMAT.noCode()
 
     var fiatAmount: Fiat? = null
-    var fiatBalance: String = ""
     var inputValue: String = CoinbaseConstants.VALUE_ZERO
     var isMaxAmountSelected: Boolean = false
-    var formattedValue: String = ""
     val onContinueTransferEvent = SingleLiveEvent<Pair<Fiat, Coin>>()
+
+    /**
+     * The digits-only slice of the text [applyNewValue] last returned -- without the
+     * currency symbol or code. Single source of truth for the span bounds the view styles
+     * and for the keypad's decimal gate, so neither can be paired with text from the other
+     * branch (MO-995).
+     */
+    var amountPart: String = CoinbaseConstants.VALUE_ZERO
+        private set
+
+    /** The mode [applyNewValue] last formatted in. */
+    internal var amountMode: AmountMode = AmountMode.DASH
+        private set
+
+    /** Bounds of the currency label in the text [applyNewValue] last returned. */
+    internal var currencySpan: AmountCurrencySpan? = null
+        private set
+
+    /** Decimal places the keypad may accept for the text now on screen. */
+    val maxDecimals: Int
+        get() = amountMode.maxDecimals
+
     var isFiatSelected: Boolean = false
         set(value) {
             if (field != value) {
@@ -84,8 +108,19 @@ class EnterAmountToTransferViewModel @Inject constructor(
     val dashBalanceInWalletState: StateFlow<Coin>
         get() = _dashBalanceInWallet
 
-    var localCurrencyCode: String = Constants.USD_CURRENCY
-        private set
+    private val _localCurrencyCode = MutableStateFlow(Constants.USD_CURRENCY)
+
+    /** Selected local currency, for synchronous formatting inside this ViewModel. */
+    val localCurrencyCode: String
+        get() = _localCurrencyCode.value
+
+    /**
+     * Emits the selected local currency: seeded with the default, then re-emitted once the
+     * real value loads from [WalletUIConfig]. The view must rebuild its currency picker on
+     * every emission -- reading the code once in onViewCreated left the fiat option
+     * labelled USD for the life of the view (MO-995 C).
+     */
+    val localCurrencyCodeState: LiveData<String> = _localCurrencyCode.asLiveData()
 
     private val _localCurrencyExchangeRate = MutableLiveData<ExchangeRate?>()
     val localCurrencyExchangeRate: LiveData<ExchangeRate?>
@@ -111,7 +146,7 @@ class EnterAmountToTransferViewModel @Inject constructor(
         setDashWalletBalance()
         walletUIConfig.observe(WalletUIConfig.SELECTED_CURRENCY)
             .filterNotNull()
-            .onEach { localCurrencyCode = it }
+            .onEach { _localCurrencyCode.value = it }
             .flatMapLatest(exchangeRates::observeExchangeRate)
             .onEach(_localCurrencyExchangeRate::postValue)
             .launchIn(viewModelScope)
@@ -137,50 +172,34 @@ class EnterAmountToTransferViewModel @Inject constructor(
             .optionalDecimals(0, 8).format(dashBalanceInWalletState.value).toString()
     }
 
-    fun applyNewValue(value: String, monetaryCode: String): String {
-        inputValue = value.ifEmpty { CoinbaseConstants.VALUE_ZERO }
-        val isFraction = inputValue.indexOf(decimalSeparator) > -1
-        val lengthOfDecimalPart = inputValue.length - inputValue.indexOf(decimalSeparator)
-
-        return if (localCurrencyCode == monetaryCode) {
-            val cleanedValue = GenericUtils.formatFiatWithoutComma(inputValue)
-            fiatAmount = Fiat.parseFiat(localCurrencyCode, cleanedValue)
-            val localCurrencySymbol = GenericUtils.getLocalCurrencySymbol(localCurrencyCode)
-
-            fiatBalance = if (isFraction && lengthOfDecimalPart > 2) {
-                format.format(fiatAmount).toString()
-            } else {
-                inputValue
-            }
-            if (fiatAmount!!.isCurrencyFirst()) {
-                "$localCurrencySymbol $fiatBalance"
-            } else {
-                "$fiatBalance $localCurrencySymbol"
-            }
-        } else {
-            val rawFormattedValue = if (inputValue.contains("E")) {
-                DecimalFormat("########.########").format(inputValue.toDouble())
-            } else {
-                inputValue
-            }
-            
-            // Limit to 8 decimal places max using BigDecimal for proper rounding
-            formattedValue = if (rawFormattedValue.endsWith(".") || rawFormattedValue.isEmpty()) {
-                // Don't process incomplete decimal entries
-                rawFormattedValue
-            } else if (isFraction && lengthOfDecimalPart <= 8) {
-                // Preserve input format for incomplete decimal entries like "0.0"
-                rawFormattedValue
-            } else {
-                try {
-                    val bigDecimal = rawFormattedValue.toBigDecimal()
-                    bigDecimal.setScale(8, RoundingMode.HALF_UP).stripTrailingZeros().toPlainString()
-                } catch (e: Exception) {
-                    rawFormattedValue
-                }
-            }
-            "$formattedValue $monetaryCode"
-        }
+    /**
+     * Formats [value] for display and republishes everything derived from it -- the digits
+     * slice ([amountPart]), the currency-label bounds ([currencySpan]) and the keypad's
+     * decimal limit ([maxDecimals]) -- so no caller can pair the returned text with bounds
+     * or a limit belonging to the other branch.
+     *
+     * MO-995: this used to take the currency picker's visible LABEL and branch on
+     * `localCurrencyCode == monetaryCode`. The label is the selected currency code, which
+     * loads asynchronously, so a stale "USD" against a real "BYN" failed to match and sent
+     * a fiat amount down the DASH branch -- 8 decimals, a "USD" label on a BYN figure, a
+     * keypad gated at 2 places that then refused every digit, and span bounds taken from
+     * the other branch's field, which crashed `Spannable.setSpan`. It now branches on the
+     * boolean the picker itself sets, and labels with its own [localCurrencyCode].
+     */
+    fun applyNewValue(value: String, isFiat: Boolean): String {
+        val amount = transferAmount(
+            value = value,
+            isFiat = isFiat,
+            localCurrencyCode = localCurrencyCode,
+            decimalSeparator = decimalSeparator,
+            fiatFormat = format
+        )
+        amountMode = amount.mode
+        inputValue = amount.inputValue
+        fiatAmount = amount.fiatAmount
+        amountPart = amount.amountPart
+        currencySpan = amount.currencySpan
+        return amount.text
     }
 
     val hasBalance: Boolean
@@ -226,9 +245,7 @@ class EnterAmountToTransferViewModel @Inject constructor(
 
     private fun applyCoinbaseExchangeRate(amount: String): String {
         return coinbaseExchangeRate?.let { uiModel ->
-            val cleanedValue = amount
-                .replace(',', '.') // TODO: the amount sometimes comes here with a comma as decimal separator.
-                // TODO: it's better to identify the root of this and replace in there to prevent this problem from appearing anywhere else.
+            val cleanedValue = GenericUtils.formatFiatWithoutComma(amount)
                 .toBigDecimal() / uiModel.currencyToDashExchangeRate
             cleanedValue.setScale(8, RoundingMode.HALF_UP).toPlainString()
         } ?: CoinbaseConstants.VALUE_ZERO

--- a/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/viewmodels/TransferAmountFormat.kt
+++ b/integrations/coinbase/src/main/java/org/dash/wallet/integrations/coinbase/viewmodels/TransferAmountFormat.kt
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.dash.wallet.integrations.coinbase.viewmodels
+
+import org.bitcoinj.utils.Fiat
+import org.bitcoinj.utils.MonetaryFormat
+import org.dash.wallet.common.util.Constants
+import org.dash.wallet.common.util.GenericUtils
+import org.dash.wallet.common.util.isCurrencyFirst
+import org.dash.wallet.integrations.coinbase.CoinbaseConstants
+import java.math.RoundingMode
+import java.text.DecimalFormat
+
+/**
+ * Pure decision logic behind the "enter amount to transfer" screen.
+ *
+ * MO-995: the screen used to derive the amount text, the span that styles its currency
+ * label, and the keypad's decimal limit from three different places -- the picker's
+ * visible LABEL, the ViewModel's `formattedValue`/`fiatBalance`/`inputValue` fields, and
+ * a hard-coded threshold keyed off the picker index. A stale label was enough to make
+ * them disagree, which showed up as a crash, a frozen keypad and a mislabelled amount.
+ *
+ * Everything here takes plain values and returns plain values so it can be unit tested
+ * on the host JVM, and so [EnterAmountToTransferViewModel.applyNewValue] can publish the
+ * text, the span and the decimal limit together, from the one branch it actually took.
+ */
+
+/** Which kind of money the amount currently on screen is denominated in. */
+internal enum class AmountMode {
+    DASH,
+    FIAT;
+
+    /** Digits allowed after the decimal separator in this mode. */
+    val maxDecimals: Int
+        get() = if (this == FIAT) FIAT_MAX_DECIMALS else DASH_MAX_DECIMALS
+}
+
+/**
+ * The decimal separator every value in this pipeline is stored, counted, gated and parsed
+ * with.
+ *
+ * It is the character the numeric keypad inserts, and the one `BigDecimal`, `Coin.parseCoin`
+ * and `Fiat.parseFiat` all require. The *device locale's* separator is a display concern
+ * only. Mixing the two is what made the decimal gate inert on every comma-decimal locale:
+ * the keypad wrote "12.34" while the gate looked for "12,34", found no separator, and let
+ * a fiat amount grow to 8 decimal places (MO-995 follow-up).
+ */
+internal const val CANONICAL_SEPARATOR = '.'
+
+/** Fiat is quoted to cents. */
+internal const val FIAT_MAX_DECIMALS = 2
+
+/** Duffs give Dash 8 decimal places. */
+internal const val DASH_MAX_DECIMALS = 8
+
+/** The slice of the amount text that renders in the smaller currency style. */
+internal data class AmountCurrencySpan(val from: Int, val to: Int)
+
+/**
+ * The mode the screen should format in.
+ *
+ * Deliberately takes the picker's boolean, not its title: the title is a currency code
+ * that arrives asynchronously, so comparing it against the selected currency produced a
+ * false "these differ" whenever the label was still the seeded default (MO-995 C/D).
+ */
+internal fun amountMode(isFiatSelected: Boolean): AmountMode =
+    if (isFiatSelected) AmountMode.FIAT else AmountMode.DASH
+
+/** Number of digits after [separator] in [input]; 0 when there is no separator. */
+internal fun decimalCount(input: String, separator: Char): Int {
+    val index = input.indexOf(separator)
+    return if (index < 0) 0 else input.length - index - 1
+}
+
+/**
+ * True when typing one more digit onto [current] would push it past [maxDecimals]
+ * decimal places, so the keypad should swallow the press.
+ *
+ * [maxDecimals] must come from the mode that produced the text now on screen. Gating
+ * DASH-scale text on the fiat limit of 2 rejects every digit and looks like a dead
+ * keypad (MO-995 B).
+ */
+internal fun wouldExceedDecimals(current: String, separator: Char, maxDecimals: Int): Boolean =
+    current.indexOf(separator) >= 0 && decimalCount(current, separator) + 1 > maxDecimals
+
+/**
+ * Bounds of the currency label inside [text], given the [amountPart] that [text] was
+ * built around.
+ *
+ * Both branches measure against the same [amountPart] the formatter just produced, which
+ * is what keeps them consistent: the old code measured the currency-last fiat branch
+ * against the raw `inputValue` instead, and since `fiatBalance` can be SHORTER than the
+ * raw input (a conversion rounds to 2 places), `from` overshot `to` and
+ * `Spannable.setSpan` threw (MO-995 A).
+ *
+ * Returns null when [amountPart] cannot describe [text] -- an unstyled amount is a far
+ * better outcome than a crash.
+ */
+internal fun amountCurrencySpan(
+    text: String,
+    amountPart: String,
+    isCurrencyFirst: Boolean
+): AmountCurrencySpan? {
+    if (amountPart.isEmpty() || amountPart.length >= text.length) return null
+
+    val span = if (isCurrencyFirst) {
+        // text == "<symbol> <amountPart>" -- style the leading symbol.
+        AmountCurrencySpan(0, text.length - amountPart.length)
+    } else {
+        // text == "<amountPart> <symbol>" -- style the trailing symbol or code.
+        AmountCurrencySpan(amountPart.length, text.length)
+    }
+
+    return if (span.from < 0 || span.to > text.length || span.from >= span.to) null else span
+}
+
+/**
+ * Everything the view needs to render one amount, produced by a single pass so the text,
+ * the bounds that style its currency label and the keypad's decimal limit can never
+ * describe different amounts.
+ */
+internal data class TransferAmount(
+    val text: String,
+    /** [text] without its currency symbol or code. */
+    val amountPart: String,
+    val currencySpan: AmountCurrencySpan?,
+    /** The raw value the rest of the screen reads back; re-scaled in fiat mode. */
+    val inputValue: String,
+    val fiatAmount: Fiat?,
+    val mode: AmountMode
+) {
+    /** Decimal places the keypad may accept for [text]. */
+    val maxDecimals: Int
+        get() = mode.maxDecimals
+}
+
+/**
+ * Formats [value] for the transfer screen.
+ *
+ * Takes [isFiat] -- the boolean the currency picker sets -- rather than the picker's
+ * visible title. The title is the selected currency code, loaded asynchronously, so
+ * comparing it against [localCurrencyCode] reported "these differ" for as long as the
+ * label was still the seeded default and pushed fiat amounts down the DASH branch.
+ */
+internal fun transferAmount(
+    value: String,
+    isFiat: Boolean,
+    localCurrencyCode: String,
+    /** The DEVICE locale's separator -- used only to normalise [fiatFormat]'s output. */
+    decimalSeparator: Char,
+    fiatFormat: MonetaryFormat
+): TransferAmount {
+    val mode = amountMode(isFiat)
+    var inputValue = value.ifEmpty { CoinbaseConstants.VALUE_ZERO }
+
+    val amountPart: String
+    val text: String
+    val isCurrencyFirst: Boolean
+    val fiatAmount: Fiat?
+
+    if (mode == AmountMode.FIAT) {
+        // A value arriving from a conversion (MAX, or a currency switch) is scaled to 8
+        // places, but fiat is quoted to cents -- and leaving the extra digits in would let
+        // the keypad gate and the rendered figure disagree about how precise the amount is.
+        // Hand the re-scaled value back too: the keypad and the transfer button read it.
+        if (decimalCount(inputValue, CANONICAL_SEPARATOR) > FIAT_MAX_DECIMALS) {
+            inputValue = truncateToDecimals(inputValue, FIAT_MAX_DECIMALS)
+        }
+        val fiat = parseFiatOrZero(localCurrencyCode, GenericUtils.formatFiatWithoutComma(inputValue))
+        fiatAmount = fiat
+        isCurrencyFirst = fiat.isCurrencyFirst()
+        amountPart = if (decimalCount(inputValue, CANONICAL_SEPARATOR) >= FIAT_MAX_DECIMALS) {
+            // fiatFormat is locale-aware and emits the locale's separator; bring it back to
+            // canonical form so the value the keypad reads next stays parseable.
+            canonicalizeSeparator(fiatFormat.format(fiat).toString(), decimalSeparator)
+        } else {
+            inputValue
+        }
+        val symbol = GenericUtils.getLocalCurrencySymbol(localCurrencyCode)
+        text = if (isCurrencyFirst) "$symbol $amountPart" else "$amountPart $symbol"
+    } else {
+        fiatAmount = null
+        isCurrencyFirst = false
+        amountPart = formatDashInput(inputValue)
+        text = "$amountPart ${Constants.DASH_CURRENCY}"
+    }
+
+    return TransferAmount(
+        text = text,
+        amountPart = amountPart,
+        currencySpan = amountCurrencySpan(text, amountPart, isCurrencyFirst),
+        inputValue = inputValue,
+        fiatAmount = fiatAmount,
+        mode = mode
+    )
+}
+
+private fun formatDashInput(input: String): String {
+    val isFraction = input.indexOf(CANONICAL_SEPARATOR) > -1
+    val lengthOfDecimalPart = input.length - input.indexOf(CANONICAL_SEPARATOR)
+    val rawFormattedValue = if (input.contains("E")) {
+        DecimalFormat("########.########").format(input.toDouble())
+    } else {
+        input
+    }
+
+    // Limit to 8 decimal places max using BigDecimal for proper rounding
+    return if (rawFormattedValue.endsWith(".") || rawFormattedValue.isEmpty()) {
+        // Don't process incomplete decimal entries
+        rawFormattedValue
+    } else if (isFraction && lengthOfDecimalPart <= DASH_MAX_DECIMALS) {
+        // Preserve input format for incomplete decimal entries like "0.0"
+        rawFormattedValue
+    } else {
+        try {
+            rawFormattedValue.toBigDecimal()
+                .setScale(DASH_MAX_DECIMALS, RoundingMode.HALF_UP)
+                .stripTrailingZeros()
+                .toPlainString()
+        } catch (e: Exception) {
+            rawFormattedValue
+        }
+    }
+}
+
+/**
+ * Truncates -- never rounds up -- to [maxDecimals] places, so a MAX transfer cannot end up
+ * asking for more than the balance it was derived from.
+ */
+internal fun truncateToDecimals(input: String, maxDecimals: Int): String =
+    GenericUtils.formatFiatWithoutComma(input).toBigDecimalOrNull()
+        ?.setScale(maxDecimals, RoundingMode.DOWN)
+        ?.toPlainString()
+        ?: input
+
+/**
+ * Rewrites [value] from the device locale's decimal separator to [CANONICAL_SEPARATOR].
+ *
+ * Only the decimal mark moves: bitcoinj's `MonetaryFormat` emits no grouping separator, so
+ * the result is the same length as [value] and the span bounds measured against it stay
+ * valid for the localised text.
+ */
+internal fun canonicalizeSeparator(value: String, localeSeparator: Char): String =
+    if (localeSeparator == CANONICAL_SEPARATOR) value else value.replace(localeSeparator, CANONICAL_SEPARATOR)
+
+/** Partial input such as "" or "0." must render a zero, not throw out of the screen. */
+internal fun parseFiatOrZero(currencyCode: String, value: String): Fiat =
+    try {
+        Fiat.parseFiat(currencyCode, value)
+    } catch (e: Exception) {
+        Fiat.valueOf(currencyCode, 0)
+    }

--- a/integrations/coinbase/src/test/java/org/dash/wallet/integrations/coinbase/ApiAmountFormatTest.kt
+++ b/integrations/coinbase/src/test/java/org/dash/wallet/integrations/coinbase/ApiAmountFormatTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.dash.wallet.integrations.coinbase
+
+import org.bitcoinj.core.Coin
+import org.bitcoinj.utils.Fiat
+import org.bitcoinj.utils.MonetaryFormat
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import java.math.RoundingMode
+import java.util.Locale
+
+/**
+ * The amount strings in Coinbase request bodies must be plain decimals.
+ *
+ * The buy flow formatted them with `Constants.SEND_PAYMENT_LOCAL_FORMAT`, which is built
+ * with `withLocale(deviceLocale)` and therefore renders "12,34" on every comma-decimal
+ * locale -- straight into a bank deposit and a buy order.
+ */
+class ApiAmountFormatTest {
+    private val original: Locale = Locale.getDefault()
+
+    @After
+    fun restoreLocale() {
+        Locale.setDefault(original)
+    }
+
+    private fun wireAmount(value: String): String =
+        CoinbaseConstants.API_AMOUNT_FORMAT
+            .roundingMode(RoundingMode.UP)
+            .format(Fiat.parseFiat("USD", value))
+            .toString()
+
+    @Test
+    fun `the wire amount is a plain decimal on every locale`() {
+        val locales = listOf(
+            Locale.US, Locale.UK, Locale.GERMANY, Locale.FRANCE, Locale("ru", "RU"), Locale("be", "BY")
+        )
+        for (locale in locales) {
+            Locale.setDefault(locale)
+            val formatted = wireAmount("12.34")
+            assertEquals("wrong wire amount under $locale", "12.34", formatted)
+            assertFalse("$locale must not produce a comma", formatted.contains(','))
+        }
+    }
+
+    @Test
+    fun `the wire amount always carries two decimals`() {
+        Locale.setDefault(Locale.US)
+        assertEquals("12.00", wireAmount("12"))
+        assertEquals("12.50", wireAmount("12.5"))
+        assertEquals("1234567.89", wireAmount("1234567.89"))
+    }
+
+    @Test
+    fun `the wire amount is never grouped`() {
+        // A thousands separator would be just as unparseable as a comma decimal mark.
+        Locale.setDefault(Locale.GERMANY)
+        val formatted = wireAmount("1234567.89")
+        assertEquals("1234567.89", formatted)
+        assertFalse(formatted.contains('.') && formatted.indexOf('.') != formatted.lastIndexOf('.'))
+    }
+
+    @Test
+    fun `a MonetaryFormat without withLocale is canonical everywhere`() {
+        // What the transfer screen's dashFormat relies on: values it produces are inputs to
+        // BigDecimal and Coin.parseCoin, so they must carry a dot on every locale.
+        val inputFormat = MonetaryFormat().noCode().minDecimals(6).optionalDecimals()
+        for (locale in listOf(Locale.US, Locale.GERMANY, Locale("be", "BY"))) {
+            Locale.setDefault(locale)
+            val formatted = inputFormat.format(Coin.parseCoin("1.5")).toString()
+            assertEquals("wrong under $locale", "1.500000", formatted)
+            assertNotNull("$locale must stay parseable", formatted.toBigDecimalOrNull())
+        }
+    }
+
+    @Test
+    fun `rounding is up, so a deposit always covers the order`() {
+        Locale.setDefault(Locale.US)
+        // Fiat holds 8 decimals in dashj; the wire amount rounds up to the next cent.
+        assertEquals("12.35", wireAmount("12.341"))
+    }
+}

--- a/integrations/coinbase/src/test/java/org/dash/wallet/integrations/coinbase/ExchangeRateSemanticsTest.kt
+++ b/integrations/coinbase/src/test/java/org/dash/wallet/integrations/coinbase/ExchangeRateSemanticsTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+package org.dash.wallet.integrations.coinbase
+
+import org.dash.wallet.integrations.coinbase.model.Balance
+import org.dash.wallet.integrations.coinbase.model.CoinbaseAccount
+import org.dash.wallet.integrations.coinbase.model.CoinBaseUserAccountDataUIModel
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.util.UUID
+
+/**
+ * Pins what each rate on [CoinBaseUserAccountDataUIModel] means, because `toDashValue`
+ * picks between them and picking wrong is a wrong amount rather than a visible failure.
+ *
+ * Coinbase's /exchange-rates?currency=LOCAL returns rates[X] = how many X one unit of the
+ * local currency buys. So `currencyToDashExchangeRate` is DASH per local currency and
+ * `currencyToCryptoCurrencyExchangeRate` is crypto per local currency.
+ */
+class ExchangeRateSemanticsTest {
+    companion object {
+        // 1 EUR buys 0.02 DASH (DASH = 50 EUR) and 0.00002 BTC (BTC = 50,000 EUR).
+        private val DASH_PER_LOCAL = BigDecimal("0.02")
+        private val CRYPTO_PER_LOCAL = BigDecimal("0.00002")
+    }
+
+    private val account = CoinBaseUserAccountDataUIModel(
+        CoinbaseAccount(
+            uuid = UUID.randomUUID(),
+            name = "BTC Wallet",
+            currency = "BTC",
+            availableBalance = Balance("1.0", "BTC"),
+            default = true,
+            active = true,
+            type = "ACCOUNT_TYPE_CRYPTO",
+            ready = true
+        ),
+        CRYPTO_PER_LOCAL,
+        DASH_PER_LOCAL,
+        BigDecimal("1.1")
+    )
+
+    private fun scaled(value: BigDecimal) = value.setScale(8, RoundingMode.HALF_UP)
+
+    @Test
+    fun `crypto to dash is the ratio of the two rates`() {
+        // 1 BTC = 50,000 EUR = 1000 DASH.
+        assertEquals(scaled(BigDecimal("1000")), scaled(account.getCryptoToDashExchangeRate()))
+    }
+
+    @Test
+    fun `a crypto amount converts with the crypto rate`() {
+        // 0.5 BTC -> 500 DASH.
+        val dash = BigDecimal("0.5") * account.getCryptoToDashExchangeRate()
+        assertEquals(scaled(BigDecimal("500")), scaled(dash))
+    }
+
+    @Test
+    fun `a local-currency amount converts with the local rate`() {
+        // 100 EUR -> 2 DASH.
+        val dash = BigDecimal("100") * account.currencyToDashExchangeRate
+        assertEquals(scaled(BigDecimal("2")), scaled(dash))
+    }
+
+    @Test
+    fun `using the crypto rate on a local-currency amount is wrong by the price ratio`() {
+        // The defect toDashValue carried: its `if` and `else` were the same expression, so
+        // a fiat entry took the crypto rate. 100 EUR became 100,000 DASH instead of 2.
+        val correct = BigDecimal("100") * account.currencyToDashExchangeRate
+        val asItWas = BigDecimal("100") * account.getCryptoToDashExchangeRate()
+
+        assertEquals(scaled(BigDecimal("2")), scaled(correct))
+        assertEquals(scaled(BigDecimal("100000")), scaled(asItWas))
+    }
+}

--- a/integrations/coinbase/src/test/java/org/dash/wallet/integrations/coinbase/TransferAmountFormatTest.kt
+++ b/integrations/coinbase/src/test/java/org/dash/wallet/integrations/coinbase/TransferAmountFormatTest.kt
@@ -1,0 +1,370 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.dash.wallet.integrations.coinbase
+
+import org.bitcoinj.utils.MonetaryFormat
+import org.dash.wallet.integrations.coinbase.viewmodels.AmountMode
+import org.dash.wallet.integrations.coinbase.viewmodels.TransferAmount
+import org.dash.wallet.integrations.coinbase.viewmodels.DASH_MAX_DECIMALS
+import org.dash.wallet.integrations.coinbase.viewmodels.FIAT_MAX_DECIMALS
+import org.dash.wallet.integrations.coinbase.viewmodels.CANONICAL_SEPARATOR
+import org.dash.wallet.integrations.coinbase.viewmodels.canonicalizeSeparator
+import org.dash.wallet.integrations.coinbase.viewmodels.amountCurrencySpan
+import org.dash.wallet.integrations.coinbase.viewmodels.amountMode
+import org.dash.wallet.integrations.coinbase.viewmodels.decimalCount
+import org.dash.wallet.integrations.coinbase.viewmodels.transferAmount
+import org.dash.wallet.integrations.coinbase.viewmodels.truncateToDecimals
+import org.dash.wallet.integrations.coinbase.viewmodels.wouldExceedDecimals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Locale
+
+/**
+ * MO-995. The transfer screen used to derive the amount text, the span that styles its
+ * currency label and the keypad's decimal limit from three different places, keyed off the
+ * currency picker's asynchronously loaded LABEL. These cover the four reported symptoms:
+ * the setSpan crash (A), the frozen keypad (B), the stale USD label (C) and the USD label
+ * on a local-currency figure (D).
+ */
+class TransferAmountFormatTest {
+    companion object {
+        private const val SEPARATOR = '.'
+        private const val BYN = "BYN"
+
+        /** Same shape as Constants.SEND_PAYMENT_LOCAL_FORMAT.noCode(). */
+        private val FIAT_FORMAT: MonetaryFormat = MonetaryFormat()
+            .withLocale(Locale.US)
+            .minDecimals(2)
+            .optionalDecimals()
+            .noCode()
+    }
+
+    private fun fiat(value: String, currency: String = BYN) = transferAmount(
+        value = value,
+        isFiat = true,
+        localCurrencyCode = currency,
+        decimalSeparator = SEPARATOR,
+        fiatFormat = FIAT_FORMAT
+    )
+
+    private fun dash(value: String, currency: String = BYN) = transferAmount(
+        value = value,
+        isFiat = false,
+        localCurrencyCode = currency,
+        decimalSeparator = SEPARATOR,
+        fiatFormat = FIAT_FORMAT
+    )
+
+    /**
+     * Asserts the span styles exactly the currency label -- whatever remains of the text once
+     * the digits are removed. Placement-agnostic: a locale may put the symbol on either side.
+     */
+    private fun assertSpansOnlyTheCurrencyLabel(amount: TransferAmount) {
+        val span = amount.currencySpan!!
+        assertEquals(
+            "the span must cover the label and nothing but the label",
+            amount.amountPart,
+            amount.text.removeRange(span.from, span.to)
+        )
+    }
+
+    // ---------------------------------------------------------------- mode selection (C, D)
+
+    @Test
+    fun `mode follows the picker's boolean, never a currency label`() {
+        assertEquals(AmountMode.FIAT, amountMode(isFiatSelected = true))
+        assertEquals(AmountMode.DASH, amountMode(isFiatSelected = false))
+    }
+
+    @Test
+    fun `fiat mode with a non-USD local currency labels in that currency, not USD`() {
+        // C and D: the picker label used to be the seeded "USD" while the real currency was
+        // BYN, so the label never matched and a BYN amount was rendered as "<figure> USD".
+        val amount = fiat("12.34")
+
+        assertEquals(AmountMode.FIAT, amount.mode)
+        assertFalse("must not label a BYN amount as USD", amount.text.contains("USD"))
+        assertTrue(amount.text.contains("12.34"))
+    }
+
+    @Test
+    fun `a currency emission that never arrives leaves the default seeded code, still in fiat mode`() {
+        // The absent-emission case: localCurrencyCode is still the USD default. The mode must
+        // stay FIAT anyway -- that is exactly what the old label comparison got wrong in
+        // reverse, and it is what keeps the decimal limit and the span bounds consistent.
+        val amount = fiat("12.34", currency = "USD")
+
+        assertEquals(AmountMode.FIAT, amount.mode)
+        assertEquals(FIAT_MAX_DECIMALS, amount.maxDecimals)
+        assertNotNull(amount.currencySpan)
+    }
+
+    @Test
+    fun `dash mode labels in DASH whatever the local currency is`() {
+        val amount = dash("1.5")
+
+        assertEquals(AmountMode.DASH, amount.mode)
+        assertEquals("1.5 DASH", amount.text)
+        assertEquals("1.5", amount.amountPart)
+    }
+
+    // ------------------------------------------------------------------- span bounds (A)
+
+    @Test
+    fun `span covers the trailing currency label and nothing else`() {
+        val amount = dash("1.5")
+        val span = amount.currencySpan!!
+
+        assertEquals("1.5".length, span.from)
+        assertEquals(amount.text.length, span.to)
+        assertEquals(" DASH", amount.text.substring(span.from, span.to))
+    }
+
+    @Test
+    fun `span is measured against the formatted amount, not the raw input`() {
+        // A: the crash. A conversion hands in 8 decimals; the fiat branch renders 2. Bounds
+        // taken from the raw 8-decimal input overshot the text and setSpan threw.
+        val amount = fiat("0.00123456")
+
+        assertTrue("raw input is longer than the rendered figure", "0.00123456".length > amount.amountPart.length)
+        val span = amount.currencySpan!!
+        assertTrue("from must not overshoot to", span.from < span.to)
+        assertTrue("to must stay inside the text", span.to <= amount.text.length)
+        assertSpansOnlyTheCurrencyLabel(amount)
+
+        // Measured against the raw input instead, the bounds no longer describe the text --
+        // which is what made setSpan throw.
+        assertNull(amountCurrencySpan(amount.text, "0.00123456", isCurrencyFirst = false))
+    }
+
+    @Test
+    fun `span degrades to null rather than producing out-of-range bounds`() {
+        // The belt: a mismatched amountPart must yield no styling, never a crash.
+        assertNull(amountCurrencySpan("0.00 Br", "0.00123456", isCurrencyFirst = false))
+        assertNull(amountCurrencySpan("0.00 Br", "", isCurrencyFirst = false))
+        assertNull(amountCurrencySpan("", "0.00", isCurrencyFirst = false))
+        assertNull(amountCurrencySpan("0.00", "0.00", isCurrencyFirst = false))
+    }
+
+    @Test
+    fun `currency-first text styles the leading symbol`() {
+        val span = amountCurrencySpan("$ 12.34", "12.34", isCurrencyFirst = true)!!
+
+        assertEquals(0, span.from)
+        assertEquals(2, span.to)
+        assertEquals("$ ", "$ 12.34".substring(span.from, span.to))
+    }
+
+    @Test
+    fun `every span the formatter publishes is a valid setSpan range`() {
+        val inputs = listOf("", "0", "0.", "0.0", "0.00", "12", "12.3", "12.34", "0.00123456", "1234.5678")
+        for (input in inputs) {
+            for (isFiat in listOf(true, false)) {
+                val amount = transferAmount(input, isFiat, BYN, SEPARATOR, FIAT_FORMAT)
+                amount.currencySpan?.let { span ->
+                    assertTrue("$input/$isFiat: from >= 0", span.from >= 0)
+                    assertTrue("$input/$isFiat: from < to", span.from < span.to)
+                    assertTrue("$input/$isFiat: to <= length", span.to <= amount.text.length)
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------- decimal gating (B)
+
+    @Test
+    fun `decimalCount counts digits after the separator`() {
+        assertEquals(0, decimalCount("12", SEPARATOR))
+        assertEquals(0, decimalCount("12.", SEPARATOR))
+        assertEquals(1, decimalCount("12.3", SEPARATOR))
+        assertEquals(8, decimalCount("0.00123456", SEPARATOR))
+    }
+
+    @Test
+    fun `keypad accepts up to two decimals in fiat mode`() {
+        assertFalse(wouldExceedDecimals("12", SEPARATOR, FIAT_MAX_DECIMALS))
+        assertFalse(wouldExceedDecimals("12.", SEPARATOR, FIAT_MAX_DECIMALS))
+        assertFalse(wouldExceedDecimals("12.3", SEPARATOR, FIAT_MAX_DECIMALS))
+        assertTrue(wouldExceedDecimals("12.34", SEPARATOR, FIAT_MAX_DECIMALS))
+    }
+
+    @Test
+    fun `keypad accepts up to eight decimals in dash mode`() {
+        assertFalse(wouldExceedDecimals("0.0012345", SEPARATOR, DASH_MAX_DECIMALS))
+        assertTrue(wouldExceedDecimals("0.00123456", SEPARATOR, DASH_MAX_DECIMALS))
+    }
+
+    @Test
+    fun `a dash-scale amount is never gated on the fiat limit`() {
+        // B: the frozen keypad. The text carried 8 decimals while the gate used 2, so every
+        // digit press returned early. The limit now comes from the mode that made the text.
+        val amount = dash("0.00123456")
+
+        assertEquals(DASH_MAX_DECIMALS, amount.maxDecimals)
+        assertFalse(
+            "a dash amount must not be gated at 2 places",
+            wouldExceedDecimals(amount.amountPart.dropLast(1), SEPARATOR, amount.maxDecimals)
+        )
+    }
+
+    // --------------------------------------------- comma-decimal locales (separator)
+
+    /**
+     * The device locale's separator is a DISPLAY concern. The keypad writes '.', and so must
+     * every value that is counted, gated or parsed -- otherwise on a comma-decimal locale
+     * (de, fr, es, it, pt, nl, pl, ru, be_BY ...) the gate looks for a ',' that is never
+     * there, finds no separator, and lets a fiat amount grow to 8 decimal places.
+     */
+    @Test
+    fun `the decimal gate keys off the separator the keypad inserts`() {
+        // A comma-locale user typing 12.34 writes '.', not ','.
+        assertTrue(wouldExceedDecimals("12.34", CANONICAL_SEPARATOR, FIAT_MAX_DECIMALS))
+        // Gating that same text on the locale's ',' finds nothing and waves it through.
+        assertFalse(wouldExceedDecimals("12.34", ',', FIAT_MAX_DECIMALS))
+    }
+
+    @Test
+    fun `fiat is held to two decimals on a comma-decimal locale`() {
+        // decimalSeparator = ',' (the device locale), input written with '.' by the keypad.
+        val amount = transferAmount("12.999999", true, BYN, ',', FIAT_FORMAT)
+
+        assertEquals("12.99", amount.inputValue)
+        assertEquals("12.99", amount.amountPart)
+        assertEquals(FIAT_MAX_DECIMALS, amount.maxDecimals)
+    }
+
+    @Test
+    fun `a partial dash entry survives on a comma-decimal locale`() {
+        // Counting "0.0" with ',' saw no fraction and sent it through the BigDecimal path,
+        // where stripTrailingZeros collapsed it to "0" and swallowed the user's decimal
+        // point. Counting canonically preserves it.
+        assertEquals("0.0 DASH", transferAmount("0.0", false, BYN, ',', FIAT_FORMAT).text)
+        assertEquals("0. DASH", transferAmount("0.", false, BYN, ',', FIAT_FORMAT).text)
+    }
+
+    @Test
+    fun `everything the formatter publishes is parseable regardless of locale`() {
+        // amountPart re-enters the keypad and inputValue reaches BigDecimal, Coin.parseCoin
+        // and Fiat.parseFiat. A locale separator in either would break all three.
+        val inputs = listOf("0", "0.", "0.0", "12", "12.3", "12.34", "12.999999", "1234.5678")
+        for (sep in listOf('.', ',')) {
+            for (input in inputs) {
+                for (isFiat in listOf(true, false)) {
+                    val amount = transferAmount(input, isFiat, BYN, sep, FIAT_FORMAT)
+                    assertFalse(
+                        "amountPart '${amount.amountPart}' ($input/$isFiat/sep=$sep) must not carry a comma",
+                        amount.amountPart.contains(',')
+                    )
+                    assertFalse(
+                        "inputValue '$${amount.inputValue}' ($input/$isFiat/sep=$sep) must not carry a comma",
+                        amount.inputValue.contains(',')
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `canonicalizeSeparator rewrites only the decimal mark and keeps the length`() {
+        assertEquals("12.34", canonicalizeSeparator("12,34", ','))
+        assertEquals("12.34", canonicalizeSeparator("12.34", '.'))
+        assertEquals("12,34".length, canonicalizeSeparator("12,34", ',').length)
+    }
+
+    @Test
+    fun `a localised fiat figure is canonicalised before the keypad reads it back`() {
+        // MonetaryFormat with a comma locale renders "12,34"; left as-is it would reach
+        // BigDecimal and Fiat.parseFiat, which both reject a comma.
+        val commaFormat = MonetaryFormat()
+            .withLocale(Locale.GERMANY)
+            .minDecimals(2)
+            .optionalDecimals()
+            .noCode()
+        val amount = transferAmount("12.34", true, "EUR", ',', commaFormat)
+
+        assertEquals("12.34", amount.amountPart)
+        assertNotNull(amount.amountPart.toBigDecimalOrNull())
+        assertSpansOnlyTheCurrencyLabel(amount)
+    }
+
+    // ------------------------------------------------------- fiat conversion overflow
+
+    @Test
+    fun `a conversion finer than two decimals is truncated, not rounded up`() {
+        assertEquals("0.00", truncateToDecimals("0.00123456", FIAT_MAX_DECIMALS))
+        assertEquals("12.99", truncateToDecimals("12.999999", FIAT_MAX_DECIMALS))
+        assertEquals("12.34", truncateToDecimals("12.34", FIAT_MAX_DECIMALS))
+    }
+
+    @Test
+    fun `fiat mode re-scales an over-precise conversion and reports it back`() {
+        // Fiat.parseFiat throws on anything finer than 4 places, and the keypad would refuse
+        // every further digit while the text still showed 2. The input value handed back has
+        // to be the re-scaled one, since the keypad and the transfer button read it again.
+        val amount = fiat("12.999999")
+
+        assertEquals("12.99", amount.inputValue)
+        assertEquals("12.99", amount.amountPart)
+        assertEquals(FIAT_MAX_DECIMALS, decimalCount(amount.inputValue, SEPARATOR))
+        assertTrue(amount.text.contains("12.99"))
+    }
+
+    @Test
+    fun `partial fiat input renders a zero instead of throwing`() {
+        for (input in listOf("", "0", "0.")) {
+            val amount = fiat(input)
+            assertNotNull("[$input] must produce a fiat value", amount.fiatAmount)
+        }
+    }
+
+    // -------------------------------------------------------------- round trip (B, C, D)
+
+    @Test
+    fun `fiat to dash to fiat round trip stays consistent`() {
+        // The reported reproduction: switching fiat -> dash -> fiat left the screen with a
+        // DASH-scale figure under a fiat label, an over-long span and a gate that refused
+        // every digit. Each leg must now agree with itself.
+        val first = fiat("12.34")
+        assertEquals(AmountMode.FIAT, first.mode)
+        assertEquals(FIAT_MAX_DECIMALS, first.maxDecimals)
+        assertSpansOnlyTheCurrencyLabel(first)
+
+        // dash leg, as the picker hands over a converted, 8-decimal value
+        val second = dash("0.05432100")
+        assertEquals(AmountMode.DASH, second.mode)
+        assertEquals(DASH_MAX_DECIMALS, second.maxDecimals)
+        // A full 8 decimals goes through the BigDecimal path, which strips trailing zeros --
+        // master's behaviour, preserved.
+        assertEquals("0.054321 DASH", second.text)
+        assertSpansOnlyTheCurrencyLabel(second)
+
+        // back to fiat, again with a converted value that is finer than cents
+        val third = fiat("12.3456789")
+        assertEquals(AmountMode.FIAT, third.mode)
+        assertEquals(FIAT_MAX_DECIMALS, third.maxDecimals)
+        assertEquals("12.34", third.inputValue)
+        assertEquals("12.34", third.amountPart)
+        assertFalse("must not carry the DASH label", third.text.contains("DASH"))
+        assertFalse("must not carry a stale USD label", third.text.contains("USD"))
+        assertSpansOnlyTheCurrencyLabel(third)
+    }
+}

--- a/wallet/src/de/schildbach/wallet/service/ExchangeIntegrationListProvider.kt
+++ b/wallet/src/de/schildbach/wallet/service/ExchangeIntegrationListProvider.kt
@@ -83,8 +83,9 @@ class ExchangeIntegrationListProvider @Inject constructor(
                     exchangeIntegrations
                 )
             ) {
-                // determine if we are connected
-                if (coinBaseRepository.isAuthenticated) {
+                // determine if we are connected -- suspending read, so a cold start can't
+                // report "not connected" before the stored token has been read back
+                if (coinBaseRepository.isUserAuthenticated()) {
                     // A failed account/address lookup must not hide Coinbase entirely: log why
                     // and add the row without an address, so a logged-in user still sees the
                     // integration instead of it silently vanishing from the list.

--- a/wallet/src/de/schildbach/wallet/ui/buy_sell/BuyAndSellViewModel.kt
+++ b/wallet/src/de/schildbach/wallet/ui/buy_sell/BuyAndSellViewModel.kt
@@ -117,6 +117,17 @@ class BuyAndSellViewModel @Inject constructor(
             }
             .launchIn(viewModelScope)
 
+        // The seed in _uiState can be a startup-race `false`: the stored Coinbase token is
+        // read back on an IO dispatcher, which may not have happened yet. Track the state
+        // so the row and the balance catch up when it lands (MO-995).
+        coinBaseRepository.isAuthenticatedFlow
+            .onEach { isAuthenticated ->
+                _uiState.update { it.copy(isCoinbaseAuthenticated = isAuthenticated) }
+                updateServicesStatus()
+                updateBalances()
+            }
+            .launchIn(viewModelScope)
+
         viewModelScope.launch {
             topperClient.refreshSupportedAssets()
             topperClient.refreshPaymentMethods()

--- a/wallet/src/de/schildbach/wallet/ui/main/shortcuts/ShortcutsViewModel.kt
+++ b/wallet/src/de/schildbach/wallet/ui/main/shortcuts/ShortcutsViewModel.kt
@@ -84,10 +84,17 @@ class ShortcutsViewModel @Inject constructor(
     var shortcuts by mutableStateOf(getPresetShortcuts().take(maxShortcuts))
     var showShortcutInfo by mutableStateOf(false)
 
-    val isCoinbaseAuthenticated: Boolean
-        get() = coinBaseRepository.isAuthenticated
+    // Tracked rather than read through to the repository on every tap: the repository's
+    // cached flag can still be a startup-race `false`, and a wrong answer here routes the
+    // user to the "connect Coinbase" flow when they are already connected (MO-995).
+    var isCoinbaseAuthenticated by mutableStateOf(false)
+        private set
 
     init {
+        coinBaseRepository.isAuthenticatedFlow
+            .onEach { isCoinbaseAuthenticated = it }
+            .launchIn(viewModelScope)
+
         shortcutProvider.customShortcuts
             .onEach { Log.i("SHORTCUTS", "size: ${it.size}") }
             .filterNot { it.isEmpty() }


### PR DESCRIPTION
Jira: [MO-1028](https://dashpay.atlassian.net/browse/MO-1028) — split from MO-995 comment 91129.

Everything here is **pre-existing on `master`**, not a regression from the v11.9.0 merge. QA found it on a release build of a feature branch; the responsible code was identical on master.

## 1. Transfer screen — four QA symptoms, one root cause

| # | Reported | Symptom |
| --- | --- | --- |
| A | MO-995 c91098 #1 | Tapping the fiat option crashes the screen |
| B | MO-995 c91129 #3 | After fiat → dash → fiat the amount can't be changed; number keys dead, backspace works |
| C | MO-995 c91129 #4 | With a non-USD local currency (BYN) the fiat option shows USD on first open |
| D | MO-995 c91129 #5 | Small "USD" label next to an amount actually in the local currency |

`EnterAmountToTransferFragment` built the currency picker once in `onViewCreated` from a synchronous read of `localCurrencyCode`, which is only ever assigned asynchronously from `WalletUIConfig` — so it kept the seeded `USD` default (**C**). That stale *label* was then passed to `applyNewValue` as the formatting mode, which branched on `localCurrencyCode == monetaryCode`. A stale `"USD"` never matched a real `"BYN"`, so fiat amounts took the DASH branch: DASH-scale digits under a USD label (**D**), a keypad gated at 2 decimals that refused every digit (**B**), and span bounds from the other branch giving `from > to`, so `Spannable.setSpan` threw (**A**).

Fix — address the cause, not just the crash:
- `applyNewValue` branches on `isFiatSelected`, never on a currency label.
- The selected currency is observed; the picker and rendered amount rebuild on every emission.
- The text, its currency-label span, and the keypad's decimal limit are produced together by one pure function (`TransferAmountFormat.kt`), so they cannot describe different amounts. A bounds check degrades to an unstyled amount rather than crashing — as a belt, not the fix.

## 2. "I need to link Coinbase every time" (c91129 #2)

- `TokenAuthenticator` cleared **both** tokens on any non-success refresh, so one timeout or 5xx silently de-authenticated the user. Now clears only on a definitive OAuth2 rejection of the grant (400/401), never on transport failure. Also drops two `println` calls that printed tokens to logcat.
- `CoinBaseRepository.isAuthenticated` was a non-volatile `var` seeded `false`, written only from a `Dispatchers.IO` collector. Its four synchronous readers could read `false` before the first emission and without a memory barrier might never observe the write. Now `StateFlow`-backed, with a flow for reactive consumers and a suspending authoritative read; all four readers react to the emission.

## 3. Found while fixing

- **Locale-formatted amounts sent to the Coinbase API — live, money-moving.** `buyDash()` formatted the deposit and buy-order amounts with `Constants.SEND_PAYMENT_LOCAL_FORMAT` (`withLocale(deviceLocale)`), rendering `"12,34"` on every comma-decimal locale — including **be_BY, the tester's own** — straight into a bank deposit body and the buy-order `quote_size`. The buy button is not hidden, so this ships. Now uses a locale-independent `CoinbaseConstants.API_AMOUNT_FORMAT`. Audited every other wire amount: `SendTransactionToWalletParams.amount` comes from `Coin.toPlainString()`, verified locale-independent.
- **Decimal separator mixing.** The keypad inserted `'.'` while the gate counted with the locale separator, so on comma-decimal locales the limit never fired, `"0.0"` collapsed to `"0"`, and MAX in DASH mode produced `"1,5"` leaving the transfer button permanently disabled. `'.'` is now canonical for everything stored, counted, gated or parsed. Resolves the two standing `// TODO`s in `applyCoinbaseExchangeRate`.
- **`GenericUtils.formatFiatWithoutComma` mis-read grouped amounts.** Its rule was "contains a dot and a comma → strip the commas", turning `"1.234,56"` into `"1.23456"` — a 1000× error. The decimal mark is now decided, not guessed: it occurs at most once, so the last separator is the decimal mark precisely when that character appears once. Ambiguous single-separator input keeps its existing reading, so output is byte-identical for every currently reachable input.
- **Convert screen** (unreachable behind `convertBtn.isVisible = false`) gets the same span fix, and `toDashValue` no longer has identical `if`/`else` branches that scaled a local-currency amount by the crypto rate.

## Verification

- `:integrations:coinbase:compileDebugKotlin`, `:integrations:coinbase:testDebugUnitTest`, `:common:testDebugUnitTest`, `:wallet:compile_testNet3DebugKotlin` — all pass, re-run after rebasing onto `520555d37`.
- **56 unit tests, up from 7.** Covers span bounds, mode selection, decimal gating, BYN with a stale/absent currency emission, the fiat → dash → fiat round trip, conversions finer than 2 decimals, comma-decimal locales, separator normalisation, exchange-rate semantics, and wire-format locale independence.
- ktlint is not applied to `coinbase`/`common`/`wallet` (only exploredash, maya, uphold, crowdnode), so `ktlintFormat` is a no-op here; the 120-char limit was enforced by hand.

**Not verified on device.** QA should re-check A–D and the re-link behaviour on a release build with a non-USD, comma-decimal locale — BYN reproduces both classes.

## Reviewer note

The first commit, `fix(common): repair two compile errors that block every module`, is **unrelated** to MO-1028 — `master` did not compile (duplicate `Configuration` import in `MenuItem.kt`; `ActionItem.kt` missing the `subtitleMaxLines` three maya call sites pass). It's kept separate so it can be dropped or picked independently. An equivalent `ActionItem`/`MenuItem` fix is currently sitting uncommitted on `master` from parallel work — functionally identical, differing only in parameter position and KDoc. **If that lands on master first, drop commit 1 from this branch.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Action items can now display subtitles across multiple lines before truncating.

- **Bug Fixes**
  - Improved Coinbase amount formatting across regional locales.
  - Corrected fiat and cryptocurrency conversion calculations.
  - Prevented amount-display crashes when converted values use different decimal lengths.
  - Coinbase authentication status now updates reliably after startup and connection changes.
  - Preserved credentials during temporary network failures while clearing them after rejected authentication.
  - Improved handling of decimal limits and partial amount entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->