### PR TITLE
fix(explore): merchant locations screen regressions on the All and Online tabs

### DIFF
--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/explore/model/SearchResult.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/data/explore/model/SearchResult.kt
@@ -46,33 +46,31 @@ open class SearchResult(
     @Ignore var distance: Double = Double.NaN
 ) {
     fun getDisplayAddress(separator: String = "\n"): String {
-        val addressBuilder = StringBuilder()
-        addressBuilder.append(address1)
+        // Only non-blank parts contribute, so a record with missing fields yields a shorter
+        // address (or an empty string) rather than a string of stray separators such as ", , ".
+        // Some explore records arrive with no street, city or territory at all.
+        val parts = mutableListOf<String>()
 
-        if (!address2.isNullOrBlank()) {
-            addressBuilder.append("${separator}$address2")
-        }
-
-        if (!address3.isNullOrBlank()) {
-            addressBuilder.append("${separator}$address3")
-        }
-
-        if (!address4.isNullOrBlank()) {
-            addressBuilder.append("${separator}$address4")
+        listOf(address1, address2, address3, address4).forEach { line ->
+            if (!line.isNullOrBlank()) {
+                parts.add(line)
+            }
         }
 
         // CTX records do not use address2, address3, address4
         if (source?.lowercase() == GiftCardProviderType.CTX.name.lowercase() ||
             source?.lowercase() == GiftCardProviderType.PiggyCards.name.lowercase()
         ) {
-            addressBuilder.append("${separator}$city")
-            territory?.let {
-                addressBuilder.append(", ")
-                addressBuilder.append(territory)
+            val cityAndTerritory = listOf(city, territory)
+                .filter { !it.isNullOrBlank() }
+                .joinToString(", ")
+
+            if (cityAndTerritory.isNotEmpty()) {
+                parts.add(cityAndTerritory)
             }
         }
 
-        return addressBuilder.toString()
+        return parts.joinToString(separator)
     }
 
     fun getDistanceStr(isMetric: Boolean): String {

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/explore/ExploreViewModel.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/explore/ExploreViewModel.kt
@@ -564,7 +564,10 @@ class ExploreViewModel @Inject constructor(
     }
 
     fun openAllMerchantLocations(merchantId: String?, source: String) {
-        _screenState.postValue(ScreenState.MerchantLocations)
+        // The screen state is resolved on the first emission instead of here: a merchant whose
+        // locations carry no address at all has nothing to pick from, and is sent to its details
+        // screen rather than to a picker full of blank rows.
+        var screenStateResolved = false
         this.allMerchantLocationsJob?.cancel()
         this.allMerchantLocationsJob = _searchBounds
             // The Google Map camera callback is the only writer of searchBounds. On devices
@@ -617,6 +620,20 @@ class ExploreViewModel @Inject constructor(
                     locations.sortedBy { it.getDisplayAddress(", ") }
                 }
                 _allMerchantLocations.postValue(sorted)
+
+                if (!screenStateResolved) {
+                    screenStateResolved = true
+                    // A location is only worth picking if it can be told apart from the others.
+                    // Some explore records carry coordinates but no street, city or territory.
+                    val hasSelectableLocation = sorted.any { it.getDisplayAddress(", ").isNotBlank() }
+
+                    if (hasSelectableLocation) {
+                        _screenState.postValue(ScreenState.MerchantLocations)
+                    } else {
+                        (_selectedItem.value as? Merchant)?.let { nearestLocation = it }
+                        _screenState.postValue(ScreenState.DetailsGrouped)
+                    }
+                }
             }
             .launchIn(viewModelWorkerScope)
     }

--- a/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/explore/ExploreViewModel.kt
+++ b/features/exploredash/src/main/java/org/dash/wallet/features/exploredash/ui/explore/ExploreViewModel.kt
@@ -519,7 +519,12 @@ class ExploreViewModel @Inject constructor(
         _selectedItem.value = merchant
 
         if (isGrouped) {
-            if (canShowNearestLocation(merchant)) {
+            // The Online tab lists a merchant's online listing, so there is no nearest physical
+            // location to resolve and the details screen never offers the all-locations list for
+            // it. Open details directly, even for chains whose grouped row counts many physical
+            // locations; otherwise, with location disabled or a territory selected, the tap would
+            // land on the all-locations screen instead.
+            if (_filterMode.value == FilterMode.Online || canShowNearestLocation(merchant)) {
                 // Opening details screen
                 nearestLocation = merchant
                 _screenState.postValue(ScreenState.DetailsGrouped)

--- a/features/exploredash/src/test/java/org/dash/wallet/features/exploredash/ExploreViewModelTest.kt
+++ b/features/exploredash/src/test/java/org/dash/wallet/features/exploredash/ExploreViewModelTest.kt
@@ -46,6 +46,7 @@ import org.dash.wallet.features.exploredash.ui.explore.DenomOption
 import org.dash.wallet.features.exploredash.ui.explore.ExploreTopic
 import org.dash.wallet.features.exploredash.ui.explore.ExploreViewModel
 import org.dash.wallet.features.exploredash.ui.explore.FilterMode
+import org.dash.wallet.features.exploredash.ui.explore.ScreenState
 import org.dash.wallet.features.exploredash.utils.ExploreConfig
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -656,6 +657,97 @@ class ExploreViewModelTest {
                 eq(userBounds),
                 any()
             )
+        }
+    }
+
+    private fun multiLocationChain(): Merchant =
+        Merchant(
+            plusCode = "",
+            addDate = "2021-09-08 11:22",
+            updateDate = "2021-09-08 12:22",
+            deeplink = "",
+            paymentMethod = "gift card"
+        ).apply {
+            id = 100
+            merchantId = "merchant1"
+            source = "DashSpend"
+            name = "Chipotle"
+            active = true
+            type = MerchantType.ONLINE
+            // The grouped Online query counts the chain's online and "both" rows
+            physicalAmount = 25
+        }
+
+    private fun viewModelWithLocationDisabled(dataSource: ExploreDataSource): ExploreViewModel {
+        dataSource.stub { onBlocking { getGiftCardProvidersFor(any()) } doReturn emptyList() }
+        val locationMock = mock<UserLocationStateInt> {
+            onBlocking { getCountryCodeFromLocation() } doReturn "US"
+        }
+        val dataSyncStatus = mock<DataSyncStatusService> {
+            on { getSyncProgressFlow() } doReturn flow { emit(Resource.loading(50.0)) }
+            on { hasObservedLastError() } doReturn flow { emit(false) }
+        }
+        return ExploreViewModel(
+            dataSource,
+            locationMock,
+            dataSyncStatus,
+            networkState,
+            mockPreferences,
+            mock<AnalyticsService>()
+        ).also { it.init(ExploreTopic.Merchants) }
+    }
+
+    @Test
+    fun openMerchantDetails_onlineTabGroupedChain_opensDetailsNotAllLocations() {
+        // Regression test: in the Online tab, tapping a chain whose grouped row counts many
+        // physical locations, with location services disabled, must open the merchant details.
+        // It used to fall through to the all-locations screen (which the seeded noBounds query
+        // then filled with every location of the chain).
+        runBlocking {
+            val dataSource = mock<ExploreDataSource>()
+            val viewModel = viewModelWithLocationDisabled(dataSource)
+            viewModel.setFilterMode(FilterMode.Online)
+            val chain = multiLocationChain()
+
+            viewModel.openMerchantDetails(chain, isGrouped = true)
+            kotlinx.coroutines.delay(100)
+
+            assertEquals(ScreenState.DetailsGrouped, viewModel.screenState.value)
+            assertEquals(chain, viewModel.selectedItem.value)
+            verify(dataSource, never()).observeMerchantLocations(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        }
+    }
+
+    @Test
+    fun openMerchantDetails_allTabGroupedChainWithoutLocation_opensAllLocations() {
+        // Counterpart of the Online-tab test: on the physical tabs the all-locations screen is
+        // still the right destination when the nearest location cannot be resolved.
+        runBlocking {
+            val physicalLocations = merchants.filter { it.type == MerchantType.PHYSICAL }
+            val dataSource =
+                mock<ExploreDataSource> {
+                    onBlocking {
+                        observeMerchantLocations(any(), any(), any(), any(), any(), any(), any(), any())
+                    } doReturn flow { emit(physicalLocations) }
+                }
+            val viewModel = viewModelWithLocationDisabled(dataSource)
+            viewModel.setFilterMode(FilterMode.All)
+            val chain = multiLocationChain()
+
+            viewModel.openMerchantDetails(chain, isGrouped = true)
+            kotlinx.coroutines.delay(200)
+
+            assertEquals(ScreenState.MerchantLocations, viewModel.screenState.value)
+            assertEquals(physicalLocations, viewModel.allMerchantLocations.value)
         }
     }
 

--- a/features/exploredash/src/test/java/org/dash/wallet/features/exploredash/ExploreViewModelTest.kt
+++ b/features/exploredash/src/test/java/org/dash/wallet/features/exploredash/ExploreViewModelTest.kt
@@ -697,6 +697,73 @@ class ExploreViewModelTest {
         ).also { it.init(ExploreTopic.Merchants) }
     }
 
+    private fun addressLessLocation(locationId: Int): Merchant =
+        Merchant(
+            plusCode = "merged",
+            addDate = "2021-09-08 11:22",
+            updateDate = "2021-09-08 12:22",
+            deeplink = "",
+            paymentMethod = "gift card"
+        ).apply {
+            id = locationId
+            merchantId = "merchant1"
+            source = "CTX"
+            name = "Starbucks"
+            active = true
+            type = MerchantType.PHYSICAL
+            // Coordinates survive, everything a person could read does not
+            address1 = ""
+            city = ""
+            territory = ""
+            latitude = 33.21492
+            longitude = -86.82601
+        }
+
+    @Test
+    fun openAllMerchantLocations_locationsWithoutAddresses_opensDetailsInsteadOfPicker() {
+        // Regression test: explore records can carry coordinates but no street, city or
+        // territory. A picker listing them shows nothing but blank rows, so the merchant
+        // details screen is opened instead.
+        runBlocking {
+            val dataSource =
+                mock<ExploreDataSource> {
+                    onBlocking {
+                        observeMerchantLocations(any(), any(), any(), any(), any(), any(), any(), any())
+                    } doReturn flow { emit(listOf(addressLessLocation(1), addressLessLocation(2))) }
+                }
+            val viewModel = viewModelWithLocationDisabled(dataSource)
+
+            viewModel.openAllMerchantLocations("merchant1", "DashSpend")
+            kotlinx.coroutines.delay(200)
+
+            assertEquals(ScreenState.DetailsGrouped, viewModel.screenState.value)
+        }
+    }
+
+    @Test
+    fun openAllMerchantLocations_someLocationsHaveAddresses_opensThePicker() {
+        // The picker is still the right destination as soon as one location can be told apart.
+        runBlocking {
+            val readable = addressLessLocation(1).apply {
+                address1 = "2171 Kent Dairy Rd"
+                city = "Alabaster"
+                territory = "Alabama"
+            }
+            val dataSource =
+                mock<ExploreDataSource> {
+                    onBlocking {
+                        observeMerchantLocations(any(), any(), any(), any(), any(), any(), any(), any())
+                    } doReturn flow { emit(listOf(addressLessLocation(2), readable)) }
+                }
+            val viewModel = viewModelWithLocationDisabled(dataSource)
+
+            viewModel.openAllMerchantLocations("merchant1", "DashSpend")
+            kotlinx.coroutines.delay(200)
+
+            assertEquals(ScreenState.MerchantLocations, viewModel.screenState.value)
+        }
+    }
+
     @Test
     fun openMerchantDetails_onlineTabGroupedChain_opensDetailsNotAllLocations() {
         // Regression test: in the Online tab, tapping a chain whose grouped row counts many

--- a/features/exploredash/src/test/java/org/dash/wallet/features/exploredash/SearchResultAddressTest.kt
+++ b/features/exploredash/src/test/java/org/dash/wallet/features/exploredash/SearchResultAddressTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.dash.wallet.features.exploredash
+
+import org.dash.wallet.features.exploredash.data.explore.model.Merchant
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SearchResultAddressTest {
+    private fun merchant(
+        address1: String? = "",
+        city: String? = "",
+        territory: String? = "",
+        merchantSource: String = "CTX"
+    ) = Merchant().apply {
+        this.address1 = address1
+        this.city = city
+        this.territory = territory
+        this.source = merchantSource
+    }
+
+    @Test
+    fun fullAddress_rendersStreetCityTerritory() {
+        val address = merchant(address1 = "2171 Kent Dairy Rd", city = "Alabaster", territory = "Alabama")
+            .getDisplayAddress(", ")
+
+        assertEquals("2171 Kent Dairy Rd, Alabaster, Alabama", address)
+    }
+
+    @Test
+    fun emptyRecord_rendersNothingInsteadOfStraySeparators() {
+        // Regression test: explore records can arrive with no street, city or territory.
+        // Those rows used to render as ", , " in the merchant locations list.
+        assertEquals("", merchant().getDisplayAddress(", "))
+    }
+
+    @Test
+    fun nullRecord_rendersNothingInsteadOfTheWordNull() {
+        assertEquals("", merchant(address1 = null, city = null, territory = null).getDisplayAddress(", "))
+    }
+
+    @Test
+    fun missingStreet_doesNotLeaveALeadingSeparator() {
+        val address = merchant(address1 = "", city = "Alabaster", territory = "Alabama").getDisplayAddress(", ")
+
+        assertEquals("Alabaster, Alabama", address)
+    }
+
+    @Test
+    fun missingCity_doesNotLeaveASeparatorBeforeTheTerritory() {
+        val address = merchant(address1 = "2171 Kent Dairy Rd", city = "", territory = "Alabama")
+            .getDisplayAddress(", ")
+
+        assertEquals("2171 Kent Dairy Rd, Alabama", address)
+    }
+
+    @Test
+    fun nonCtxSource_ignoresCityAndTerritory() {
+        val address = merchant(
+            address1 = "1 Main St",
+            city = "Alabaster",
+            territory = "Alabama",
+            merchantSource = "DCG"
+        )
+            .getDisplayAddress(", ")
+
+        assertEquals("1 Main St", address)
+    }
+}


### PR DESCRIPTION
Stacked on #1556 — review and merge that one first.

## Issue being fixed or feature implemented

Three defects on the merchant locations screen, found while testing #1556 (Jira: [MO-1013](https://dashpay.atlassian.net/browse/MO-1013)).

**1. Online tab opened the all-locations list instead of details.** The Online tab's grouped query counts a chain's online and "both" rows, so `physicalAmount` exceeds 1 for chains like Chipotle. With location services off (or a territory selected) `canShowNearestLocation()` was false and the tap fell through to the all-locations screen. Before #1556 seeded the query with `noBounds` that screen never loaded, so the fall-through was masked by a blank list; with the seeding it showed every location of the chain. There is no nearest physical location to resolve for an online listing, and the details screen never offers the all-locations list for one, so the Online tab now opens details directly. Physical tabs keep the existing routing.

**2. Locations rendered as `", , "`.** `getDisplayAddress` appended the CTX/PiggyCards city and territory unconditionally, so a record with no street, city or territory rendered as bare separators, and a null street rendered the word `null`. The details screen was affected too: it gates its address block on `getDisplayAddress().isNotEmpty()`, which was true for a record with no address at all. Only the parts that are present are joined now.

**3. A picker of blank rows.** A merchant whose locations carry coordinates but no address has nothing to choose between. The destination is resolved from the loaded locations instead of being assumed: with no readable location the merchant details screen opens, where the purchase flow is reachable. One readable location is enough to keep the picker. The screen state is posted on the first emission rather than up front, so the picker no longer appears before its contents are known.

### Note on the underlying data

Defects 2 and 3 surface a dataset problem that this PR only guards against. In the testnet explore database downloaded on 2026-09-09, 94,654 of 144,463 physical merchant rows have no street, city or territory — only coordinates — and all of them carry `plusCode = "merged"`. Ten merchants (T.J.Maxx, Starbucks, CVS, AutoZone, Burger King, Chipotle, Domino's, Ace Hardware among them) have no usable address on any location; five more are partly affected; the remaining 68 are intact. A testnet copy from three hours earlier and the current mainnet dataset are both clean (7 affected rows), so this is a recent testnet publish and needs fixing at the source.

## Related PR's and Dependencies

- Based on #1556 (`fix/piggycards-minmax-as-fixed`). Retarget to master once that merges.

## How Has This Been Tested?

Unit tests, all 36 in `:features:exploredash` passing, `ktlintCheck` clean. Each regression test was confirmed to fail without its fix:

- Online tab routing: `expected DetailsGrouped but was MerchantLocations`
- Blank-address fallback: `expected DetailsGrouped but was MerchantLocations`
- Address formatting: six cases covering full, partial, empty and null records

Reproduced on an Android 14 emulator with location permission denied, on the testnet dataset above. The failing screen was confirmed by dumping the view hierarchy: every row's text was literally `", , "`. The fixed build is installed on that emulator; on-device confirmation of the final screen is still pending.

- [ ] QA (Mobile Team)

## Checklist:

- [x] I have performed a self-review of my own code and added comments where necessary
- [x] I have added or updated relevant unit/integration/functional/e2e tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merchant address display by omitting blank fields and unnecessary separators.
  * Online grouped merchants now open directly to their details.
  * Merchant location selection now opens the location picker only when a readable address is available; otherwise, it opens merchant details.
  * Improved address formatting for different merchant record types.

* **Tests**
  * Added coverage for address formatting and merchant navigation across online and all-merchant views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->