### PR TITLE
test(username): pin the DPNS contestability rule; extract the UI hints

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/username/request/RequestUserNameViewModel.kt
+++ b/wallet/src/de/schildbach/wallet/ui/username/request/RequestUserNameViewModel.kt
@@ -1352,18 +1352,10 @@ class RequestUserNameViewModel @Inject constructor(
         }
     }
 
-    private fun validateNonContestedUsernameSize(uname: String): Boolean {
-        return uname.length in Constants.USERNAME_NON_CONTESTED_MIN_LENGTH..Constants.USERNAME_MAX_LENGTH
-    }
-
     private fun validateUsernameCharacters(uname: String): Pair<Boolean, Boolean> {
         val alphaNumHyphenValid = !Regex("[^a-zA-Z0-9\\-]").containsMatchIn(uname)
         val startOrEndWithHyphen = uname.startsWith("-") || uname.endsWith("-")
         return Pair(alphaNumHyphenValid, startOrEndWithHyphen)
-    }
-
-    private fun validateNonContestedUsernameCharacters(uname: String): Boolean {
-        return Regex("[2-9]").containsMatchIn(uname)
     }
 
     /**
@@ -1614,8 +1606,8 @@ class RequestUserNameViewModel @Inject constructor(
                 usernameSubmittedPoolSyncing = false,
                 usernameCheckSuccess = false,
                 usernameCheckFailed = false,
-                usernameNonContestedLength = validateNonContestedUsernameSize(username),
-                usernameNonContestedChars = validateNonContestedUsernameCharacters(username)
+                usernameNonContestedLength = isNonContestedByLength(username),
+                usernameNonContestedChars = isNonContestedByCharacters(username)
             )
         }
         return validCharacters && validLength

--- a/wallet/src/de/schildbach/wallet/ui/username/request/UsernameContestability.kt
+++ b/wallet/src/de/schildbach/wallet/ui/username/request/UsernameContestability.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.wallet.ui.username.request
+
+import de.schildbach.wallet.Constants
+
+/**
+ * The DPNS contested-name rule, and the two UI hints derived from it.
+ *
+ * THE RULE — there is exactly ONE contestability predicate in the app,
+ * `org.dashj.platform.sdk.platform.Names.isUsernameContestable`, which
+ * matches the DPNS data contract's `contestedIndex` regex:
+ *
+ *     ^[a-zA-Z01-]{3,19}$
+ *
+ * A name is contestable when it is 3..19 characters long AND every
+ * character is a letter, a hyphen, or the digit `0`/`1`. `0` and `1` are
+ * in the alphabet because they are HOMOGLYPHS of `o` and `l` — "he11o"
+ * and "hello" are confusable, so DPNS puts both in the contest. The digits
+ * `2`-`9` have no letter lookalike, so ONE of them anywhere in the name
+ * takes it out of the contested index.
+ *
+ * The consequence that repeatedly surprises readers of the logs: a name
+ * containing digits can still be contestable. `asd10augsh` is contestable
+ * — its only digits are `1` and `0`. `asd10augda6` is not.
+ *
+ * Everything that spends money on a username creation (the balance gate in
+ * [RequestUserNameViewModel], `SdkShieldedUsernameCreation`,
+ * `SdkTransparentUsernameCreation`, `TopUpRepository`, `CreateIdentityService`)
+ * calls `Names.isUsernameContestable` directly. Do NOT re-implement the rule;
+ * a divergent copy would fund a contested name with the non-contested
+ * denomination.
+ *
+ * WHAT THIS FILE IS FOR — the request screen shows two "avoid the contest"
+ * checkmarks, one per REASON a name can fall outside the contested index
+ * (too long, or contains a `2`-`9` digit). Those hints have to decompose the
+ * rule, because the rule's two clauses map to two separate rows of UI. They
+ * live here, as pure functions, so the decomposition can be pinned against
+ * `Names.isUsernameContestable` in [UsernameContestabilityTest] instead of
+ * drifting silently inside the ViewModel. They are LABELS ONLY: no funding
+ * denomination is derived from them.
+ */
+
+/**
+ * Longest name the DPNS `contestedIndex` regex still matches. A name longer
+ * than this is outside the contest regardless of its characters.
+ */
+internal const val DPNS_CONTESTED_MAX_LENGTH = 19
+
+/**
+ * Shortest name the DPNS `contestedIndex` regex matches. Names below it are
+ * rejected by DPNS outright, so the request screen never offers them.
+ */
+internal const val DPNS_CONTESTED_MIN_LENGTH = 3
+
+/**
+ * Digits with no letter homoglyph. One of these anywhere in a name takes it
+ * out of the contested index — the complement of the `0`/`1` the DPNS
+ * alphabet admits.
+ */
+private val NON_HOMOGLYPH_DIGIT = Regex("[2-9]")
+
+/**
+ * True when [uname] escapes the contest BY LENGTH — long enough to fall out
+ * of the DPNS contested index, and still short enough for DPNS to accept.
+ */
+internal fun isNonContestedByLength(uname: String): Boolean =
+    uname.length in Constants.USERNAME_NON_CONTESTED_MIN_LENGTH..Constants.USERNAME_MAX_LENGTH
+
+/**
+ * True when [uname] escapes the contest BY CHARACTERS — it contains at least
+ * one `2`-`9` digit, which the DPNS contested alphabet does not admit.
+ */
+internal fun isNonContestedByCharacters(uname: String): Boolean =
+    NON_HOMOGLYPH_DIGIT.containsMatchIn(uname)

