### PR TITLE
fix(dashspend): recover a payment whose merchant reply is lost

### DIFF
--- a/common/src/main/java/org/dash/wallet/common/services/SendPaymentService.kt
+++ b/common/src/main/java/org/dash/wallet/common/services/SendPaymentService.kt
@@ -20,6 +20,7 @@ package org.dash.wallet.common.services
 import org.bitcoinj.core.Address
 import org.bitcoinj.core.Coin
 import org.bitcoinj.core.InsufficientMoneyException
+import org.bitcoinj.core.Sha256Hash
 import org.bitcoinj.core.Transaction
 import org.bitcoinj.core.TransactionOutput
 import org.bitcoinj.uri.BitcoinURI
@@ -30,6 +31,15 @@ import java.util.function.Predicate
 
 class LeftoverBalanceException(missing: Coin, message: String) : InsufficientMoneyException(missing, message)
 class DirectPayException(message: String) : Exception(message)
+
+/**
+ * Thrown when a BIP70 payment was submitted but the merchant's response was lost, so the
+ * transaction may or may not have been broadcast. The transaction's inputs stay locked while
+ * the wallet keeps checking the network in the background; once the transaction is seen it is
+ * committed as sent, and if it never appears the inputs are released.
+ */
+class PaymentSubmissionPendingException(val txId: Sha256Hash, cause: Throwable?) :
+    Exception("Payment submission result unknown for $txId; verification pending", cause)
 
 interface SendPaymentService {
     @Throws(LeftoverBalanceException::class)

--- a/common/src/main/java/org/dash/wallet/common/services/TransactionMetadataProvider.kt
+++ b/common/src/main/java/org/dash/wallet/common/services/TransactionMetadataProvider.kt
@@ -63,6 +63,12 @@ interface TransactionMetadataProvider {
     suspend fun updateGiftCardMetadata(giftCard: GiftCard)
     suspend fun updateGiftCardBarcode(txId: Sha256Hash, index: Int, barcodeValue: String, barcodeFormat: BarcodeFormat)
 
+    /**
+     * Removes the gift cards recorded for a transaction. Used when a payment that was saved
+     * optimistically turns out never to have reached the merchant, so the cards never existed.
+     */
+    suspend fun removeGiftCards(txId: Sha256Hash)
+
     suspend fun getAllTransactionMetadata(): List<TransactionMetadata>
 
     fun observePresentableMetadata(): Flow<Map<Sha256Hash, PresentableTxMetadata>>

--- a/common/src/main/java/org/dash/wallet/common/services/TransactionMetadataProvider.kt
+++ b/common/src/main/java/org/dash/wallet/common/services/TransactionMetadataProvider.kt
@@ -64,10 +64,14 @@ interface TransactionMetadataProvider {
     suspend fun updateGiftCardBarcode(txId: Sha256Hash, index: Int, barcodeValue: String, barcodeFormat: BarcodeFormat)
 
     /**
-     * Removes the gift cards recorded for a transaction. Used when a payment that was saved
-     * optimistically turns out never to have reached the merchant, so the cards never existed.
+     * Discards everything recorded locally about a transaction: its metadata, any gift cards
+     * saved against it, and any changes still queued for Dash Platform.
+     *
+     * For payments recorded optimistically that turn out never to have reached the merchant, so
+     * the transaction will never exist. Implementations must ignore a transaction that is present
+     * in the wallet, since that would be real user data.
      */
-    suspend fun removeGiftCards(txId: Sha256Hash)
+    suspend fun forgetTransaction(txId: Sha256Hash)
 
     suspend fun getAllTransactionMetadata(): List<TransactionMetadata>
 

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -109,6 +109,8 @@
     <string name="payment_request_problem_title">Payment was not acknowledged</string>
     <string name="payment_protocol_default_error_title">Payment error</string>
     <string name="payment_request_problem_message">Your payment could not be processed by the server, please inquire with the merchant</string>
+    <string name="payment_submission_pending_title">Payment status unknown</string>
+    <string name="payment_submission_pending_message">The payment was sent, but we did not receive a confirmation from the merchant. Your wallet will keep checking the network and will show the transaction as sent once it is found. Please wait before sending this payment again.</string>
     <string name="exchange_rate_not_found">Could not find exchange rate.</string>
     <string name="send_coins_fragment_hint_replaying">Currently payments are not possible because the wallet is not fully synced with the network</string>
 

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/explore/GiftCardDao.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/explore/GiftCardDao.kt
@@ -38,6 +38,10 @@ interface GiftCardDao {
     @Update(entity = GiftCard::class)
     suspend fun updateGiftCard(giftCard: GiftCard): Int
 
+    /** Removes every card of an order, used when its payment turns out never to have been sent. */
+    @Query("DELETE FROM gift_cards WHERE txId = :txId")
+    suspend fun removeCardsForTransaction(txId: Sha256Hash)
+
     @Query("SELECT COUNT(*) FROM gift_cards WHERE txId = :txId")
     suspend fun getCardCountForTransaction(txId: Sha256Hash): Int
 

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/explore/GiftCardDao.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/explore/GiftCardDao.kt
@@ -38,10 +38,6 @@ interface GiftCardDao {
     @Update(entity = GiftCard::class)
     suspend fun updateGiftCard(giftCard: GiftCard): Int
 
-    /** Removes every card of an order, used when its payment turns out never to have been sent. */
-    @Query("DELETE FROM gift_cards WHERE txId = :txId")
-    suspend fun removeCardsForTransaction(txId: Sha256Hash)
-
     @Query("SELECT COUNT(*) FROM gift_cards WHERE txId = :txId")
     suspend fun getCardCountForTransaction(txId: Sha256Hash): Int
 

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/dashspend/DashSpendViewModel.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/dashspend/DashSpendViewModel.kt
@@ -33,7 +33,6 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.bitcoinj.core.Coin
 import org.bitcoinj.core.Sha256Hash
@@ -549,7 +548,12 @@ class DashSpendViewModel @Inject constructor(
         providers[provider]?.logout()
     }
 
-    fun saveGiftCardDummy(txId: Sha256Hash, giftCards: List<GiftCardInfo>) {
+    /**
+     * Records the ordered cards against [txId]. Suspends until the rows are written: the caller
+     * may be about to dismiss this screen, and on the payment-pending path nothing else holds the
+     * order details, so losing the write would strand the purchase with no way back to the order.
+     */
+    suspend fun saveGiftCardDummy(txId: Sha256Hash, giftCards: List<GiftCardInfo>) {
         log.info("saving {} dummy gift cards: {}", giftCards.size, txId)
         var index = 0
         val giftCard = giftCards.map {
@@ -563,9 +567,7 @@ class DashSpendViewModel @Inject constructor(
                 index = index++
             )
         }
-        viewModelScope.launch {
-            giftCardDao.insertGiftCards(giftCard)
-        }
+        giftCardDao.insertGiftCards(giftCard)
     }
 
     fun needsCrowdNodeWarning(dashAmount: Coin): Boolean {

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/dashspend/DashSpendViewModel.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/dashspend/DashSpendViewModel.kt
@@ -549,6 +549,22 @@ class DashSpendViewModel @Inject constructor(
     }
 
     /**
+     * Records a purchase whose payment result is unknown, so it looks like any other gift card
+     * purchase if the payment did reach the merchant. The success path marks the transaction from
+     * [createSendingRequestFromDashUri]; that never runs when submission ends in
+     * PaymentSubmissionPendingException, so do both here. If the wallet later proves the payment
+     * was never sent, PendingDirectPaymentVerifier discards all of it again.
+     */
+    suspend fun saveGiftCardsForPendingPayment(txId: Sha256Hash, giftCards: List<GiftCardInfo>) {
+        transactionMetadata.markGiftCardTransaction(
+            txId,
+            selectedProvider?.serviceName ?: ServiceName.CTXSpend,
+            _giftCardMerchant.value?.logoLocation
+        )
+        saveGiftCardDummy(txId, giftCards)
+    }
+
+    /**
      * Records the ordered cards against [txId]. Suspends until the rows are written: the caller
      * may be about to dismiss this screen, and on the payment-pending path nothing else holds the
      * order details, so losing the write would strand the purchase with no way back to the order.

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/dashspend/dialogs/PurchaseGiftCardConfirmDialog.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/dashspend/dialogs/PurchaseGiftCardConfirmDialog.kt
@@ -478,8 +478,15 @@ class PurchaseGiftCardConfirmDialog : ComposeBottomSheet() {
             }
             val transactionId = createSendingRequestFromDashUri(dashPaymentUrl, data)
             transactionId?.let {
-                enterAmountViewModel.clearSavedState()
-                viewModel.saveGiftCardDummy(transactionId, data)
+                // saveGiftCardDummy awaits the insert, so a database failure would otherwise
+                // abort this coroutine and leave the user on the purchase screen with no
+                // feedback, even though the payment succeeded.
+                try {
+                    viewModel.saveGiftCardDummy(transactionId, data)
+                    enterAmountViewModel.clearSavedState()
+                } catch (e: Exception) {
+                    log.error("could not save gift cards for {}", transactionId, e)
+                }
                 showGiftCardDetailsDialog(transactionId)
             }
         }
@@ -513,9 +520,13 @@ class PurchaseGiftCardConfirmDialog : ComposeBottomSheet() {
             // with the only copy of the order details. If the wallet later proves the payment
             // never arrived, PendingDirectPaymentVerifier removes these rows again.
             try {
-                enterAmountViewModel.clearSavedState()
+                // Persist first: clearing the entered amount discards the last copy of this
+                // order held anywhere, so it must not happen until the rows are written.
                 viewModel.saveGiftCardsForPendingPayment(ex.txId, giftCards)
+                enterAmountViewModel.clearSavedState()
             } catch (e: Exception) {
+                // Keep the saved state so the order details are not lost as well, and still tell
+                // the user the payment status is unknown - that matters more than this failure.
                 log.error("could not save gift cards for pending payment {}", ex.txId, e)
             }
             hideLoading()

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/dashspend/dialogs/PurchaseGiftCardConfirmDialog.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/dashspend/dialogs/PurchaseGiftCardConfirmDialog.kt
@@ -514,7 +514,7 @@ class PurchaseGiftCardConfirmDialog : ComposeBottomSheet() {
             // never arrived, PendingDirectPaymentVerifier removes these rows again.
             try {
                 enterAmountViewModel.clearSavedState()
-                viewModel.saveGiftCardDummy(ex.txId, giftCards)
+                viewModel.saveGiftCardsForPendingPayment(ex.txId, giftCards)
             } catch (e: Exception) {
                 log.error("could not save gift cards for pending payment {}", ex.txId, e)
             }

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/dashspend/dialogs/PurchaseGiftCardConfirmDialog.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/dashspend/dialogs/PurchaseGiftCardConfirmDialog.kt
@@ -69,6 +69,7 @@ import org.bitcoinj.uri.BitcoinURIParseException
 import org.dash.wallet.common.data.ServiceName
 import org.dash.wallet.common.services.AuthenticationManager
 import org.dash.wallet.common.services.DirectPayException
+import org.dash.wallet.common.services.PaymentSubmissionPendingException
 import org.dash.wallet.common.ui.components.DashButton
 import org.dash.wallet.common.ui.components.EnterAmount
 import org.dash.wallet.common.ui.components.LocalDashColors
@@ -82,6 +83,7 @@ import org.dash.wallet.common.ui.dialogs.MinimumBalanceDialog
 import org.dash.wallet.common.ui.enter_amount.EnterAmountViewModel
 import org.dash.wallet.common.util.Constants
 import org.dash.wallet.features.exploredash.R
+import org.dash.wallet.features.exploredash.data.dashspend.model.GiftCardInfo
 import org.dash.wallet.features.exploredash.repository.CTXSpendException
 import org.dash.wallet.features.exploredash.ui.dashspend.DashSpendViewModel
 import org.dash.wallet.features.exploredash.ui.dashspend.GiftCardPurchaseMode
@@ -474,7 +476,7 @@ class PurchaseGiftCardConfirmDialog : ComposeBottomSheet() {
                 }
                 return@launch
             }
-            val transactionId = createSendingRequestFromDashUri(dashPaymentUrl)
+            val transactionId = createSendingRequestFromDashUri(dashPaymentUrl, data)
             transactionId?.let {
                 enterAmountViewModel.clearSavedState()
                 viewModel.saveGiftCardDummy(transactionId, data)
@@ -483,7 +485,10 @@ class PurchaseGiftCardConfirmDialog : ComposeBottomSheet() {
         }
     }
 
-    private suspend fun createSendingRequestFromDashUri(url: String): Sha256Hash? {
+    private suspend fun createSendingRequestFromDashUri(
+        url: String,
+        giftCards: List<GiftCardInfo>
+    ): Sha256Hash? {
         return try {
             viewModel.createSendingRequestFromDashUri(url)
         } catch (x: InsufficientMoneyException) {
@@ -494,6 +499,31 @@ class PurchaseGiftCardConfirmDialog : ComposeBottomSheet() {
                     R.drawable.ic_error,
                     getString(R.string.insufficient_money_title),
                     getString(R.string.insufficient_money_msg),
+                    getString(R.string.button_close)
+                ).show(requireActivity())
+            }
+            null
+        } catch (ex: PaymentSubmissionPendingException) {
+            // The payment left the device but the merchant's answer was lost. The wallet keeps
+            // checking the network in the background; the transaction shows up as sent once it is
+            // found, and its inputs are released if it never appears. Don't let the user retry now.
+            log.warn("purchaseGiftCard submission result unknown for {}", ex.txId, ex)
+            // The transaction is fully built and its id is final, so record the order now. The
+            // merchant may well have received the payment, and this screen is about to go away
+            // with the only copy of the order details. If the wallet later proves the payment
+            // never arrived, PendingDirectPaymentVerifier removes these rows again.
+            try {
+                enterAmountViewModel.clearSavedState()
+                viewModel.saveGiftCardDummy(ex.txId, giftCards)
+            } catch (e: Exception) {
+                log.error("could not save gift cards for pending payment {}", ex.txId, e)
+            }
+            hideLoading()
+            if (isAdded) {
+                AdaptiveDialog.create(
+                    R.drawable.ic_warning,
+                    getString(R.string.payment_submission_pending_title),
+                    getString(R.string.payment_submission_pending_message),
                     getString(R.string.button_close)
                 ).show(requireActivity())
             }

--- a/wallet/src/de/schildbach/wallet/data/PendingDirectPaymentConfig.kt
+++ b/wallet/src/de/schildbach/wallet/data/PendingDirectPaymentConfig.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.wallet.data
+
+import android.content.Context
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.bitcoinj.core.Sha256Hash
+import org.bitcoinj.core.Utils
+import org.dash.wallet.common.WalletDataProvider
+import org.dash.wallet.common.data.BaseConfig
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
+import org.slf4j.LoggerFactory
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * A signed BIP70 payment whose HTTP submission failed ambiguously: the request may or may not
+ * have reached the merchant, so the transaction may or may not have been broadcast.
+ *
+ * Kept on disk because dashj's output locks are in-memory only; on the next start the inputs are
+ * re-locked and verification resumes (see PendingDirectPaymentVerifier).
+ */
+data class PendingDirectPayment(
+    val txId: Sha256Hash,
+    val txBytes: ByteArray,
+    val paymentUrl: String,
+    val serviceName: String?,
+    val createdAt: Long
+) {
+    fun toJson(): JSONObject = JSONObject()
+        .put(KEY_TX_ID, txId.toString())
+        .put(KEY_TX, Utils.HEX.encode(txBytes))
+        .put(KEY_PAYMENT_URL, paymentUrl)
+        .put(KEY_SERVICE_NAME, serviceName ?: JSONObject.NULL)
+        .put(KEY_CREATED_AT, createdAt)
+
+    companion object {
+        private const val KEY_TX_ID = "txId"
+        private const val KEY_TX = "tx"
+        private const val KEY_PAYMENT_URL = "paymentUrl"
+        private const val KEY_SERVICE_NAME = "serviceName"
+        private const val KEY_CREATED_AT = "createdAt"
+
+        fun fromJson(json: JSONObject): PendingDirectPayment = PendingDirectPayment(
+            txId = Sha256Hash.wrap(json.getString(KEY_TX_ID)),
+            txBytes = Utils.HEX.decode(json.getString(KEY_TX)),
+            paymentUrl = json.getString(KEY_PAYMENT_URL),
+            serviceName = if (json.isNull(KEY_SERVICE_NAME)) null else json.getString(KEY_SERVICE_NAME),
+            createdAt = json.getLong(KEY_CREATED_AT)
+        )
+    }
+}
+
+@Singleton
+// Persists BIP70 payments whose submission result is unknown, keyed by transaction id.
+open class PendingDirectPaymentConfig @Inject constructor(
+    context: Context,
+    walletDataProvider: WalletDataProvider
+) : BaseConfig(context, PREFERENCES_NAME, walletDataProvider) {
+    companion object {
+        const val PREFERENCES_NAME = "pending_direct_payments"
+        val PENDING_PAYMENTS = stringPreferencesKey("pending_payments")
+        private val log = LoggerFactory.getLogger(PendingDirectPaymentConfig::class.java)
+    }
+
+    private val mutex = Mutex()
+
+    open suspend fun getAll(): List<PendingDirectPayment> = decode(get(PENDING_PAYMENTS))
+
+    open suspend fun add(payment: PendingDirectPayment) = mutex.withLock {
+        val payments = getAll().filter { it.txId != payment.txId } + payment
+        set(PENDING_PAYMENTS, encode(payments))
+    }
+
+    open suspend fun remove(txId: Sha256Hash) = mutex.withLock {
+        val payments = getAll()
+        val remaining = payments.filter { it.txId != txId }
+        if (remaining.size != payments.size) {
+            set(PENDING_PAYMENTS, encode(remaining))
+        }
+    }
+
+    private fun encode(payments: List<PendingDirectPayment>): String {
+        val array = JSONArray()
+        payments.forEach { array.put(it.toJson()) }
+        return array.toString()
+    }
+
+    private fun decode(value: String?): List<PendingDirectPayment> {
+        if (value.isNullOrEmpty()) {
+            return emptyList()
+        }
+        return try {
+            val array = JSONArray(value)
+            (0 until array.length()).map { PendingDirectPayment.fromJson(array.getJSONObject(it)) }
+        } catch (e: JSONException) {
+            log.error("could not parse pending direct payments, discarding: {}", value, e)
+            emptyList()
+        } catch (e: IllegalArgumentException) {
+            log.error("could not parse pending direct payments, discarding: {}", value, e)
+            emptyList()
+        }
+    }
+}

--- a/wallet/src/de/schildbach/wallet/database/AppDatabase.kt
+++ b/wallet/src/de/schildbach/wallet/database/AppDatabase.kt
@@ -21,6 +21,7 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import de.schildbach.wallet.database.dao.*
+import de.schildbach.wallet.database.dao.TransactionRecordsDao
 import de.schildbach.wallet.database.dao.TxGroupCacheDao
 import de.schildbach.wallet.database.entity.DashPayContactRequest
 import de.schildbach.wallet.database.entity.DashPayProfile
@@ -91,4 +92,5 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun txDisplayCacheDao(): TxDisplayCacheDao
     abstract fun txGroupCacheDao(): TxGroupCacheDao
     abstract fun swapOrderDao(): SwapOrderDao
+    abstract fun transactionRecordsDao(): TransactionRecordsDao
 }

--- a/wallet/src/de/schildbach/wallet/database/dao/TransactionMetadataChangeCacheDao.kt
+++ b/wallet/src/de/schildbach/wallet/database/dao/TransactionMetadataChangeCacheDao.kt
@@ -34,6 +34,13 @@ interface TransactionMetadataChangeCacheDao {
     @Query("delete from transaction_metadata_cache where id in (:idList)")
     suspend fun removeByIds(idList: List<Long>)
 
+    /**
+     * Drops every queued platform change for a transaction, so metadata about a transaction that
+     * was never broadcast is not published.
+     */
+    @Query("DELETE FROM transaction_metadata_cache WHERE txId = :txId")
+    suspend fun removeByTxId(txId: Sha256Hash)
+
     @Query("SELECT * FROM transaction_metadata_cache ORDER BY id")
     suspend fun load(): List<TransactionMetadataCacheItem>
 

--- a/wallet/src/de/schildbach/wallet/database/dao/TransactionMetadataChangeCacheDao.kt
+++ b/wallet/src/de/schildbach/wallet/database/dao/TransactionMetadataChangeCacheDao.kt
@@ -34,13 +34,6 @@ interface TransactionMetadataChangeCacheDao {
     @Query("delete from transaction_metadata_cache where id in (:idList)")
     suspend fun removeByIds(idList: List<Long>)
 
-    /**
-     * Drops every queued platform change for a transaction, so metadata about a transaction that
-     * was never broadcast is not published.
-     */
-    @Query("DELETE FROM transaction_metadata_cache WHERE txId = :txId")
-    suspend fun removeByTxId(txId: Sha256Hash)
-
     @Query("SELECT * FROM transaction_metadata_cache ORDER BY id")
     suspend fun load(): List<TransactionMetadataCacheItem>
 

--- a/wallet/src/de/schildbach/wallet/database/dao/TransactionMetadataDao.kt
+++ b/wallet/src/de/schildbach/wallet/database/dao/TransactionMetadataDao.kt
@@ -38,6 +38,10 @@ interface TransactionMetadataDao {
     @Query("SELECT * FROM transaction_metadata")
     suspend fun load(): List<TransactionMetadata>
 
+    /** Drops the metadata of a transaction that turned out never to have existed. */
+    @Query("DELETE FROM transaction_metadata WHERE txid = :txId")
+    suspend fun remove(txId: Sha256Hash)
+
     @Query("SELECT COUNT(1) FROM transaction_metadata WHERE txid = :txId;")
     suspend fun exists(txId: Sha256Hash): Boolean
 

--- a/wallet/src/de/schildbach/wallet/database/dao/TransactionMetadataDao.kt
+++ b/wallet/src/de/schildbach/wallet/database/dao/TransactionMetadataDao.kt
@@ -38,10 +38,6 @@ interface TransactionMetadataDao {
     @Query("SELECT * FROM transaction_metadata")
     suspend fun load(): List<TransactionMetadata>
 
-    /** Drops the metadata of a transaction that turned out never to have existed. */
-    @Query("DELETE FROM transaction_metadata WHERE txid = :txId")
-    suspend fun remove(txId: Sha256Hash)
-
     @Query("SELECT COUNT(1) FROM transaction_metadata WHERE txid = :txId;")
     suspend fun exists(txId: Sha256Hash): Boolean
 

--- a/wallet/src/de/schildbach/wallet/database/dao/TransactionRecordsDao.kt
+++ b/wallet/src/de/schildbach/wallet/database/dao/TransactionRecordsDao.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.wallet.database.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Transaction
+import org.bitcoinj.core.Sha256Hash
+
+/**
+ * Erases every local record of a single transaction. The deletes span three tables, so they live
+ * on one DAO to run inside a single Room transaction: a partial cleanup would leave rows behind
+ * with nothing left to retry them.
+ *
+ * Only for transactions that were recorded optimistically and turned out never to have been
+ * broadcast. Callers must confirm the wallet does not hold the transaction first.
+ */
+@Dao
+interface TransactionRecordsDao {
+    @Query("SELECT COUNT(*) FROM gift_cards WHERE txId = :txId")
+    suspend fun countGiftCards(txId: Sha256Hash): Int
+
+    @Query("DELETE FROM gift_cards WHERE txId = :txId")
+    suspend fun removeGiftCards(txId: Sha256Hash)
+
+    /** Queued Dash Platform changes; dropping these stops the metadata being published. */
+    @Query("DELETE FROM transaction_metadata_cache WHERE txId = :txId")
+    suspend fun removeQueuedMetadataChanges(txId: Sha256Hash)
+
+    @Query("DELETE FROM transaction_metadata WHERE txid = :txId")
+    suspend fun removeMetadata(txId: Sha256Hash)
+
+    /**
+     * Drops the gift cards, the queued platform changes and the metadata together.
+     * Queued changes go before the metadata so a concurrent publish cannot re-add it.
+     *
+     * @return how many gift cards were removed
+     */
+    @Transaction
+    suspend fun forgetTransaction(txId: Sha256Hash): Int {
+        val cards = countGiftCards(txId)
+        removeGiftCards(txId)
+        removeQueuedMetadataChanges(txId)
+        removeMetadata(txId)
+        return cards
+    }
+}

--- a/wallet/src/de/schildbach/wallet/di/AppModule.kt
+++ b/wallet/src/de/schildbach/wallet/di/AppModule.kt
@@ -32,6 +32,7 @@ import de.schildbach.wallet.WalletApplication
 import de.schildbach.wallet.data.CoinJoinConfig
 import de.schildbach.wallet.database.entity.BlockchainIdentityConfig
 import de.schildbach.wallet.payments.ConfirmTransactionLauncher
+import de.schildbach.wallet.payments.PendingDirectPaymentVerifier
 import de.schildbach.wallet.payments.SendCoinsTaskRunner
 import de.schildbach.wallet.security.SecurityFunctions
 import de.schildbach.wallet.service.*
@@ -115,9 +116,23 @@ abstract class AppModule {
             coinJoinService: CoinJoinService,
             identityRepository: IdentityRepository,
             platformRepo: PlatformRepo,
-            transactionMetadataProvider: TransactionMetadataProvider
+            transactionMetadataProvider: TransactionMetadataProvider,
+            pendingPaymentVerifier: PendingDirectPaymentVerifier
         ): SendPaymentService {
-            val realService = SendCoinsTaskRunner(walletData, walletApplication, securityFunctions, packageInfoProvider, analyticsService, identityConfig, coinJoinConfig, coinJoinService, identityRepository, platformRepo, transactionMetadataProvider)
+            val realService = SendCoinsTaskRunner(
+                walletData,
+                walletApplication,
+                securityFunctions,
+                packageInfoProvider,
+                analyticsService,
+                identityConfig,
+                coinJoinConfig,
+                coinJoinService,
+                identityRepository,
+                platformRepo,
+                transactionMetadataProvider,
+                pendingPaymentVerifier
+            )
 
             return if (BuildConfig.FLAVOR.lowercase() == "prod") {
                 realService

--- a/wallet/src/de/schildbach/wallet/di/DatabaseModule.kt
+++ b/wallet/src/de/schildbach/wallet/di/DatabaseModule.kt
@@ -27,6 +27,7 @@ import dagger.hilt.components.SingletonComponent
 import de.schildbach.wallet.database.AppDatabase
 import de.schildbach.wallet.database.AppDatabaseMigrations
 import de.schildbach.wallet.database.dao.*
+import de.schildbach.wallet.database.dao.TransactionRecordsDao
 import de.schildbach.wallet.database.dao.TxGroupCacheDao
 import org.dash.wallet.features.exploredash.data.explore.GiftCardDao
 import org.dash.wallet.integrations.maya.data.SwapOrderDao
@@ -84,6 +85,11 @@ object DatabaseModule {
     @Provides
     fun provideGiftCardDao(appDatabase: AppDatabase): GiftCardDao {
         return appDatabase.giftCardDao()
+    }
+
+    @Provides
+    fun provideTransactionRecordsDao(appDatabase: AppDatabase): TransactionRecordsDao {
+        return appDatabase.transactionRecordsDao()
     }
 
     // DashPay

--- a/wallet/src/de/schildbach/wallet/payments/PendingDirectPaymentVerifier.kt
+++ b/wallet/src/de/schildbach/wallet/payments/PendingDirectPaymentVerifier.kt
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.wallet.payments
+
+import androidx.annotation.VisibleForTesting
+import de.schildbach.wallet.WalletApplication
+import de.schildbach.wallet.data.PendingDirectPayment
+import de.schildbach.wallet.data.PendingDirectPaymentConfig
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.bitcoinj.core.Context
+import org.bitcoinj.core.Sha256Hash
+import org.bitcoinj.core.Transaction
+import org.bitcoinj.core.TransactionConfidence
+import org.bitcoinj.wallet.Wallet
+import org.dash.wallet.common.WalletDataProvider
+import org.dash.wallet.common.data.NetworkStatus
+import org.dash.wallet.common.services.BlockchainStateProvider
+import org.dash.wallet.common.services.TransactionMetadataProvider
+import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Tracks BIP70 payments whose HTTP submission failed after the request may already have reached
+ * the merchant (connection dropped mid-response, read timeout, ...). The merchant may have
+ * broadcast the transaction, so it can be neither treated as sent nor as failed.
+ *
+ * While a payment is pending its inputs are locked in the wallet so a retry cannot build a
+ * conflicting transaction. The verifier then watches the network, independently of the UI that
+ * started the payment:
+ *  - as soon as the transaction is seen (relayed by peers, InstantSend-locked, or mined) it is
+ *    committed to the wallet, its inputs are unlocked and it is (re)broadcast;
+ *  - if the wallet has been connected and fully synced for a while and the transaction still
+ *    has not appeared, the merchant never received it: the inputs are released.
+ *
+ * Pending payments are persisted so the locks and the verification survive process death;
+ * [resume] must be called once the wallet is available (the blockchain service does this).
+ */
+@Singleton
+class PendingDirectPaymentVerifier @Inject constructor(
+    private val walletData: WalletDataProvider,
+    private val walletApplication: WalletApplication,
+    private val blockchainStateProvider: BlockchainStateProvider,
+    private val metadataProvider: TransactionMetadataProvider,
+    private val config: PendingDirectPaymentConfig
+) {
+    companion object {
+        private val log = LoggerFactory.getLogger(PendingDirectPaymentVerifier::class.java)
+        private const val DEFAULT_POLL_INTERVAL_MS = 5_000L
+        /** Never declare a payment lost sooner than this after it was submitted. */
+        private const val DEFAULT_MIN_AGE_MS = 10 * 60_000L
+        /** How long the wallet must be continuously connected and synced without seeing the tx. */
+        private const val DEFAULT_SYNCED_GRACE_MS = 5 * 60_000L
+        /** A chain tip older than this means we are not really caught up, whatever the sync state says. */
+        private const val RECENT_CHAIN_TIP_MS = 30 * 60_000L
+    }
+
+    @VisibleForTesting internal var pollIntervalMs = DEFAULT_POLL_INTERVAL_MS
+    @VisibleForTesting internal var minAgeMs = DEFAULT_MIN_AGE_MS
+    @VisibleForTesting internal var syncedGraceMs = DEFAULT_SYNCED_GRACE_MS
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val jobs = ConcurrentHashMap<Sha256Hash, Deferred<Transaction?>>()
+    private val jobsMutex = Mutex()
+
+    /**
+     * Locks the inputs of [tx], persists it and starts watching the network for it.
+     *
+     * @return a deferred that completes with the committed transaction once it is seen on the
+     *         network, or with null if it never appears and its inputs were released.
+     */
+    suspend fun quarantine(tx: Transaction, paymentUrl: String, serviceName: String?): Deferred<Transaction?> {
+        val wallet = walletData.wallet ?: throw IllegalStateException("wallet is not available")
+        val payment = PendingDirectPayment(
+            txId = tx.txId,
+            txBytes = tx.bitcoinSerialize(),
+            paymentUrl = paymentUrl,
+            serviceName = serviceName,
+            createdAt = System.currentTimeMillis()
+        )
+        lockInputs(wallet, tx)
+        config.add(payment)
+        log.info("quarantined possibly-sent tx {} ({} inputs locked)", tx.txId, tx.inputs.size)
+        return track(tx, payment)
+    }
+
+    /**
+     * Re-locks the inputs of persisted pending payments and restarts their verification.
+     * Safe to call repeatedly; payments already being tracked are skipped.
+     */
+    fun resume() {
+        scope.launch {
+            try {
+                val wallet = walletData.wallet ?: walletData.observeWallet().filterNotNull().first()
+                val pending = config.getAll()
+                if (pending.isEmpty()) {
+                    return@launch
+                }
+                log.info("resuming verification of {} pending direct payment(s)", pending.size)
+                for (payment in pending) {
+                    try {
+                        val tx = Transaction(wallet.params, payment.txBytes)
+                        if (!isTracked(tx.txId)) {
+                            lockInputs(wallet, tx)
+                        }
+                        track(tx, payment)
+                    } catch (e: Exception) {
+                        log.error("could not restore pending direct payment {}, dropping it", payment.txId, e)
+                        config.remove(payment.txId)
+                    }
+                }
+            } catch (e: Exception) {
+                log.error("failed to resume pending direct payments", e)
+            }
+        }
+    }
+
+    fun isTracked(txId: Sha256Hash): Boolean = jobs[txId]?.isActive == true
+
+    /**
+     * True if there is any evidence that the network knows about [tx]: it is in the wallet with a
+     * network source, has an InstantSend or ChainLock, or was announced by at least one peer.
+     * Requires connected peers to ever become true.
+     */
+    fun isTransactionOnNetwork(tx: Transaction): Boolean {
+        return try {
+            val wallet = walletData.wallet ?: return false
+            val inWalletTx = wallet.getTransaction(tx.txId)
+            val confidence = (inWalletTx ?: tx).confidence ?: return false
+
+            (inWalletTx != null && confidence.source == TransactionConfidence.Source.NETWORK) ||
+                confidence.isChainLocked ||
+                confidence.isTransactionLocked ||
+                confidence.numBroadcastPeers() > 0
+        } catch (e: Exception) {
+            log.debug("Error checking transaction network status: {}", e.message)
+            false
+        }
+    }
+
+    private suspend fun track(tx: Transaction, payment: PendingDirectPayment): Deferred<Transaction?> =
+        jobsMutex.withLock {
+            jobs[tx.txId]?.takeIf { it.isActive }
+                ?: scope.async { verify(tx, payment) }.also { jobs[tx.txId] = it }
+        }
+
+    private suspend fun verify(tx: Transaction, payment: PendingDirectPayment): Transaction? {
+        log.info("watching the network for possibly-sent tx {} (submitted to {})", tx.txId, payment.paymentUrl)
+        var syncedSince = 0L
+
+        while (true) {
+            try {
+                if (isTransactionOnNetwork(tx)) {
+                    return commit(tx, payment)
+                }
+
+                val now = System.currentTimeMillis()
+                syncedSince = if (isConnectedAndSynced()) {
+                    if (syncedSince == 0L) now else syncedSince
+                } else {
+                    0L
+                }
+
+                if (syncedSince != 0L &&
+                    now - syncedSince >= syncedGraceMs &&
+                    now - payment.createdAt >= minAgeMs
+                ) {
+                    release(tx, payment)
+                    return null
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log.warn("error while verifying possibly-sent tx {}", tx.txId, e)
+            }
+            delay(pollIntervalMs)
+        }
+    }
+
+    private suspend fun isConnectedAndSynced(): Boolean {
+        if (blockchainStateProvider.getNetworkStatus() != NetworkStatus.CONNECTED) {
+            return false
+        }
+        val state = blockchainStateProvider.getState() ?: return false
+        val bestChainDate = state.bestChainDate ?: return false
+        return state.isSynced() && System.currentTimeMillis() - bestChainDate.time < RECENT_CHAIN_TIP_MS
+    }
+
+    private suspend fun commit(tx: Transaction, payment: PendingDirectPayment): Transaction {
+        val wallet = walletData.wallet ?: throw IllegalStateException("wallet is not available")
+        Context.propagate(wallet.context)
+
+        val existing = wallet.getTransaction(tx.txId)
+        if (existing == null) {
+            wallet.maybeCommitTx(tx)
+            log.info("possibly-sent tx {} was seen on the network, committed to wallet", tx.txId)
+        } else {
+            log.info("possibly-sent tx {} was seen on the network and is already in the wallet", tx.txId)
+        }
+        unlockInputs(wallet, tx)
+
+        payment.serviceName?.let { metadataProvider.setTransactionService(tx.txId, it) }
+        val walletTx = wallet.getTransaction(tx.txId) ?: tx
+        // harmless if the merchant already broadcast it; makes sure the network has it otherwise
+        walletApplication.broadcastTransaction(walletTx)
+        finish(payment)
+        return walletTx
+    }
+
+    private suspend fun release(tx: Transaction, payment: PendingDirectPayment) {
+        log.warn(
+            "possibly-sent tx {} was never seen on the network while connected and synced; " +
+                "the merchant did not receive the payment, releasing its inputs",
+            tx.txId
+        )
+        walletData.wallet?.let { unlockInputs(it, tx) }
+        // Anything saved optimistically against this tx describes an order that was never placed.
+        try {
+            metadataProvider.removeGiftCards(tx.txId)
+        } catch (e: Exception) {
+            log.error("could not remove gift cards recorded for abandoned payment {}", tx.txId, e)
+        }
+        finish(payment)
+    }
+
+    private suspend fun finish(payment: PendingDirectPayment) {
+        config.remove(payment.txId)
+        jobs.remove(payment.txId)
+    }
+
+    private fun lockInputs(wallet: Wallet, tx: Transaction) {
+        tx.inputs.forEach { wallet.lockOutput(it.outpoint) }
+    }
+
+    private fun unlockInputs(wallet: Wallet, tx: Transaction) {
+        tx.inputs.forEach { wallet.unlockOutput(it.outpoint) }
+    }
+}

--- a/wallet/src/de/schildbach/wallet/payments/PendingDirectPaymentVerifier.kt
+++ b/wallet/src/de/schildbach/wallet/payments/PendingDirectPaymentVerifier.kt
@@ -106,7 +106,15 @@ class PendingDirectPaymentVerifier @Inject constructor(
             createdAt = System.currentTimeMillis()
         )
         lockInputs(wallet, tx)
-        config.add(payment)
+        try {
+            config.add(payment)
+        } catch (e: Exception) {
+            // The locks live in memory only, and without a persisted record resume() could never
+            // find them again: they would strand these outputs until the process restarts.
+            log.error("could not persist pending direct payment {}, releasing its inputs", tx.txId, e)
+            unlockInputs(wallet, tx)
+            throw e
+        }
         log.info("quarantined possibly-sent tx {} ({} inputs locked)", tx.txId, tx.inputs.size)
         return track(tx, payment)
     }

--- a/wallet/src/de/schildbach/wallet/payments/PendingDirectPaymentVerifier.kt
+++ b/wallet/src/de/schildbach/wallet/payments/PendingDirectPaymentVerifier.kt
@@ -241,11 +241,12 @@ class PendingDirectPaymentVerifier @Inject constructor(
             tx.txId
         )
         walletData.wallet?.let { unlockInputs(it, tx) }
-        // Anything saved optimistically against this tx describes an order that was never placed.
+        // Anything saved optimistically against this tx describes an order that was never placed,
+        // and its metadata must not reach Dash Platform either.
         try {
-            metadataProvider.removeGiftCards(tx.txId)
+            metadataProvider.forgetTransaction(tx.txId)
         } catch (e: Exception) {
-            log.error("could not remove gift cards recorded for abandoned payment {}", tx.txId, e)
+            log.error("could not discard the records of abandoned payment {}", tx.txId, e)
         }
         finish(payment)
     }

--- a/wallet/src/de/schildbach/wallet/payments/SendCoinsTaskRunner.kt
+++ b/wallet/src/de/schildbach/wallet/payments/SendCoinsTaskRunner.kt
@@ -59,6 +59,7 @@ import org.dash.wallet.common.WalletDataProvider
 import org.dash.wallet.common.payments.parsers.DashPaymentIntentParser
 import org.dash.wallet.common.services.DirectPayException
 import org.dash.wallet.common.services.LeftoverBalanceException
+import org.dash.wallet.common.services.PaymentSubmissionPendingException
 import org.dash.wallet.common.services.SendPaymentService
 import org.dash.wallet.common.services.TransactionMetadataProvider
 import org.dash.wallet.common.services.analytics.AnalyticsConstants
@@ -69,6 +70,9 @@ import org.dash.wallet.common.util.Constants
 import org.dash.wallet.common.util.call
 import org.dash.wallet.common.util.ensureSuccessful
 import org.slf4j.LoggerFactory
+import java.net.ConnectException
+import java.net.NoRouteToHostException
+import java.net.UnknownHostException
 import java.util.function.Consumer
 import java.util.function.Predicate
 import javax.inject.Inject
@@ -84,12 +88,29 @@ class SendCoinsTaskRunner @Inject constructor(
     coinJoinService: CoinJoinService,
     private val identityRepository: IdentityRepository,
     private val platformRepo: PlatformRepo,
-    private val metadataProvider: TransactionMetadataProvider
+    private val metadataProvider: TransactionMetadataProvider,
+    private val pendingPaymentVerifier: PendingDirectPaymentVerifier
 ) : SendPaymentService {
     companion object {
         private const val WALLET_EXCEPTION_MESSAGE = "this method can't be used before creating the wallet"
         private val MAX_NO_CHANGE_FEE = Coin.valueOf(10_0000).multiply(2) // 0.002 DASH
         private val log = LoggerFactory.getLogger(SendCoinsTaskRunner::class.java)
+        /** How long a BIP70 payment waits for network evidence after an ambiguous HTTP failure. */
+        private const val DEFAULT_AMBIGUOUS_SUBMISSION_WAIT_MS = 30_000L
+    }
+
+    @VisibleForTesting
+    internal var ambiguousSubmissionWaitMs = DEFAULT_AMBIGUOUS_SUBMISSION_WAIT_MS
+
+    /**
+     * Client for the BIP70 payment POST. Connection-failure retries are off on purpose: OkHttp
+     * would otherwise re-send the payment message on a fresh connection after a failure that may
+     * already have reached the merchant, and report only the last (often unrelated, e.g. DNS)
+     * failure. Seeing the first failure is what lets [isDefinitelyNotSubmitted] tell a request
+     * that never left the device from one whose result is unknown.
+     */
+    private val directPayHttpClient by lazy {
+        Constants.HTTP_CLIENT.newBuilder().retryOnConnectionFailure(false).build()
     }
     private var coinJoinSend = false
     private var coinJoinMode = CoinJoinMode.NONE
@@ -330,18 +351,28 @@ class SendCoinsTaskRunner @Inject constructor(
      * This method completes the transaction, sends it via HTTP to the payment URL,
      * and handles the payment acknowledgment.
      *
+     * The whole submission runs in a [NonCancellable] context: once the payment message may have
+     * left the device, cancelling the caller (screen lock, activity recreation) must not abandon
+     * the transaction in an unknown state.
+     *
+     * If the HTTP request fails after it may have reached the merchant, the signed transaction is
+     * handed to [PendingDirectPaymentVerifier]: its inputs are locked and the network is watched
+     * for it. If it shows up within [ambiguousSubmissionWaitMs] it is returned as sent; otherwise
+     * [PaymentSubmissionPendingException] is thrown and verification continues in the background.
+     *
      * @param sendRequest The send request (should already be created via createSendRequest)
      * @param finalPaymentIntent The payment intent containing the payment URL
      * @param serviceName Optional service name for transaction metadata
      * @return The committed transaction
      * @throws DirectPayException if the payment is not acknowledged
-     * @throws IOException if the HTTP request fails
+     * @throws PaymentSubmissionPendingException if the submission result is unknown
+     * @throws IOException if the HTTP request fails before it could have reached the merchant
      */
     private suspend fun directPay(
         sendRequest: SendRequest,
         finalPaymentIntent: PaymentIntent,
         serviceName: String?
-    ): Transaction {
+    ): Transaction = withContext(NonCancellable) {
         log.info("completing sendRequest transaction")
         val wallet = walletData.wallet ?: throw RuntimeException(WALLET_EXCEPTION_MESSAGE)
         Context.propagate(wallet.context)
@@ -365,7 +396,7 @@ class SendCoinsTaskRunner @Inject constructor(
         val timer = AnalyticsTimer(analyticsService, log, AnalyticsConstants.Process.PROCESS_BIP7O_SEND_PAYMENT)
         val request = buildOkHttpDirectPayRequest(requestUrl, payment)
         try {
-            val response = Constants.HTTP_CLIENT.call(request)
+            val response = directPayHttpClient.call(request)
             response.ensureSuccessful()
             requestUrl.toUri().host?.let {
                 timer.logTiming(hashMapOf(AnalyticsConstants.Parameter.ARG1 to it))
@@ -382,51 +413,51 @@ class SendCoinsTaskRunner @Inject constructor(
             if (!acknowledged) {
                 throw DirectPayException("Payment was not acknowledged by the server")
             }
-        } catch (e: Exception) {
-            if (e !is DirectPayException) {
-                log.warn("Payment submission failed, but transaction may have been sent: ${sendRequest.tx.txId}", e)
-                val tx = sendRequest.tx
-                val delays = listOf(0L, 1000L, 3000L, 5000L)
-
-                for (delayMs in delays) {
-                    delay(delayMs)
-                    if (isTransactionOnNetwork(tx)) {
-                        log.info("Transaction found on network despite HTTP timeout: ${tx.txId}")
-                        // The BIP70 server may have broadcast the tx and our wallet may have already
-                        // picked it up via the P2P network — use maybeCommitTx to avoid throwing
-                        // "commitTx called on the same transaction twice" in that race.
-                        if (!wallet.maybeCommitTx(tx)) {
-                            log.info("tx was already in the wallet (received via network): {}", tx.txId)
-                        }
-                        return tx
-                    }
-                }
-
-                log.warn("Transaction not found on network after timeout, treating as failed: ${tx.txId}")
-                // throw exception below
-            }
+        } catch (e: DirectPayException) {
             throw e
+        } catch (e: Exception) {
+            val tx = sendRequest.tx
+
+            if (isDefinitelyNotSubmitted(e)) {
+                log.warn("Payment submission failed before the request could be sent: ${tx.txId}", e)
+                throw e
+            }
+
+            log.warn("Payment submission failed, but transaction may have been sent: ${tx.txId}", e)
+            // The merchant may have received the payment and broadcast the tx. Lock its inputs
+            // so a retry can't double-spend them, and watch the network for it. The verifier
+            // is application-scoped and persists the tx, so it keeps going after this call,
+            // the purchase screen and even the process are gone.
+            val verification = pendingPaymentVerifier.quarantine(tx, requestUrl, serviceName)
+            val result = withTimeoutOrNull(ambiguousSubmissionWaitMs) { verification.await() }
+
+            if (result != null) {
+                log.info("Transaction found on network despite HTTP failure: ${tx.txId}")
+                return@withContext result
+            }
+
+            if (verification.isCompleted) {
+                // resolved as never sent within the wait: inputs are released, report the failure
+                log.warn("Transaction not found on network, treating as failed: ${tx.txId}")
+                throw e
+            }
+
+            log.warn("Transaction ${tx.txId} not seen on network yet, verification continues in the background")
+            throw PaymentSubmissionPendingException(tx.txId, e)
         }
 
-
-        return sendCoins(sendRequest, txCompleted = true, checkBalanceConditions = true)
+        sendCoins(sendRequest, txCompleted = true, checkBalanceConditions = true)
     }
 
-    private fun isTransactionOnNetwork(transaction: Transaction): Boolean {
-        return try {
-            val wallet = walletData.wallet ?: return false
-            val inWalletTx = wallet.getTransaction(transaction.txId)
-            val confidence = (inWalletTx ?: transaction).confidence ?: return false
-
-            // If we have the wallet’s instance, also accept network source as proof
-            (inWalletTx != null && confidence.source == TransactionConfidence.Source.NETWORK) ||
-                    confidence.isChainLocked ||
-                    confidence.isTransactionLocked ||
-                    confidence.numBroadcastPeers() > 0
-        } catch (e: Exception) {
-            log.debug("Error checking transaction network status: ${e.message}")
-            false
-        }
+    /**
+     * True when the failure happened before any bytes could reach the server (DNS or TCP connect
+     * failure), so the merchant definitely did not receive the payment. Anything else - a
+     * dropped connection, a read timeout, a reset HTTP/2 stream - may have been processed by the
+     * merchant and is treated as ambiguous. Relies on [directPayHttpClient] not retrying, so the
+     * exception describes the only attempt made.
+     */
+    private fun isDefinitelyNotSubmitted(e: Exception): Boolean {
+        return e is UnknownHostException || e is ConnectException || e is NoRouteToHostException
     }
 
     fun createSendRequest(

--- a/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.kt
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.kt
@@ -57,6 +57,7 @@ import de.schildbach.wallet.WalletBalanceWidgetProvider
 import de.schildbach.wallet.data.AddressBookProvider
 import de.schildbach.wallet.database.dao.BlockchainStateDao
 import de.schildbach.wallet.database.dao.ExchangeRatesDao
+import de.schildbach.wallet.payments.PendingDirectPaymentVerifier
 import de.schildbach.wallet.service.extensions.registerCrowdNodeConfirmedAddressFilter
 import de.schildbach.wallet.service.platform.IdentityRepository
 import de.schildbach.wallet.service.platform.PlatformSyncService
@@ -222,6 +223,10 @@ class BlockchainServiceImpl : LifecycleService(), BlockchainService {
         // Set to 0 to disable test timeout (use Android's default 6-hour limit)
         // Set to 1-2 minutes for testing the timeout behavior
         private val TEST_TIMEOUT_MINUTES = 0L // Change to 0 to disable
+        /** How long a new instance waits for the previous instance's cleanup before complaining. */
+        private const val CLEANUP_WAIT_MS = 15_000L
+        /** Additional wait before giving up, stopping and rescheduling the service. */
+        private const val CLEANUP_EXTRA_WAIT_MS = 60_000L
     }
     private val serviceJob = SupervisorJob()
     private val serviceScope = CoroutineScope(Dispatchers.IO + serviceJob)
@@ -263,6 +268,7 @@ class BlockchainServiceImpl : LifecycleService(), BlockchainService {
 
     @Inject lateinit var coinJoinService: CoinJoinService
     @Inject lateinit var serviceConfig: BlockchainServiceConfig
+    @Inject lateinit var pendingDirectPaymentVerifier: PendingDirectPaymentVerifier
     @Inject lateinit var analyticsService: AnalyticsService
     @Inject lateinit var securityFunctions: AuthenticationManager
 
@@ -1374,20 +1380,39 @@ class BlockchainServiceImpl : LifecycleService(), BlockchainService {
             try {
                 log.info("onCreate() serviceScope waiting for cleanup {}", cleanupDeferred?.isActive)
 
-                val cleanupCompleted = withTimeoutOrNull(15_000) {
+                var cleanupCompleted = withTimeoutOrNull(CLEANUP_WAIT_MS) {
                     cleanupDeferred?.await()
                     true
                 } != null
 
                 if (!cleanupCompleted) {
-                    log.error("CRITICAL: Cleanup did not complete within 15 seconds")
+                    // The previous instance is still shutting down (forced peergroup stop, long wallet
+                    // saves on big wallets). This is common when the user leaves and re-enters the app
+                    // within a minute, so keep waiting instead of giving up right away.
+                    log.error(
+                        "Cleanup of the previous service instance did not complete within {} seconds, " +
+                            "waiting up to {} more seconds",
+                        CLEANUP_WAIT_MS / 1000, CLEANUP_EXTRA_WAIT_MS / 1000
+                    )
+                    cleanupCompleted = withTimeoutOrNull(CLEANUP_EXTRA_WAIT_MS) {
+                        cleanupDeferred?.await()
+                        true
+                    } != null
+                }
+
+                if (!cleanupCompleted) {
+                    log.error("CRITICAL: Cleanup did not complete within {} seconds", (CLEANUP_WAIT_MS + CLEANUP_EXTRA_WAIT_MS) / 1000)
                     log.error("This indicates a deadlock in onDestroy - cannot proceed with onCreate")
-                    log.error("Stopping service to prevent resource conflicts and file lock exceptions")
+                    log.error("Stopping service to prevent resource conflicts and file lock exceptions; restart scheduled")
 
                     // Complete onCreate to unblock any waiting onStartCommand calls
                     if (onCreateCompleted.isActive) {
                         onCreateCompleted.complete(Unit)
                     }
+
+                    // Don't leave the wallet without a service (and without peers for any payment in
+                    // progress): come back once the old instance has had time to release its locks.
+                    rescheduleService()
 
                     // Stop the service - we cannot safely initialize with cleanup still running
                     withContext(Dispatchers.Main) {
@@ -1402,6 +1427,8 @@ class BlockchainServiceImpl : LifecycleService(), BlockchainService {
                     log.error("onCreate: wallet is null after cleanup, service cannot continue")
                     return@launch
                 }
+                // re-lock inputs of BIP70 payments with an unknown result and keep watching for them
+                pendingDirectPaymentVerifier.resume()
                 peerConnectivityListener = PeerConnectivityListener()
                 broadcastPeerState(0)
                 blockChainFile =
@@ -2020,8 +2047,14 @@ class BlockchainServiceImpl : LifecycleService(), BlockchainService {
 
     override fun onTrimMemory(level: Int) {
         log.info("onTrimMemory({}) called", level)
-        if (level >= TRIM_MEMORY_BACKGROUND) {
-            log.warn("low memory detected, stopping service")
+        // TRIM_MEMORY_BACKGROUND (40) and TRIM_MEMORY_MODERATE (60) only mean the process is on the
+        // cached/LRU list, which Android reports routinely after the user leaves the app. Stopping
+        // on those levels killed the service (and any payment in flight) shortly after every
+        // backgrounding. Only TRIM_MEMORY_COMPLETE means the process is next in line to be killed;
+        // stop gracefully then so the wallet is saved cleanly, and come back once memory frees up.
+        if (level >= TRIM_MEMORY_COMPLETE) {
+            log.warn("process is about to be killed for memory (level {}), stopping service and scheduling restart", level)
+            rescheduleService()
             stopSelf()
         }
     }
@@ -2174,8 +2207,11 @@ class BlockchainServiceImpl : LifecycleService(), BlockchainService {
             val syncing =
                 blockchainState.bestChainDate!!.time < Utils.currentTimeMillis() - DateUtils.HOUR_IN_MILLIS //1 hour
             try {
-                if (!syncing && blockchainState.bestChainHeight == config.bestChainHeightEver && mixingStatus != MixingStatus.MIXING && mixingStatus != MixingStatus.FINISHING) {
+                if (!syncing && blockchainState.bestChainHeight == config.bestChainHeightEver && !isMixingOrPaused(mixingStatus)) {
                     //Remove ongoing notification if blockchain sync finished
+                    if (foregroundService != ForegroundService.NONE) {
+                        log.info("sync finished and not mixing ({}), demoting from foreground service", mixingStatus)
+                    }
                     stopForeground(true)
                     foregroundService = ForegroundService.NONE
                     nm!!.cancel(Constants.NOTIFICATION_ID_BLOCKCHAIN_SYNC)
@@ -2183,7 +2219,7 @@ class BlockchainServiceImpl : LifecycleService(), BlockchainService {
                     //Shows ongoing notification when synchronizing the blockchain
                     val notification = createNetworkSyncNotification(blockchainState)
                     nm!!.notify(Constants.NOTIFICATION_ID_BLOCKCHAIN_SYNC, notification)
-                } else if (mixingStatus == MixingStatus.MIXING || mixingStatus == MixingStatus.PAUSED || mixingStatus == MixingStatus.FINISHING) {
+                } else if (isMixingOrPaused(mixingStatus)) {
                     log.info("foreground service: {}", foregroundService)
                     if (foregroundService == ForegroundService.NONE) {
                         log.info("foreground service not active, create notification")
@@ -2201,6 +2237,17 @@ class BlockchainServiceImpl : LifecycleService(), BlockchainService {
         }
         this.blockchainState = blockchainState
         this.mixingStatus = mixingStatus
+    }
+
+    /**
+     * Mixing states that need the service kept in the foreground. PAUSED is included on purpose:
+     * demoting a paused-mixing wallet and re-promoting it on the next state change made the
+     * service flap between foreground and background, exposing it to the background service kill.
+     */
+    private fun isMixingOrPaused(mixingStatus: MixingStatus): Boolean {
+        return mixingStatus == MixingStatus.MIXING ||
+            mixingStatus == MixingStatus.PAUSED ||
+            mixingStatus == MixingStatus.FINISHING
     }
 
     private fun percentageSync(): Int {

--- a/wallet/src/de/schildbach/wallet/service/WalletTransactionMetadataProvider.kt
+++ b/wallet/src/de/schildbach/wallet/service/WalletTransactionMetadataProvider.kt
@@ -345,6 +345,14 @@ class WalletTransactionMetadataProvider @Inject constructor(
         }
     }
 
+    override suspend fun removeGiftCards(txId: Sha256Hash) {
+        val removed = giftCardDao.getCardCountForTransaction(txId)
+        if (removed > 0) {
+            log.info("removing {} gift card(s) recorded for abandoned payment {}", removed, txId)
+            giftCardDao.removeCardsForTransaction(txId)
+        }
+    }
+
     override suspend fun updateGiftCardMetadata(giftCard: GiftCard) {
         // Room's @Update rewrites every column, so a caller passing a partially-populated
         // GiftCard would otherwise null out fields it didn't set (number/pin/note/...).

--- a/wallet/src/de/schildbach/wallet/service/WalletTransactionMetadataProvider.kt
+++ b/wallet/src/de/schildbach/wallet/service/WalletTransactionMetadataProvider.kt
@@ -24,6 +24,7 @@ import de.schildbach.wallet.database.dao.IconBitmapDao
 import de.schildbach.wallet.database.dao.TransactionMetadataDao
 import de.schildbach.wallet.database.dao.TransactionMetadataChangeCacheDao
 import de.schildbach.wallet.database.dao.TransactionMetadataDocumentDao
+import de.schildbach.wallet.database.dao.TransactionRecordsDao
 import de.schildbach.wallet.database.entity.TransactionMetadataCacheItem
 import de.schildbach.wallet.ui.dashpay.utils.DashPayConfig
 import kotlinx.coroutines.*
@@ -62,6 +63,7 @@ class WalletTransactionMetadataProvider @Inject constructor(
     private val iconBitmapDao: IconBitmapDao,
     private val walletData: WalletDataProvider,
     private val giftCardDao: GiftCardDao,
+    private val transactionRecordsDao: TransactionRecordsDao,
     private val swapOrderDao: SwapOrderDao,
     private val transactionMetadataChangeCacheDao: TransactionMetadataChangeCacheDao,
     private val transactionMetadataDocumentDao: TransactionMetadataDocumentDao,
@@ -346,20 +348,22 @@ class WalletTransactionMetadataProvider @Inject constructor(
     }
 
     override suspend fun forgetTransaction(txId: Sha256Hash) {
-        // Guard against ever discarding real user data: if the wallet holds the transaction, it
-        // was broadcast after all and its memo, tax category and cards must be kept.
-        if (walletData.wallet?.getTransaction(txId) != null) {
+        // Fail closed: only proceed when a wallet is available AND says it does not hold the
+        // transaction. Without a wallet we cannot tell "never broadcast" from "cannot check
+        // right now", and deleting on a guess would discard the memo, tax category and cards of
+        // a real payment.
+        val wallet = walletData.wallet
+        if (wallet == null) {
+            log.warn("not forgetting {}: no wallet available to confirm the transaction is absent", txId)
+            return
+        }
+        if (wallet.getTransaction(txId) != null) {
             log.warn("refusing to forget {}: the wallet holds this transaction", txId)
             return
         }
 
-        val cards = giftCardDao.getCardCountForTransaction(txId)
-        if (cards > 0) {
-            giftCardDao.removeCardsForTransaction(txId)
-        }
-        // drop queued platform changes first, so a concurrent publish cannot re-add the metadata
-        transactionMetadataChangeCacheDao.removeByTxId(txId)
-        transactionMetadataDao.remove(txId)
+        // one Room transaction: a partial cleanup would strand rows with nothing left to retry it
+        val cards = transactionRecordsDao.forgetTransaction(txId)
         log.info("forgot transaction {} that was never broadcast ({} gift card(s) removed)", txId, cards)
     }
 

--- a/wallet/src/de/schildbach/wallet/service/WalletTransactionMetadataProvider.kt
+++ b/wallet/src/de/schildbach/wallet/service/WalletTransactionMetadataProvider.kt
@@ -345,12 +345,22 @@ class WalletTransactionMetadataProvider @Inject constructor(
         }
     }
 
-    override suspend fun removeGiftCards(txId: Sha256Hash) {
-        val removed = giftCardDao.getCardCountForTransaction(txId)
-        if (removed > 0) {
-            log.info("removing {} gift card(s) recorded for abandoned payment {}", removed, txId)
+    override suspend fun forgetTransaction(txId: Sha256Hash) {
+        // Guard against ever discarding real user data: if the wallet holds the transaction, it
+        // was broadcast after all and its memo, tax category and cards must be kept.
+        if (walletData.wallet?.getTransaction(txId) != null) {
+            log.warn("refusing to forget {}: the wallet holds this transaction", txId)
+            return
+        }
+
+        val cards = giftCardDao.getCardCountForTransaction(txId)
+        if (cards > 0) {
             giftCardDao.removeCardsForTransaction(txId)
         }
+        // drop queued platform changes first, so a concurrent publish cannot re-add the metadata
+        transactionMetadataChangeCacheDao.removeByTxId(txId)
+        transactionMetadataDao.remove(txId)
+        log.info("forgot transaction {} that was never broadcast ({} gift card(s) removed)", txId, cards)
     }
 
     override suspend fun updateGiftCardMetadata(giftCard: GiftCard) {

--- a/wallet/src/de/schildbach/wallet/ui/send/PaymentProtocolFragment.kt
+++ b/wallet/src/de/schildbach/wallet/ui/send/PaymentProtocolFragment.kt
@@ -40,6 +40,7 @@ import org.bitcoinj.utils.MonetaryFormat
 import org.bitcoinj.wallet.SendRequest
 import org.dash.wallet.common.Configuration
 import org.dash.wallet.common.services.AuthenticationManager
+import org.dash.wallet.common.services.PaymentSubmissionPendingException
 import org.dash.wallet.common.ui.dialogs.AdaptiveDialog
 import org.dash.wallet.common.ui.viewBinding
 import org.dash.wallet.common.util.toFormattedString
@@ -173,10 +174,18 @@ class PaymentProtocolFragment : Fragment(R.layout.fragment_payment_protocol) {
                 Status.ERROR -> {
                     if (isAdded) {
                         binding.viewFlipper.displayedChild = VIEW_ERROR
-                        binding.errorView.title = R.string.payment_request_problem_title
-                        binding.errorView.setMessage(ack.message)
-                        binding.errorView.setOnConfirmClickListener(R.string.payment_request_try_again) {
-                            viewModel.sendPayment()
+                        if (ack.exception is PaymentSubmissionPendingException) {
+                            // The merchant may have received the payment; the wallet keeps checking
+                            // the network in the background. Retrying now could pay twice.
+                            binding.errorView.title = R.string.payment_submission_pending_title
+                            binding.errorView.message = R.string.payment_submission_pending_message
+                            binding.errorView.hideConfirmButton()
+                        } else {
+                            binding.errorView.title = R.string.payment_request_problem_title
+                            binding.errorView.setMessage(ack.message)
+                            binding.errorView.setOnConfirmClickListener(R.string.payment_request_try_again) {
+                                viewModel.sendPayment()
+                            }
                         }
                         binding.errorView.hideCancelButton()
                     }

--- a/wallet/test/de/schildbach/wallet/payments/PendingDirectPaymentVerifierTest.kt
+++ b/wallet/test/de/schildbach/wallet/payments/PendingDirectPaymentVerifierTest.kt
@@ -177,8 +177,9 @@ class PendingDirectPaymentVerifierTest {
         val result = verifier.quarantine(tx, paymentUrl, "CTXSpend")
         withTimeout(5_000) { result.await() }
 
-        // the order was never placed, so the cards recorded for it must go
-        coVerify { metadataProvider.removeGiftCards(tx.txId) }
+        // the order was never placed, so everything recorded for it must go: cards, metadata,
+        // and anything queued for Dash Platform
+        coVerify { metadataProvider.forgetTransaction(tx.txId) }
     }
 
     @Test
@@ -189,7 +190,7 @@ class PendingDirectPaymentVerifierTest {
         tx.confidence.markBroadcastBy(PeerAddress(params, InetAddress.getLoopbackAddress(), 9999))
         withTimeout(5_000) { result.await() }
 
-        coVerify(exactly = 0) { metadataProvider.removeGiftCards(any()) }
+        coVerify(exactly = 0) { metadataProvider.forgetTransaction(any()) }
     }
 
     @Test

--- a/wallet/test/de/schildbach/wallet/payments/PendingDirectPaymentVerifierTest.kt
+++ b/wallet/test/de/schildbach/wallet/payments/PendingDirectPaymentVerifierTest.kt
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.wallet.payments
+
+import de.schildbach.wallet.WalletApplication
+import de.schildbach.wallet.data.PendingDirectPayment
+import de.schildbach.wallet.data.PendingDirectPaymentConfig
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.bitcoinj.core.Address
+import org.bitcoinj.core.Coin
+import org.bitcoinj.core.Context
+import org.bitcoinj.core.PeerAddress
+import org.bitcoinj.core.Sha256Hash
+import org.bitcoinj.core.Transaction
+import org.bitcoinj.params.TestNet3Params
+import org.bitcoinj.script.ScriptBuilder
+import org.bitcoinj.wallet.Wallet
+import org.dash.wallet.common.WalletDataProvider
+import org.dash.wallet.common.data.NetworkStatus
+import org.dash.wallet.common.data.entity.BlockchainState
+import org.dash.wallet.common.services.BlockchainStateProvider
+import org.dash.wallet.common.services.TransactionMetadataProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.net.InetAddress
+import java.util.Date
+import java.util.EnumSet
+import java.util.concurrent.atomic.AtomicInteger
+
+class PendingDirectPaymentVerifierTest {
+    companion object {
+        // static: JUnit builds a new test instance per method, so a per-instance counter would
+        // restart and hand every test the same txid
+        private val txCounter = AtomicInteger(0)
+    }
+
+    private val params = TestNet3Params.get()
+    private val paymentUrl = "https://merchant.example/payment"
+
+    private lateinit var wallet: Wallet
+    private lateinit var walletData: WalletDataProvider
+    private lateinit var walletApplication: WalletApplication
+    private lateinit var blockchainStateProvider: BlockchainStateProvider
+    private lateinit var metadataProvider: TransactionMetadataProvider
+    private lateinit var config: PendingDirectPaymentConfig
+    private lateinit var verifier: PendingDirectPaymentVerifier
+
+    @Before
+    fun setUp() {
+        Context.propagate(Context(params))
+        wallet = Wallet.createBasic(params)
+
+        walletData = mockk(relaxed = true)
+        every { walletData.wallet } returns wallet
+        walletApplication = mockk(relaxed = true)
+        blockchainStateProvider = mockk(relaxed = true)
+        every { blockchainStateProvider.getNetworkStatus() } returns NetworkStatus.DISCONNECTED
+        coEvery { blockchainStateProvider.getState() } returns null
+        metadataProvider = mockk(relaxed = true)
+        config = mockk(relaxed = true)
+        coEvery { config.getAll() } returns emptyList()
+
+        verifier = PendingDirectPaymentVerifier(
+            walletData, walletApplication, blockchainStateProvider, metadataProvider, config
+        ).apply {
+            pollIntervalMs = 20L
+        }
+    }
+
+    /**
+     * A structurally valid tx spending one (foreign) outpoint; signatures aren't checked on commit.
+     * Each call spends a different outpoint, so every test gets its own txid. dashj keeps
+     * TransactionConfidence in a table on the global Context, so tests that reused a txid would
+     * inherit each other's broadcast state.
+     */
+    private fun createTransaction(): Transaction {
+        val tx = Transaction(params)
+        val unique = Sha256Hash.of("pending-payment-${txCounter.incrementAndGet()}".toByteArray())
+        tx.addInput(unique, 0, ScriptBuilder.createEmpty())
+        val address = Address.fromString(params, "yWdXnYxGbouNoo8yMvcbZmZ3Gdp6BpySxL")
+        tx.addOutput(Coin.parseCoin("0.01"), address)
+        return tx
+    }
+
+    private fun goOnlineAndSynced() {
+        every { blockchainStateProvider.getNetworkStatus() } returns NetworkStatus.CONNECTED
+        coEvery { blockchainStateProvider.getState() } returns BlockchainState(
+            Date(), 100_000, false, EnumSet.noneOf(BlockchainState.Impediment::class.java), 0, 0, 100
+        )
+    }
+
+    @Test
+    fun `quarantine locks inputs, persists the payment and stays pending without network evidence`() = runBlocking {
+        val tx = createTransaction()
+
+        val result = verifier.quarantine(tx, paymentUrl, "CTXSpend")
+        delay(100)
+
+        tx.inputs.forEach { assertTrue(wallet.isLockedOutput(it.outpoint)) }
+        coVerify { config.add(match { it.txId == tx.txId && it.paymentUrl == paymentUrl && it.serviceName == "CTXSpend" }) }
+        assertTrue(verifier.isTracked(tx.txId))
+        assertFalse("must not resolve while disconnected", result.isCompleted)
+        assertNull(wallet.getTransaction(tx.txId))
+    }
+
+    @Test
+    fun `commits, unlocks and broadcasts once a peer announces the tx`() = runBlocking {
+        val tx = createTransaction()
+        val result = verifier.quarantine(tx, paymentUrl, "CTXSpend")
+
+        // a peer relays the tx: the merchant did broadcast it
+        tx.confidence.markBroadcastBy(PeerAddress(params, InetAddress.getLoopbackAddress(), 9999))
+
+        val committed = withTimeout(5_000) { result.await() }
+
+        assertNotNull(committed)
+        assertEquals(tx.txId, committed!!.txId)
+        assertNotNull("tx should be committed to the wallet", wallet.getTransaction(tx.txId))
+        tx.inputs.forEach { assertFalse(wallet.isLockedOutput(it.outpoint)) }
+        coVerify { metadataProvider.setTransactionService(tx.txId, "CTXSpend") }
+        verify { walletApplication.broadcastTransaction(match { it.txId == tx.txId }) }
+        coVerify { config.remove(tx.txId) }
+        assertFalse(verifier.isTracked(tx.txId))
+    }
+
+    @Test
+    fun `releases inputs when connected and synced for the grace period without seeing the tx`() = runBlocking {
+        verifier.minAgeMs = 0L
+        verifier.syncedGraceMs = 100L
+        goOnlineAndSynced()
+        val tx = createTransaction()
+
+        val result = verifier.quarantine(tx, paymentUrl, null)
+        val committed = withTimeout(5_000) { result.await() }
+
+        assertNull("tx never seen: must not be committed", committed)
+        assertNull(wallet.getTransaction(tx.txId))
+        tx.inputs.forEach { assertFalse("inputs must be spendable again", wallet.isLockedOutput(it.outpoint)) }
+        coVerify { config.remove(tx.txId) }
+        verify(exactly = 0) { walletApplication.broadcastTransaction(any()) }
+    }
+
+    @Test
+    fun `removes optimistically saved gift cards when the payment is abandoned`() = runBlocking {
+        verifier.minAgeMs = 0L
+        verifier.syncedGraceMs = 100L
+        goOnlineAndSynced()
+        val tx = createTransaction()
+
+        val result = verifier.quarantine(tx, paymentUrl, "CTXSpend")
+        withTimeout(5_000) { result.await() }
+
+        // the order was never placed, so the cards recorded for it must go
+        coVerify { metadataProvider.removeGiftCards(tx.txId) }
+    }
+
+    @Test
+    fun `keeps gift cards when the payment is confirmed on the network`() = runBlocking {
+        val tx = createTransaction()
+        val result = verifier.quarantine(tx, paymentUrl, "CTXSpend")
+
+        tx.confidence.markBroadcastBy(PeerAddress(params, InetAddress.getLoopbackAddress(), 9999))
+        withTimeout(5_000) { result.await() }
+
+        coVerify(exactly = 0) { metadataProvider.removeGiftCards(any()) }
+    }
+
+    @Test
+    fun `does not release before the minimum age even when synced`() = runBlocking {
+        verifier.minAgeMs = 60_000L
+        verifier.syncedGraceMs = 0L
+        goOnlineAndSynced()
+        val tx = createTransaction()
+
+        val result = verifier.quarantine(tx, paymentUrl, null)
+        delay(200)
+
+        assertFalse(result.isCompleted)
+        tx.inputs.forEach { assertTrue(wallet.isLockedOutput(it.outpoint)) }
+    }
+
+    @Test
+    fun `resume re-locks inputs of persisted payments and tracks them`() = runBlocking {
+        val tx = createTransaction()
+        coEvery { config.getAll() } returns listOf(
+            PendingDirectPayment(tx.txId, tx.bitcoinSerialize(), paymentUrl, "CTXSpend", System.currentTimeMillis())
+        )
+
+        verifier.resume()
+        withTimeout(5_000) {
+            while (!verifier.isTracked(tx.txId)) delay(10)
+        }
+
+        tx.inputs.forEach { assertTrue(wallet.isLockedOutput(it.outpoint)) }
+        assertNull(wallet.getTransaction(tx.txId))
+    }
+
+    @Test
+    fun `resume drops payments that cannot be parsed`() = runBlocking {
+        val txId = Sha256Hash.of(byteArrayOf(9))
+        coEvery { config.getAll() } returns listOf(
+            PendingDirectPayment(txId, byteArrayOf(0, 1), paymentUrl, null, System.currentTimeMillis())
+        )
+
+        verifier.resume()
+
+        withTimeout(5_000) {
+            coVerify(timeout = 5_000) { config.remove(txId) }
+        }
+        assertFalse(verifier.isTracked(txId))
+    }
+}

--- a/wallet/test/de/schildbach/wallet/payments/SendCoinsTaskRunnerBIP70Test.kt
+++ b/wallet/test/de/schildbach/wallet/payments/SendCoinsTaskRunnerBIP70Test.kt
@@ -22,6 +22,7 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.HiltTestApplication
 import de.schildbach.wallet.WalletApplication
 import de.schildbach.wallet.data.CoinJoinConfig
+import de.schildbach.wallet.data.PendingDirectPaymentConfig
 import de.schildbach.wallet.database.entity.BlockchainIdentityConfig
 import de.schildbach.wallet.security.SecurityFunctions
 import de.schildbach.wallet.service.CoinJoinMode
@@ -32,6 +33,7 @@ import de.schildbach.wallet.ui.dashpay.PlatformRepo
 import de.schildbach.wallet.security.SecurityGuard
 import de.schildbach.wallet.service.platform.IdentityRepository
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -41,6 +43,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
 import org.bitcoin.protocols.payments.Protos
 import org.bitcoinj.core.Address
 import org.bitcoinj.core.Coin
@@ -51,11 +54,15 @@ import org.bitcoinj.wallet.SendRequest
 import org.bitcoinj.wallet.Wallet
 import org.bitcoinj.wallet.WalletProtobufSerializer
 import org.dash.wallet.common.WalletDataProvider
+import org.dash.wallet.common.data.NetworkStatus
 import org.dash.wallet.common.data.PaymentIntent
+import org.dash.wallet.common.services.BlockchainStateProvider
+import org.dash.wallet.common.services.PaymentSubmissionPendingException
 import org.dash.wallet.common.services.TransactionMetadataProvider
 import org.dash.wallet.common.services.analytics.AnalyticsService
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
@@ -65,6 +72,8 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import java.io.FileInputStream
+import java.net.Inet6Address
+import java.net.InetAddress
 import java.net.HttpURLConnection
 
 /**
@@ -93,15 +102,20 @@ class SendCoinsTaskRunnerBIP70Test {
     private lateinit var identityRepo: IdentityRepository
     private lateinit var platformRepo: PlatformRepo
     private lateinit var metadataProvider: TransactionMetadataProvider
+    private lateinit var blockchainStateProvider: BlockchainStateProvider
+    private lateinit var pendingPaymentConfig: PendingDirectPaymentConfig
+    private lateinit var pendingPaymentVerifier: PendingDirectPaymentVerifier
     private lateinit var wallet: Wallet
 
     private val networkParams: NetworkParameters = TestNet3Params.get()
+    /** Fixed loopback IP so tests that need a single route can address the server by IP. */
+    private val loopback: InetAddress = InetAddress.getLoopbackAddress()
 
     @Before
     fun setUp() {
         // Initialize MockWebServer
         mockWebServer = MockWebServer()
-        mockWebServer.start()
+        mockWebServer.start(loopback, 0)
 
         // Create mocks
         walletDataProvider = mockk(relaxed = true)
@@ -115,6 +129,8 @@ class SendCoinsTaskRunnerBIP70Test {
         identityRepo = mockk(relaxed = true)
         platformRepo = mockk(relaxed = true)
         metadataProvider = mockk(relaxed = true)
+        blockchainStateProvider = mockk(relaxed = true)
+        pendingPaymentConfig = mockk(relaxed = true)
         // wallet = mockk(relaxed = true)
 
         // dashj requires a Context to be constructed before reading a wallet
@@ -140,6 +156,20 @@ class SendCoinsTaskRunnerBIP70Test {
         every { mockSecurityGuard.retrievePassword() } returns "testPassword"
         every { securityFunctions.deriveKey(any(), any()) } returns mockk(relaxed = true)
 
+        // No peers, no sync: the verifier never resolves a quarantined payment on its own
+        every { blockchainStateProvider.getNetworkStatus() } returns NetworkStatus.DISCONNECTED
+        coEvery { blockchainStateProvider.getState() } returns null
+        coEvery { pendingPaymentConfig.getAll() } returns emptyList()
+        pendingPaymentVerifier = spyk(
+            PendingDirectPaymentVerifier(
+                walletDataProvider,
+                walletApplication,
+                blockchainStateProvider,
+                metadataProvider,
+                pendingPaymentConfig
+            )
+        )
+
         // Create SendCoinsTaskRunner
         sendCoinsTaskRunner = spyk(
             SendCoinsTaskRunner(
@@ -153,9 +183,12 @@ class SendCoinsTaskRunnerBIP70Test {
                 coinJoinService,
                 identityRepo,
                 platformRepo,
-                metadataProvider
+                metadataProvider,
+                pendingPaymentVerifier
             )
         )
+        // don't wait the production 30 seconds for network evidence in tests
+        sendCoinsTaskRunner.ambiguousSubmissionWaitMs = 500L
 
         coEvery { sendCoinsTaskRunner.logSendTxEvent(any(), any()) } returns Unit
 
@@ -799,6 +832,89 @@ class SendCoinsTaskRunnerBIP70Test {
         } catch (e: Exception) {
             // Expected - null payment URL should throw
             assertNotNull(e)
+        }
+    }
+
+    // ==================== ambiguous submission failures ====================
+
+    private fun createBip70PaymentIntent(address: Address, amount: Coin, paymentUrl: String): PaymentIntent {
+        val outputs = arrayOf(
+            PaymentIntent.Output(amount, org.bitcoinj.script.ScriptBuilder.createOutputScript(address))
+        )
+        return PaymentIntent(
+            PaymentIntent.Standard.BIP70,
+            null, null,
+            outputs,
+            null,
+            paymentUrl,
+            null, null, null, null, null
+        )
+    }
+
+    @Test
+    fun `sendDirectPayment quarantines the tx when the connection drops after the request`() = runTest {
+        // Given: the server receives the payment but the connection dies before the ACK arrives
+        val testAddress = Address.fromString(networkParams, "yWdXnYxGbouNoo8yMvcbZmZ3Gdp6BpySxL")
+        val testAmount = Coin.parseCoin("0.01")
+        // address the server by IP so there is a single route and the failure is the socket drop,
+        // not a connect failure on an alternate (IPv6/IPv4) route
+        val host = if (loopback is Inet6Address) "[${loopback.hostAddress}]" else loopback.hostAddress
+        val paymentIntent = createBip70PaymentIntent(testAddress, testAmount, "http://$host:${mockWebServer.port}/payment")
+        mockWebServer.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AFTER_REQUEST))
+        val sendRequest = createTestSendRequest(testAddress, testAmount)
+
+        // When
+        val thrown = try {
+            sendCoinsTaskRunner.sendDirectPayment(sendRequest, paymentIntent, "TestService")
+            null
+        } catch (e: Exception) {
+            e
+        }
+
+        // Then: the result is reported as pending, not as a plain failure
+        assertNotNull("expected an exception", thrown)
+        assertTrue("expected PaymentSubmissionPendingException, got $thrown", thrown is PaymentSubmissionPendingException)
+        val tx = sendRequest.tx
+        assertEquals(tx.txId, (thrown as PaymentSubmissionPendingException).txId)
+
+        // the tx was handed to the verifier and persisted
+        coVerify { pendingPaymentVerifier.quarantine(tx, paymentIntent.paymentUrl!!, "TestService") }
+        coVerify { pendingPaymentConfig.add(match { it.txId == tx.txId }) }
+
+        // its inputs are locked so a retry can't double-spend them ...
+        assertTrue(tx.inputs.isNotEmpty())
+        tx.inputs.forEach { input ->
+            assertTrue("input ${input.outpoint} should be locked", wallet.isLockedOutput(input.outpoint))
+        }
+        // ... but it is not committed: nothing has proven the merchant broadcast it
+        assertTrue(wallet.getTransaction(tx.txId) == null)
+        assertTrue(pendingPaymentVerifier.isTracked(tx.txId))
+    }
+
+    @Test
+    fun `sendDirectPayment does not quarantine when the host cannot be resolved`() = runTest {
+        // Given: a payment URL whose host does not exist - the request never leaves the device
+        val testAddress = Address.fromString(networkParams, "yWdXnYxGbouNoo8yMvcbZmZ3Gdp6BpySxL")
+        val testAmount = Coin.parseCoin("0.01")
+        val paymentIntent = createBip70PaymentIntent(
+            testAddress, testAmount, "https://payment.invalid.dash-wallet-test/payment"
+        )
+        val sendRequest = createTestSendRequest(testAddress, testAmount)
+
+        // When
+        val thrown = try {
+            sendCoinsTaskRunner.sendDirectPayment(sendRequest, paymentIntent)
+            null
+        } catch (e: Exception) {
+            e
+        }
+
+        // Then: a definitive failure, inputs stay spendable
+        assertNotNull(thrown)
+        assertFalse("DNS failure must not be reported as pending", thrown is PaymentSubmissionPendingException)
+        coVerify(exactly = 0) { pendingPaymentVerifier.quarantine(any(), any(), any()) }
+        sendRequest.tx.inputs.forEach { input ->
+            assertFalse(wallet.isLockedOutput(input.outpoint))
         }
     }
 }

--- a/wallet/test/de/schildbach/wallet/payments/SendCoinsTaskRunnerBIP70Test.kt
+++ b/wallet/test/de/schildbach/wallet/payments/SendCoinsTaskRunnerBIP70Test.kt
@@ -893,11 +893,13 @@ class SendCoinsTaskRunnerBIP70Test {
 
     @Test
     fun `sendDirectPayment does not quarantine when the host cannot be resolved`() = runTest {
-        // Given: a payment URL whose host does not exist - the request never leaves the device
+        // Given: a payment URL whose host cannot resolve, so the request never leaves the device.
+        // RFC 2606 reserves the .invalid TLD; a made-up TLD can be answered by a wildcard
+        // resolver, which would turn this into a connect/TLS failure and be classified ambiguous.
         val testAddress = Address.fromString(networkParams, "yWdXnYxGbouNoo8yMvcbZmZ3Gdp6BpySxL")
         val testAmount = Coin.parseCoin("0.01")
         val paymentIntent = createBip70PaymentIntent(
-            testAddress, testAmount, "https://payment.invalid.dash-wallet-test/payment"
+            testAddress, testAmount, "https://payment.dash-wallet-test.invalid/payment"
         )
         val sendRequest = createTestSendRequest(testAddress, testAmount)
 

--- a/wallet/test/de/schildbach/wallet/service/WalletTransactionMetadataProviderGiftCardTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/WalletTransactionMetadataProviderGiftCardTest.kt
@@ -24,10 +24,13 @@ import de.schildbach.wallet.database.dao.TransactionMetadataDocumentDao
 import de.schildbach.wallet.ui.dashpay.utils.DashPayConfig
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import org.bitcoinj.core.Sha256Hash
+import org.bitcoinj.core.Transaction
+import org.bitcoinj.wallet.Wallet
 import org.dash.wallet.common.WalletDataProvider
 import org.dash.wallet.common.data.entity.GiftCard
 import org.dash.wallet.features.exploredash.data.explore.GiftCardDao
@@ -48,6 +51,9 @@ class WalletTransactionMetadataProviderGiftCardTest {
 
     private lateinit var giftCardDao: GiftCardDao
     private lateinit var cacheDao: TransactionMetadataChangeCacheDao
+    private lateinit var metadataDao: TransactionMetadataDao
+    private lateinit var walletData: WalletDataProvider
+    private lateinit var wallet: Wallet
     private lateinit var provider: WalletTransactionMetadataProvider
 
     private val txId: Sha256Hash =
@@ -57,11 +63,16 @@ class WalletTransactionMetadataProviderGiftCardTest {
     fun setUp() {
         giftCardDao = mockk(relaxed = true)
         cacheDao = mockk(relaxed = true)
+        metadataDao = mockk(relaxed = true)
+        wallet = mockk(relaxed = true)
+        walletData = mockk(relaxed = true)
+        every { walletData.wallet } returns wallet
+        every { wallet.getTransaction(any()) } returns null
         provider = WalletTransactionMetadataProvider(
-            transactionMetadataDao = mockk(relaxed = true),
+            transactionMetadataDao = metadataDao,
             addressMetadataDao = mockk<AddressMetadataDao>(relaxed = true),
             iconBitmapDao = mockk<IconBitmapDao>(relaxed = true),
-            walletData = mockk<WalletDataProvider>(relaxed = true),
+            walletData = walletData,
             giftCardDao = giftCardDao,
             swapOrderDao = mockk<SwapOrderDao>(relaxed = true),
             transactionMetadataChangeCacheDao = cacheDao,
@@ -283,5 +294,42 @@ class WalletTransactionMetadataProviderGiftCardTest {
         coVerify(exactly = 0) {
             cacheDao.insertGiftCardData(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
         }
+    }
+
+    // ==================== forgetTransaction ====================
+
+    @Test
+    fun `forgetTransaction discards cards, queued platform changes and metadata`() = runTest {
+        coEvery { giftCardDao.getCardCountForTransaction(txId) } returns 2
+
+        provider.forgetTransaction(txId)
+
+        coVerify { giftCardDao.removeCardsForTransaction(txId) }
+        coVerify { cacheDao.removeByTxId(txId) }
+        coVerify { metadataDao.remove(txId) }
+    }
+
+    @Test
+    fun `forgetTransaction still clears metadata when there were no gift cards`() = runTest {
+        coEvery { giftCardDao.getCardCountForTransaction(txId) } returns 0
+
+        provider.forgetTransaction(txId)
+
+        coVerify(exactly = 0) { giftCardDao.removeCardsForTransaction(any()) }
+        coVerify { cacheDao.removeByTxId(txId) }
+        coVerify { metadataDao.remove(txId) }
+    }
+
+    @Test
+    fun `forgetTransaction refuses to touch a transaction the wallet holds`() = runTest {
+        // the payment did reach the network after all: this is real user data
+        every { wallet.getTransaction(txId) } returns mockk<Transaction>(relaxed = true)
+        coEvery { giftCardDao.getCardCountForTransaction(txId) } returns 1
+
+        provider.forgetTransaction(txId)
+
+        coVerify(exactly = 0) { giftCardDao.removeCardsForTransaction(any()) }
+        coVerify(exactly = 0) { cacheDao.removeByTxId(any()) }
+        coVerify(exactly = 0) { metadataDao.remove(any()) }
     }
 }

--- a/wallet/test/de/schildbach/wallet/service/WalletTransactionMetadataProviderGiftCardTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/WalletTransactionMetadataProviderGiftCardTest.kt
@@ -21,6 +21,7 @@ import de.schildbach.wallet.database.dao.IconBitmapDao
 import de.schildbach.wallet.database.dao.TransactionMetadataChangeCacheDao
 import de.schildbach.wallet.database.dao.TransactionMetadataDao
 import de.schildbach.wallet.database.dao.TransactionMetadataDocumentDao
+import de.schildbach.wallet.database.dao.TransactionRecordsDao
 import de.schildbach.wallet.ui.dashpay.utils.DashPayConfig
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -52,6 +53,7 @@ class WalletTransactionMetadataProviderGiftCardTest {
     private lateinit var giftCardDao: GiftCardDao
     private lateinit var cacheDao: TransactionMetadataChangeCacheDao
     private lateinit var metadataDao: TransactionMetadataDao
+    private lateinit var recordsDao: TransactionRecordsDao
     private lateinit var walletData: WalletDataProvider
     private lateinit var wallet: Wallet
     private lateinit var provider: WalletTransactionMetadataProvider
@@ -64,6 +66,7 @@ class WalletTransactionMetadataProviderGiftCardTest {
         giftCardDao = mockk(relaxed = true)
         cacheDao = mockk(relaxed = true)
         metadataDao = mockk(relaxed = true)
+        recordsDao = mockk(relaxed = true)
         wallet = mockk(relaxed = true)
         walletData = mockk(relaxed = true)
         every { walletData.wallet } returns wallet
@@ -74,6 +77,7 @@ class WalletTransactionMetadataProviderGiftCardTest {
             iconBitmapDao = mockk<IconBitmapDao>(relaxed = true),
             walletData = walletData,
             giftCardDao = giftCardDao,
+            transactionRecordsDao = recordsDao,
             swapOrderDao = mockk<SwapOrderDao>(relaxed = true),
             transactionMetadataChangeCacheDao = cacheDao,
             transactionMetadataDocumentDao = mockk<TransactionMetadataDocumentDao>(relaxed = true),
@@ -299,37 +303,32 @@ class WalletTransactionMetadataProviderGiftCardTest {
     // ==================== forgetTransaction ====================
 
     @Test
-    fun `forgetTransaction discards cards, queued platform changes and metadata`() = runTest {
-        coEvery { giftCardDao.getCardCountForTransaction(txId) } returns 2
+    fun `forgetTransaction discards every record in one database transaction`() = runTest {
+        coEvery { recordsDao.forgetTransaction(txId) } returns 2
 
         provider.forgetTransaction(txId)
 
-        coVerify { giftCardDao.removeCardsForTransaction(txId) }
-        coVerify { cacheDao.removeByTxId(txId) }
-        coVerify { metadataDao.remove(txId) }
-    }
-
-    @Test
-    fun `forgetTransaction still clears metadata when there were no gift cards`() = runTest {
-        coEvery { giftCardDao.getCardCountForTransaction(txId) } returns 0
-
-        provider.forgetTransaction(txId)
-
-        coVerify(exactly = 0) { giftCardDao.removeCardsForTransaction(any()) }
-        coVerify { cacheDao.removeByTxId(txId) }
-        coVerify { metadataDao.remove(txId) }
+        // one atomic call covers the cards, the queued platform changes and the metadata
+        coVerify(exactly = 1) { recordsDao.forgetTransaction(txId) }
     }
 
     @Test
     fun `forgetTransaction refuses to touch a transaction the wallet holds`() = runTest {
         // the payment did reach the network after all: this is real user data
         every { wallet.getTransaction(txId) } returns mockk<Transaction>(relaxed = true)
-        coEvery { giftCardDao.getCardCountForTransaction(txId) } returns 1
 
         provider.forgetTransaction(txId)
 
-        coVerify(exactly = 0) { giftCardDao.removeCardsForTransaction(any()) }
-        coVerify(exactly = 0) { cacheDao.removeByTxId(any()) }
-        coVerify(exactly = 0) { metadataDao.remove(any()) }
+        coVerify(exactly = 0) { recordsDao.forgetTransaction(any()) }
+    }
+
+    @Test
+    fun `forgetTransaction does nothing when no wallet is available to confirm absence`() = runTest {
+        // cannot tell "never broadcast" from "cannot check right now", so fail closed
+        every { walletData.wallet } returns null
+
+        provider.forgetTransaction(txId)
+
+        coVerify(exactly = 0) { recordsDao.forgetTransaction(any()) }
     }
 }

--- a/wallet/test/de/schildbach/wallet/util/services/SendCoinsTaskRunnerTest.kt
+++ b/wallet/test/de/schildbach/wallet/util/services/SendCoinsTaskRunnerTest.kt
@@ -51,7 +51,7 @@ class SendCoinsTaskRunnerTest {
         coEvery { coinJoinService.observeMixingState() } returns MutableStateFlow(MixingStatus.NOT_STARTED)
         val application = mockk<WalletApplication>()
 
-        val sendCoinsTaskRunner = SendCoinsTaskRunner(application, mockk(), mockk(), mockk(), mockk(), mockk(), coinJoinConfig, coinJoinService, mockk(), mockk(), mockk())
+        val sendCoinsTaskRunner = SendCoinsTaskRunner(application, mockk(), mockk(), mockk(), mockk(), mockk(), coinJoinConfig, coinJoinService, mockk(), mockk(), mockk(), mockk())
         val request = sendCoinsTaskRunner.createSendRequest(
             Address.fromBase58(MainNetParams.get(), "XjBya4EnibUyxubEA8D2Y8KSrBMW1oHq5U"),
             Coin.COIN,
@@ -73,7 +73,7 @@ class SendCoinsTaskRunnerTest {
         val application = mockk<WalletApplication>()
         every { application.wallet } returns wallet
 
-        val sendCoinsTaskRunner = SendCoinsTaskRunner(application, mockk(), mockk(), mockk(), mockk(), mockk(), coinJoinConfig, coinJoinService, mockk(), mockk(), mockk())
+        val sendCoinsTaskRunner = SendCoinsTaskRunner(application, mockk(), mockk(), mockk(), mockk(), mockk(), coinJoinConfig, coinJoinService, mockk(), mockk(), mockk(), mockk())
         val request = sendCoinsTaskRunner.createSendRequest(
             Address.fromBase58(MainNetParams.get(), "XjBya4EnibUyxubEA8D2Y8KSrBMW1oHq5U"),
             Coin.COIN,


### PR DESCRIPTION
Fixes [MO-987](https://dashpay.atlassian.net/browse/MO-987).

## The problem

A gift card purchase sat at "pending" for about two hours. The transaction had actually been mined with an InstantSend lock within 90 seconds of the PIN: CTX received the BIP70 payment and broadcast it. The wallet never found out, because the network dropped mid-request, the blockchain service was down for the whole payment window, and the app was then closed. It only discovered the transaction on the next app open.

Two things were wrong. The payment flow treated an ambiguous HTTP failure as a failure, and the signed transaction was left uncommitted with its inputs spendable, so a retry could have built a conflicting transaction. Separately, the blockchain service kept stopping itself at moments that left the payment with no peers.

## Payment submission

- The submission now runs in a `NonCancellable` context. A lock screen or activity recreation can no longer abandon it mid-flight, which is what killed the original recovery poll eight seconds in.
- On an ambiguous failure the signed transaction goes to the new `PendingDirectPaymentVerifier` rather than being guessed about. It locks the inputs so a retry cannot double-spend them, persists the transaction, and watches the network. Seen on the network means commit, unlock and rebroadcast. Never seen while connected and fully synced means the merchant did not receive it, so the inputs are released. Pending payments survive process death and resume when the service starts.
- The payment POST uses a client with `retryOnConnectionFailure` disabled. OkHttp was re-sending the payment on a fresh connection and reporting only the last failure, which is exactly how the incident's `UnknownHostException` masked an earlier attempt that had already reached CTX.
- New `PaymentSubmissionPendingException` lets callers distinguish "unknown" from "failed". The gift card dialog and the generic BIP70 screen show a status-unknown message and deliberately withhold the retry button.

## Gift cards and records

The purchase screen closes holding the only copy of the order details, so a pending payment used to lose them. The order is now recorded on that path too, keyed by the transaction id the exception carries, and `saveGiftCardDummy` suspends until the rows are written. The transaction is also marked as a gift card purchase there: `markGiftCardTransaction` only ran on the success path, so a recovered purchase kept its service tag but lost its expense tax category and merchant icon.

If the payment is later proven never to have been sent, the verifier discards all of it through the new `TransactionMetadataProvider.forgetTransaction`: the gift cards, the `transaction_metadata` row, and any changes still queued for Dash Platform. Queued changes go first so a concurrent publish cannot put the metadata back, and the whole operation refuses to run when the wallet holds the transaction, so it can never discard real user data.

## Blockchain service lifecycle

- `onTrimMemory` only stops at `TRIM_MEMORY_COMPLETE`, and reschedules. `TRIM_MEMORY_BACKGROUND` merely means the process reached the LRU list, which Android reports routinely, so the service was killing itself shortly after every backgrounding under a "low memory detected" message.
- The cleanup deadlock guard waits longer and reschedules a restart instead of leaving the wallet with no service and no peers.
- `PAUSED` mixing now keeps the service in the foreground and demotions are logged, so a paused wallet stops flapping between foreground and background.

## Testing

The full wallet unit suite passes: 117 tests, no failures. 13 are new, covering quarantine, commit, release, resume, the gift card rollback, and the guard that protects a real transaction from being forgotten.

Verified end to end on testnet against CTX staging. A real purchase failed with a `SocketTimeoutException` at `Http2Stream.takeHeaders`, meaning the request was delivered and only the reply was lost, the same failure class as the incident. The transaction was quarantined with its input locked and persisted to disk, and 15 seconds after connectivity returned the verifier found it already in the wallet and released the lock. The trim-memory paths were exercised with `am send-trim-memory`: level 40 leaves the service running, level 80 stops it and the scheduled alarm brings it back.

## Note for reviewers

If a payment is abandoned after its metadata was already published to Dash Platform, the published copy stays there; only the local records and the unpublished queue are cleaned. Unpublishing is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of uncertain direct-payment submissions.
  * Payments with unknown status continue to be monitored and confirmed automatically when detected.
  * Added clear “Payment status unknown” messaging advising customers not to submit the payment again.
  * Gift-card purchases remain safely recorded while payment verification is pending.

* **Bug Fixes**
  * Prevented stale transaction information from remaining after abandoned payments.
  * Improved wallet service recovery and background monitoring for pending payments.
  * Added recovery guidance when gift-card details cannot be saved locally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->