--- a/wallet/test/de/schildbach/wallet/ui/username/request/UsernameContestabilityTest.kt
+++ b/wallet/test/de/schildbach/wallet/ui/username/request/UsernameContestabilityTest.kt
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.wallet.ui.username.request
+
+import de.schildbach.wallet.Constants
+import kotlin.random.Random
+import org.dashj.platform.sdk.platform.Names
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The DPNS contested-name rule, pinned.
+ *
+ * `Names.isUsernameContestable` is the app's ONE contestability predicate and
+ * every funding decision reads it, so this test characterises it directly: a
+ * dashj bump that changes the rule has to break here rather than quietly
+ * change what a username creation charges.
+ *
+ * It also pins the two request-screen hints in [UsernameContestability] as an
+ * exact decomposition of that rule, so the checkmarks cannot drift away from
+ * what the wallet actually spends.
+ *
+ * Written off a QA report (MO-973) that read `asd10augsh` as non-contestable
+ * because it contains digits, and concluded the creation path had overcharged
+ * it. It had not: `0` and `1` are letter homoglyphs and stay inside the
+ * contested index, so 0.25 DASH was the correct denomination.
+ */
+class UsernameContestabilityTest {
+
+    private fun contestable(name: String) = Names.isUsernameContestable(name)
+
+    @Test
+    fun `a short all-letter name is contestable`() {
+        assertTrue(contestable("asd"))
+        assertTrue(contestable("asdsd"))
+        assertTrue(contestable("alice"))
+        assertTrue(contestable("MixedCase"))
+        assertTrue(contestable("with-hyphen"))
+    }
+
+    @Test
+    fun `a 2-9 digit takes a name out of the contest`() {
+        assertFalse(contestable("asd2"))
+        assertFalse(contestable("asd9"))
+        assertFalse(contestable("alice42"))
+        assertFalse(contestable("asd10augda6"))
+        // One non-homoglyph digit anywhere is enough, wherever it sits.
+        assertFalse(contestable("5lice"))
+        assertFalse(contestable("ali5ce"))
+        assertFalse(contestable("alice5"))
+    }
+
+    @Test
+    fun `0 and 1 are letter homoglyphs, so digits alone do not clear the contest`() {
+        // The premise the QA report got wrong: "contains a digit" is NOT the
+        // rule. `0` looks like `o` and `1` looks like `l`, so DPNS keeps both
+        // in the contested index.
+        assertTrue(contestable("he110"))
+        assertTrue(contestable("asd10"))
+        assertTrue(contestable("asd10augsh"))
+        assertTrue(contestable("asd10augda1"))
+        assertTrue(contestable("0110"))
+    }
+
+    @Test
+    fun `the contested index has a 3 to 19 character length window`() {
+        val letters = "a".repeat(Constants.USERNAME_MAX_LENGTH)
+
+        // Below the window DPNS rejects the name outright.
+        assertFalse(contestable(letters.take(DPNS_CONTESTED_MIN_LENGTH - 1)))
+        // First and last contestable lengths.
+        assertTrue(contestable(letters.take(DPNS_CONTESTED_MIN_LENGTH)))
+        assertTrue(contestable(letters.take(DPNS_CONTESTED_MAX_LENGTH)))
+        // One past the window an all-letter name escapes the contest.
+        assertFalse(contestable(letters.take(DPNS_CONTESTED_MAX_LENGTH + 1)))
+        assertFalse(contestable(letters.take(Constants.USERNAME_MAX_LENGTH)))
+    }
+
+    @Test
+    fun `the non-contested length hint starts one past the DPNS maximum`() {
+        // The hint threshold is a hand-written constant; if the DPNS window
+        // ever moves, this is the line that has to move with it.
+        assertEquals(
+            DPNS_CONTESTED_MAX_LENGTH + 1,
+            Constants.USERNAME_NON_CONTESTED_MIN_LENGTH
+        )
+    }
+
+    @Test
+    fun `the field-log names resolve to the denominations the creation path chose`() {
+        // MO-973: routed to the shielded path, funded at the 0.25 contested
+        // denomination, logged contested=true. Correct.
+        assertTrue(contestable("asd10augsh"))
+        // MO-972: the balance gate required 0.25 for every name the user
+        // typed, because none of them contained a 2-9 digit.
+        listOf("asd", "asd1", "asd10", "asd10a", "asd10au", "asd10aug", "asd10augd", "asd10augda", "asd10augda1")
+            .forEach { assertTrue("expected '$it' to be contestable", contestable(it)) }
+        // Adding a `6` is what actually cleared the gate at 0.03.
+        assertFalse(contestable("asd10augda6"))
+    }
+
+    @Test
+    fun `each request-screen hint names one reason, and together they match the rule exactly`() {
+        val alphabet = (('a'..'z') + ('A'..'Z') + ('0'..'9') + '-').toList()
+        val random = Random(20260910)
+        var escapedByLength = 0
+        var escapedByCharacters = 0
+        var contestableSeen = 0
+
+        for (length in DPNS_CONTESTED_MIN_LENGTH..Constants.USERNAME_MAX_LENGTH) {
+            repeat(400) {
+                // Hyphens are legal inside a name but not at either end, so
+                // build only names the request screen would actually accept.
+                val name = buildString {
+                    append(('a'..'z').random(random))
+                    repeat(length - 2) { append(alphabet.random(random)) }
+                    append(('a'..'z').random(random))
+                }
+
+                val byLength = isNonContestedByLength(name)
+                val byCharacters = isNonContestedByCharacters(name)
+                assertTrue(
+                    "hints disagree with Names.isUsernameContestable for '$name'",
+                    !contestable(name) == (byLength || byCharacters)
+                )
+
+                if (byLength) escapedByLength++
+                if (byCharacters) escapedByCharacters++
+                if (contestable(name)) contestableSeen++
+            }
+        }
+
+        // Guard against the equivalence above passing vacuously.
+        assertTrue("no name escaped by length", escapedByLength > 0)
+        assertTrue("no name escaped by characters", escapedByCharacters > 0)
+        assertTrue("no contestable name generated", contestableSeen > 0)
+    }
+}


### PR DESCRIPTION
## Summary

Investigation of the reported username contestability disagreement (MO-973 / MO-972). **The reported bug is not real** — no wrong funding denomination, no duplicated predicate. This PR adds the tests that would have answered the question in seconds, and removes the one piece of genuine duplication that could have grown into the reported bug.

## The report's two premises are both wrong

**1. `checkUsername`'s `contested` is not contestability.** It is `contenders.map.isNotEmpty()` — a network query for whether the name already has vote contenders. The MO-973 log proves it:

```
10:39:55  checkUsername('asd'):   exists=false contested=true  blocked=true
10:39:55  checkUsername('asdsd'): exists=false contested=false blocked=false
10:40:19  checkUsername('asda'):  exists=false contested=false blocked=false
```

`asdsd` and `asda` are short all-letter names — unambiguously contestable — yet the checker reports false. It reports true only for `asd`, the one name with real contenders (`blocked=true`, from a live `lockVoteTally`). A rule-based predicate could not produce that pattern.

**2. The DPNS rule is not "short AND no digits."** dashj's `Names.isUsernameContestable` is the DPNS contract's `contestedIndex` regex:

```
^[a-zA-Z01-]{3,19}$
```

`0` and `1` are in the alphabet because they are **homoglyphs** of `o` and `l` — "he11o" vs "hello" — so DPNS keeps them in the contest. `asd10augsh`'s only digits are `1` and `0`, so it **is** contestable and **0.25 DASH was the correct denomination.** Digits `2`-`9` have no letter lookalike; one of those anywhere clears the contest.

## There is also only one implementation

All 21 call sites — the balance gate, `SdkShieldedUsernameCreation`, `SdkTransparentUsernameCreation`, `TopUpRepository`, `CreateIdentityService`, `PlatformSyncService`, `IdentityRepository`, `RestoreIdentityWorker` — call the same dashj function.

The MO-972 gate log confirms the rule working end to end: every name the gate demanded 0.25 for is `[a-z0-1]`-only, and `asd10augda6` produced **no gate-failure line at all** — the `6` dropped the requirement to 0.03 against a 0.24999474 balance. That is a positive observation, not just an absence of evidence.

So: no wrong denomination, no wrong post-creation routing, and no caller changes in this PR.

## What actually changed

The one genuinely duplicated thing was the request screen's two "avoid the contest" checkmarks, which hand-encoded the rule's complement privately in the ViewModel (`Regex("[2-9]")` and a hardcoded `20`).

Those are **label-only** — `usernameNonContestedChars` / `usernameNonContestedLength` feed only the `RequestUsernameFragment` checkmark rows, and no denomination derives from them — but nothing stopped them drifting from what the wallet spends.

- **`UsernameContestability.kt`** (new): the two hints as pure `internal` functions, with the homoglyph rule documented where the next reader will hit it, and an explicit "do not re-implement the rule" note.
- **`RequestUserNameViewModel.kt`**: calls those instead of the private copies. Behaviour-identical.
- **`UsernameContestabilityTest.kt`** (new): pins the hints as an exact decomposition of `Names.isUsernameContestable` itself, so a dashj bump that moves the rule breaks a test instead of quietly repricing a creation.

## Tests

Seven tests pin: a short all-letters name is contestable; a `2`-`9` digit clears the contest; `0`/`1` do not; the 3..19 length window and the `20` threshold one past it; the actual field-log names from both reports; and the hint/rule equivalence over ~8k generated names.

One requested assertion was itself the bug's premise — "a name containing digits is not contestable" is false — so the tests pin the real rule instead.

**Verified with teeth:** substituting the report's assumed `[0-9]` rule fails the equivalence test. Restored, then:

- `./gradlew ktlintFormat` — no changes
- `./gradlew :wallet:compile_testNet3DebugKotlin` — clean
- `./gradlew :wallet:test_testNet3DebugUnitTest` — **1914 tests, 0 failures**

## Scope

Separate from the two underlying MO-973 / MO-972 failures (the FFI "Invalid identity data" DPNS rejection and the HONOR auth-gated Keystore refusal), which are handled elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved username contestability validation on the request screen.
  - Contestability indicators now correctly reflect username length and the presence of digits 2–9.
  - Names containing 0 or 1 continue to be treated as contestable, consistent with DPNS rules.
  - Updated handling of the contested-name length range for more accurate feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->