### PR TITLE
fix(dashpay): report the Keystore lock-gate refusal for what it is (MO-972)

### DIFF
--- a/wallet/src/de/schildbach/wallet/di/PlatformSdkModule.kt
+++ b/wallet/src/de/schildbach/wallet/di/PlatformSdkModule.kt
@@ -18,6 +18,7 @@
 package de.schildbach.wallet.di
 
 import dagger.Binds
+import dagger.Provides
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
@@ -50,15 +51,6 @@ abstract class PlatformSdkModule {
     @Singleton
     @Binds
     abstract fun bindDashSdkService(dashSdkService: DashSdkServiceImpl): DashSdkService
-
-    /**
-     * The DIP-15 coreHeight-backfill gate — the app-side interim mitigation
-     * for the SDK's in-memory-only `rescan_triggered` guard. Read-only and
-     * lazy like the rest of this module: it never starts the SDK.
-     */
-    @Singleton
-    @Binds
-    abstract fun bindDashPayBackfillGate(gate: DashPayBackfillGateImpl): DashPayBackfillGate
 
     /**
      * The Phase 3b dashj seed bridge. Never prompts: callers pass an
@@ -96,4 +88,28 @@ abstract class PlatformSdkModule {
     abstract fun bindSdkMessageSigner(
         signer: DashSdkMessageSigner
     ): SdkMessageSigner
+
+    companion object {
+        /**
+         * The DIP-15 coreHeight-backfill gate is DISABLED (bound to the
+         * no-op [DashPayBackfillGate.ALWAYS_RUN]) now that the ordered
+         * wallet bring-up (`startWalletSubsystems`, called before `startSpv`
+         * in [de.schildbach.wallet.service.platform.sdk.L1ShadowSyncService])
+         * registers contact receival accounts BEFORE the compact-filter
+         * scan — so there is no post-scan gap for the gate to detect or
+         * rewind for. This matches iOS, which has no such host gate. The
+         * gate's watch channel could not complete anyway (the SDK's
+         * persisted sync cursor is monotonic-max guarded, so the durable
+         * watermark drop it waited for never lands).
+         *
+         * [DashPayBackfillGateImpl] is left in the tree, unused, pending a
+         * later deliberate removal; flip this back to a
+         * `@Binds DashPayBackfillGateImpl` to re-enable it. See
+         * FIXES-restored-wallets.md #1/#5.
+         */
+        @Singleton
+        @Provides
+        fun provideDashPayBackfillGate(): DashPayBackfillGate =
+            DashPayBackfillGate.ALWAYS_RUN
+    }
 }

--- a/wallet/src/de/schildbach/wallet/service/platform/IdentityRepository.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/IdentityRepository.kt
@@ -1075,11 +1075,43 @@ class IdentityRepositoryImpl @Inject constructor(
         return dashPayProfileDao.loadByUserId(userId)
     }
 
+    /**
+     * Discover this wallet's identity from its first identity key.
+     *
+     * Tolerates the legacy dashj identity cache the same way the contact-request path
+     * does. `fetchIdentityFromPubKeyHash` FETCHES the identity and only then CBOR-encodes
+     * it into the in-memory cache via `PlatformStateRepository.storeIdentity`; our own
+     * 6-key identities bind keys 4/5 to `SingleContractDocumentType(dashpay,
+     * "contactRequest")`, which that encoder cannot serialize — it throws
+     * `IllegalArgumentException("No converter for ...")` AFTER a successful fetch, so the
+     * caller loses a perfectly good identity.
+     *
+     * Observed live (emulator, testnet 12000000, 2026-09-10): this escaped to EVERY caller
+     * — RestoreIdentityWorker aborted restoration outright, and
+     * `PlatformSyncService.discoverAndRecoverIdentity` (via BlockchainServiceImpl) failed
+     * identity discovery. The tolerance belongs here, at the single shared read, rather
+     * than at each of the five call sites.
+     *
+     * The cache is a pure optimization: on that specific failure refetch through the
+     * cache-bypassing DAPI path, which never calls `storeIdentity`. Every other failure
+     * propagates unchanged, so real fetch errors are never masked.
+     */
     override fun getIdentityFromPublicKeyId(): Identity? {
         return try {
             platformRepo.getWalletEncryptionKey()?.let {
                 val firstIdentityKey = platformRepo.getBlockchainIdentityKey(0, it) ?: return null
-                platform.stateRepository.fetchIdentityFromPubKeyHash(firstIdentityKey.pubKeyHash)
+                fetchIdentityToleratingCacheError(
+                    cachedGet = {
+                        platform.stateRepository.fetchIdentityFromPubKeyHash(firstIdentityKey.pubKeyHash)
+                    },
+                    cacheBypassingFetch = {
+                        log.warn(
+                            "identity lookup by public key hash was fetched but the legacy CBOR " +
+                                "cache rejected its contract-bound-key shape; bypassing the cache"
+                        )
+                        platform.client.getIdentityByFirstPublicKey(firstIdentityKey.pubKeyHash)
+                    }
+                )
             }
         } catch (e: MaxRetriesReachedException) {
             null

--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/DashSdkServiceImpl.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/DashSdkServiceImpl.kt
@@ -1100,16 +1100,28 @@ class DashSdkServiceImpl @Inject constructor(
 
         // 2. Storage layer — ← AppContainer construction (database,
         //    walletStorage, walletManagerStore fields). DEVICE_BOUND key
-        //    policy (#4060): this app gates wallet access with its own PIN
-        //    (SecurityGuard), so the SDK's default AUTH_GATED alias only
-        //    added a second, unwired auth layer — identity-key signing died
-        //    with "User not authenticated" outside the ~30 s post-unlock
-        //    window (observed live: contact-accept dead ends, mid-operation
-        //    signing failures). DEVICE_BOUND keys stay hardware-backed and
-        //    non-exportable but never throw UserNotAuthenticatedException.
-        //    Keys previously wrapped under the AUTH_GATED alias surface as
-        //    unhealthy and are re-derived + re-wrapped by the binder's
-        //    key-heal pass (repairIdentityKey) — no user action needed.
+        //    policy (landed upstream as dashpay/platform#4183; the #4060 PR
+        //    that proposed it was closed unmerged): this app gates wallet
+        //    access with its own PIN (SecurityGuard), so the SDK's default
+        //    AUTH_GATED alias only added a second, unwired auth layer —
+        //    identity-key signing died with "User not authenticated" outside
+        //    the ~30 s post-unlock window (observed live: contact-accept dead
+        //    ends, mid-operation signing failures). DEVICE_BOUND keys stay
+        //    hardware-backed and non-exportable, and carry no authentication
+        //    gate.
+        //
+        //    They can still throw UserNotAuthenticatedException, though — an
+        //    earlier version of this comment claimed otherwise and cost us
+        //    MO-972. The DEVICE_BOUND alias is not auth-gated but IS
+        //    lock-bound (`setUnlockedDeviceRequired`), and Android reports a
+        //    denial of THAT gate with the identical exception. On OEM builds
+        //    whose lock-state tracking is defective (HONOR PTP-N49; Google
+        //    confirmed the same on Fairphone 5/6) signing failed with "User
+        //    not authenticated" on a policy that has no auth window, and the
+        //    error was read as a timeout for weeks. dashpay/platform#4643
+        //    classifies that denial SDK-side and degrades the affected device
+        //    onto a never-lock-bound alias; SdkDashPayWrites classifies the
+        //    resulting typed message.
         var database: DashDatabase? = null
         var sdk: Sdk? = null
         try {

--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/L1ShadowSyncService.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/L1ShadowSyncService.kt
@@ -1272,6 +1272,21 @@ interface L1ShadowSource {
 
     suspend fun stopSpv()
 
+    /**
+     * Ordered DashPay bring-up (identity → contacts → contact-account
+     * drain) for one wallet, run immediately before [startSpv] so a
+     * contact's DIP-15 receiving addresses are watched from the first
+     * filter set — the restored-wallet receival gap (topple: 0.0836 of
+     * genuinely-ours coins missed at scan time because the accounts
+     * register only after the scan; see FIXES-restored-wallets.md #1).
+     * Wraps the SDK's `PlatformWalletManager.startWalletSubsystems`.
+     *
+     * Returns a short status summary for logging, or null when the source
+     * does not support it (test fakes). Best-effort by contract: the caller
+     * must not let a failure here block or fail SPV start.
+     */
+    suspend fun startWalletSubsystems(walletIdHex: String): String? = null
+
     /** The manager's 1 Hz SPV progress feed (live while SPV runs). */
     fun spvProgress(): Flow<SpvSyncProgressData>
 
@@ -1405,6 +1420,14 @@ internal class DashSdkL1ShadowSource(
         manager().startSpv(dataDir = dataDir)
 
     override suspend fun stopSpv() = manager().stopSpv()
+
+    override suspend fun startWalletSubsystems(walletIdHex: String): String? {
+        val walletId = walletIdFromHex(walletIdHex) ?: return null
+        val o = manager().startWalletSubsystems(walletId)
+        return "status=${o.status} discovery=${o.discoveryAttempts} " +
+            "dashPaySyncRan=${o.dashPaySyncRan} drained=${o.contactAccountsDrained} " +
+            "pending=${o.contactAccountsPending} elapsedMs=${o.elapsedMs}"
+    }
 
     override fun spvProgress(): Flow<SpvSyncProgressData> =
         flow { emitAll(manager().spvProgress) }
@@ -2091,6 +2114,24 @@ class L1ShadowSyncService internal constructor(
 
                 val dataDir = File(spvDataDirPath()).apply { mkdirs() }
                 if (!source.isSpvRunning()) {
+                    // Ordered DashPay bring-up BEFORE SPV: register the
+                    // contact receival/external accounts so their DIP-15
+                    // addresses are in the very first filter set, instead of
+                    // registering them in a post-sync drain that the scan has
+                    // already run past (FIXES-restored-wallets.md #1). Runs
+                    // once per process here (guarded by runningWalletIdHex
+                    // above). Best-effort: it returns a status rather than
+                    // throwing, and any failure must not hold back SPV — Core
+                    // sync is the wallet's primary function.
+                    try {
+                        val summary = source.startWalletSubsystems(walletIdHex)
+                        if (summary != null) {
+                            log.info("DashPay bring-up before SPV: $summary")
+                        }
+                    } catch (t: Throwable) {
+                        if (t is CancellationException) throw t
+                        log.warn("DashPay bring-up before SPV failed; starting SPV anyway", t)
+                    }
                     source.startSpv(dataDir.absolutePath)
                 }
                 runningWalletIdHex.value = walletIdHex

--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/SdkDashPayWrites.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/SdkDashPayWrites.kt
@@ -146,35 +146,55 @@ internal fun classifyBroadcastFailure(t: Throwable): SdkWriteResult<Nothing> = w
             "pre-broadcast identity data rejected by the FFI — ${t.message}",
             t
         )
-    // Android Keystore auth-window expiry: the SDK keeps identity keys
-    // AUTH_GATED (decryptable only within ~30 s of a biometric/device-credential
-    // unlock), and an expired window surfaces as UserNotAuthenticatedException —
-    // message "User not authenticated" — thrown while DECRYPTING the identity
-    // key to sign the state transition (KeystoreSigner.retrieveKeyWithAuth →
-    // WalletStorage.retrievePrivateKey; only the identity-key alias is
-    // auth-gated, so no other SDK path produces this message). Signing happens
-    // during transition CONSTRUCTION (dpp `sign_external_with_options`, called
-    // from `BatchTransition::new_document_*_transition_from_document` inside
-    // rs-sdk `put_to_platform`), strictly BEFORE `transition.broadcast` — the
-    // signer error propagates out before the broadcast line is reached, and no
+    // Android Keystore refused the key that signs the state transition.
+    // Signing happens during transition CONSTRUCTION (dpp
+    // `sign_external_with_options`, called from
+    // `BatchTransition::new_document_*_transition_from_document` inside rs-sdk
+    // `put_to_platform`), strictly BEFORE `transition.broadcast` — the signer
+    // error propagates out before the broadcast line is reached, and no
     // post-broadcast step invokes the identity-key signer. Nothing was
     // submitted → safe dashj fallback (app-side keys, no Keystore gate).
-    // Message-matched until platform PR #4060 (DEVICE_BOUND key policy)
-    // replaces the auth window and gives this a typed error.
-    t.message?.contains("User not authenticated") == true ->
-        // MO-972: this used to read "Keystore auth window expired", which
-        // ASSERTS a timeout nobody measured. Field log (2026-09-10, testnet
-        // 12000007, HONOR PTP-N49) — biometric at 11:49:16, this at 11:49:17.
-        // One second. The window had not expired; the Keystore simply refused
-        // to treat the auth as satisfying the identity key's gate, which on
-        // that OEM is the same defect family as the false-locked master alias
-        // (dashpay/platform#4643 fixes that one and explicitly does NOT cover
-        // the auth-gated identity alias; #4060's DEVICE_BOUND policy is the
-        // remedy). Report what Keystore said, not a cause we inferred.
+    //
+    // MO-972 taught us there are TWO gates behind this, and Android reports
+    // both with the same `UserNotAuthenticatedException("User not
+    // authenticated")`:
+    //
+    //  - `setUserAuthenticationRequired` — the ~30 s auth window. This app
+    //    does NOT use it: it runs KeySecurityPolicy.DEVICE_BOUND (see
+    //    DashSdkServiceImpl), whose alias has no auth gate at all.
+    //  - `setUnlockedDeviceRequired` — "the device must be unlocked right
+    //    now", which the SDK stamps on every alias including the DEVICE_BOUND
+    //    one. Some OEM builds deny it while KeyguardManager reports the device
+    //    unlocked (HONOR PTP-N49; Google confirmed the same on Fairphone 5/6,
+    //    Issue Tracker 506989112).
+    //
+    // The first arm is the one that fires today. dashpay/platform#4643
+    // classifies the lock-gate denial SDK-side into KeystoreDeviceLockedException,
+    // whose message names the alias and the KeyguardManager state at throw
+    // time — so it no longer contains "User not authenticated" and would fall
+    // through to the generic arms without this.
+    t.message?.contains("as device-locked") == true ->
         SdkWriteResult.NotBroadcast(
-            "signing failure (pre-broadcast): Keystore refused the identity key as " +
-                "unauthenticated (auth window may have expired, or the device's " +
-                "auth-bound Keystore gate is defective) — ${t.message}",
+            "signing failure (pre-broadcast): Keystore refused the signing key because " +
+                "it considers the device locked — ${t.message}",
+            t
+        )
+    // The second arm covers AAR lines older than #4643 (denial still
+    // unclassified), and the genuinely auth-gated paths that survive on an
+    // install predating the DEVICE_BOUND switch: identity-key blobs still
+    // wrapped under the legacy auth-gated alias, reached through
+    // WalletStorage.retrievePrivateKey's migration fallback.
+    //
+    // The wording deliberately does not ASSERT a timeout. It used to read
+    // "Keystore auth window expired"; the field log (2026-09-10, testnet
+    // 12000007, HONOR PTP-N49) shows the biometric at 11:49:16 and this at
+    // 11:49:17 — one second, on a policy with no window to expire. Report
+    // what Keystore said, not a cause we inferred.
+    t.message?.contains("User not authenticated") == true ->
+        SdkWriteResult.NotBroadcast(
+            "signing failure (pre-broadcast): Keystore refused the signing key as " +
+                "unauthenticated (the device's Keystore gate rejected it; on this app's " +
+                "DEVICE_BOUND policy there is no auth window to expire) — ${t.message}",
             t
         )
     // TYPED funding shortfalls — checked BEFORE the message arms because

--- a/wallet/src/de/schildbach/wallet/service/platform/sdk/SdkTxStoreWalker.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/sdk/SdkTxStoreWalker.kt
@@ -62,7 +62,18 @@ internal fun txoIsForeignSql(alias: String): String =
 internal data class TxPayloadFacts(
     val outputsTotalDuffs: Long,
     val outputCount: Int,
-    val inputCount: Int
+    val inputCount: Int,
+    /**
+     * Per-output destination address (base58), index-aligned with vout; null
+     * for an output with no resolvable address (OP_RETURN burns,
+     * non-standard scripts). The mirror-completeness guard
+     * ([firstUnmirroredKnownOutput]) matches these against `core_addresses`
+     * to tell a `txos` row that is MISSING (the store dropped it) apart from
+     * one that is legitimately absent (the output paid an external party).
+     * Empty when the facts source cannot provide addresses — the guard is
+     * then inert and the pre-guard behavior stands.
+     */
+    val outputAddresses: List<String?> = emptyList()
 )
 
 /**
@@ -76,10 +87,44 @@ internal fun dashjPayloadFacts(payload: ByteArray): TxPayloadFacts? = try {
     TxPayloadFacts(
         outputsTotalDuffs = tx.outputs.sumOf { it.value.value },
         outputCount = tx.outputs.size,
-        inputCount = tx.inputs.size
+        inputCount = tx.inputs.size,
+        outputAddresses = tx.outputs.map { out ->
+            try {
+                out.scriptPubKey.getToAddress(de.schildbach.wallet.Constants.NETWORK_PARAMETERS, true).toBase58()
+            } catch (t: Throwable) {
+                null
+            }
+        }
     )
 } catch (t: Throwable) {
     null
+}
+
+/**
+ * Mirror-completeness guard predicate: the vout of the FIRST payload output
+ * that pays an address the wallet already tracks (`core_addresses`,
+ * [knownWalletAddresses]) yet has NO `txos` row ([mirroredVouts]) — or null
+ * when every wallet-known output is mirrored.
+ *
+ * A non-null result proves the TXO mirror is missing rows for this
+ * transaction: an output to a tracked address is exactly what the store
+ * mirrors into `txos` (owned chains and the watch-only DIP-15 contact
+ * chains alike), so its absence means the rows were dropped or have not
+ * landed yet — NOT that the value left the wallet. An output to an UNKNOWN
+ * address never trips the guard: that is the ordinary external-payment
+ * shape, whose absence from the mirror is what OUTGOING classification is
+ * built on. Pure — host-testable.
+ */
+internal fun firstUnmirroredKnownOutput(
+    payload: TxPayloadFacts,
+    knownWalletAddresses: Set<String>,
+    mirroredVouts: Set<Int>
+): Int? {
+    if (knownWalletAddresses.isEmpty()) return null
+    payload.outputAddresses.forEachIndexed { vout, address ->
+        if (address != null && address in knownWalletAddresses && vout !in mirroredVouts) return vout
+    }
+    return null
 }
 
 /**
@@ -541,6 +586,30 @@ internal class SdkTxStoreWalker(
      * Rust record), which re-satisfies the flag condition and is simply
      * re-corrected and re-persisted — the invalidation is structural, not
      * keyed off time or a rescan marker.
+     *
+     * ## Guarded — no correction from a provably-INCOMPLETE mirror
+     *
+     * The recompute is only as good as the `txos` rows it sums. During the
+     * 2026-08-19 device investigation the store had DROPPED change-output
+     * rows (platform ecc6740ed4, owned-role index collisions in the
+     * same-txid record fold), so the walker summed an incomplete funded set
+     * and durably stamped born-wrong nets (5e4d7282: −0.98771 stamped when
+     * the true net was −0.00000227) — turning a transient store gap into a
+     * persisted wrong value that then FOUGHT any later correct engine
+     * upsert (the still-incomplete mirror keeps "proving" the wrong net).
+     * The guard: before applying a payload-informed correction, every
+     * payload output that pays a wallet-tracked address (`core_addresses`)
+     * must have a `txos` row ([firstUnmirroredKnownOutput]); a missing one
+     * proves the mirror dropped or has not yet written rows for this tx, so
+     * the record is SKIPPED — stored shape served, nothing persisted — and
+     * simply retried on every later pass until the mirror is complete
+     * (rows landing late is the common transient case; the flag condition
+     * re-fires structurally). Outputs paying UNKNOWN addresses never trip
+     * the guard — that is the ordinary external send, whose mirror absence
+     * is exactly what OUTGOING classification rests on. The guard needs
+     * payload facts: the payload-free degrade path and the net≥0 branch
+     * (which stays flagged and is recomputed every pass anyway, so a gap
+     * self-heals) are unchanged.
      */
     private fun reattributed(rows: List<RecordRow>): List<L1TxUiRecord> {
         // Pending-input reservations ([pendingSpentAggregates]) supplement the
@@ -654,10 +723,68 @@ internal class SdkTxStoreWalker(
             }
         }
 
+        // Mirror-completeness probes for the payload-informed subset: which
+        // of the payload output addresses the wallet tracks, and which vouts
+        // the mirror actually holds rows for. Two bounded chunked queries,
+        // paid only when a correction is pending at all.
+        val knownAddressCandidates = HashSet<String>()
+        for (row in needsFacts) {
+            facts[row.record.txidHex]?.outputAddresses?.forEach { if (it != null) knownAddressCandidates += it }
+        }
+        val knownWalletAddresses = HashSet<String>()
+        for (chunk in knownAddressCandidates.chunked(TXID_IN_CHUNK)) {
+            val placeholders = chunk.joinToString(",") { "?" }
+            rawQuery(
+                "SELECT address FROM core_addresses WHERE address IN ($placeholders)",
+                chunk.toTypedArray<Any?>()
+            ) { c -> while (c.moveToNext()) knownWalletAddresses += c.getString(0) }
+        }
+        val mirroredVouts = HashMap<String, MutableSet<Int>>()
+        if (knownWalletAddresses.isNotEmpty()) {
+            for (chunk in needsFacts.chunked(TXID_IN_CHUNK)) {
+                val placeholders = chunk.joinToString(",") { "?" }
+                val args = ArrayList<Any?>(1 + chunk.size)
+                args.add(walletId)
+                chunk.forEach { args.add(it.wireTxid) }
+                // Foreign rows count as mirrored here: the store mirrors
+                // contact-chain outputs into txos too, so their presence is
+                // part of the completeness evidence.
+                rawQuery(
+                    "SELECT t.txid, t.vout FROM txos t WHERE t.walletId = ? AND t.txid IN ($placeholders)",
+                    args.toTypedArray()
+                ) { c ->
+                    while (c.moveToNext()) {
+                        mirroredVouts.getOrPut(displayHexOf(c.getBlob(0))) { HashSet() } += c.getInt(1)
+                    }
+                }
+            }
+        }
+
         val correctedByHex = HashMap<String, L1TxUiRecord>(flagged.size)
         val toPersist = ArrayList<Pair<RecordRow, L1TxUiRecord>>()
         for (row in flagged) {
             val hex = row.record.txidHex
+            val fact = facts[hex]
+            val unmirroredVout = if (fact == null) {
+                null
+            } else {
+                firstUnmirroredKnownOutput(fact, knownWalletAddresses, mirroredVouts[hex] ?: emptySet())
+            }
+            if (unmirroredVout != null) {
+                // The mirror is missing rows for this tx — any net summed
+                // from it would be born wrong (the 2026-08-19 shape). Serve
+                // the stored record, write nothing, retry next pass.
+                if (reattributionDeferredLogged.add(hex)) {
+                    log.info(
+                        "reattribution of {} deferred: output {} pays wallet-tracked address {} " +
+                            "but has no txos row — the TXO mirror is incomplete for this tx, so a " +
+                            "recomputed net would be wrong; serving the stored record and retrying " +
+                            "once the mirror rows land",
+                        hex, unmirroredVout, fact?.outputAddresses?.getOrNull(unmirroredVout).orEmpty()
+                    )
+                }
+                continue
+            }
             val pend = pendingOf(row)
             // DISPLAY shape: confirmed spent marks PLUS in-flight reservations,
             // so the correction lands at broadcast, not at confirmation.
@@ -1047,6 +1174,22 @@ internal class SdkTxStoreWalker(
          * Bounded; an evicted txid merely re-logs, it never re-corrupts.
          */
         private val reattributionLogged: MutableSet<String> =
+            java.util.Collections.synchronizedSet(
+                java.util.Collections.newSetFromMap(
+                    object : LinkedHashMap<String, Boolean>() {
+                        override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, Boolean>): Boolean =
+                            size > 1_024
+                    }
+                )
+            )
+
+        /**
+         * Incomplete-mirror deferrals already logged, process-wide — same
+         * rationale and bound as [reattributionLogged]: the deferral repeats
+         * every pass until the mirror rows land, and one line per txid is
+         * all a log reader needs.
+         */
+        private val reattributionDeferredLogged: MutableSet<String> =
             java.util.Collections.synchronizedSet(
                 java.util.Collections.newSetFromMap(
                     object : LinkedHashMap<String, Boolean>() {

--- a/wallet/src/de/schildbach/wallet/service/platform/work/RestoreIdentityWorker.kt
+++ b/wallet/src/de/schildbach/wallet/service/platform/work/RestoreIdentityWorker.kt
@@ -177,6 +177,9 @@ class RestoreIdentityWorker @AssistedInject constructor(
                 )
             }
             updateNotification(applicationContext.getString(R.string.processing_home_title), applicationContext.getString(R.string.processing_home_step_1), 5, 1)
+            // Identity-cache CBOR tolerance for this read now lives in
+            // IdentityRepositoryImpl.getIdentityFromPublicKeyId, which every caller
+            // shares — see its KDoc.
             val existingIdentity = identityRepository.getIdentityFromPublicKeyId()
                 ?: throw IllegalArgumentException("identity $identity doesn't exist on the network")
 
@@ -255,7 +258,57 @@ class RestoreIdentityWorker @AssistedInject constructor(
                     log.warn("cutover-state read failed while completing DPNS registration; skipping", e)
                     false
                 }
-                if (cutoverCommitted && !requestedLabel.isNullOrEmpty()) {
+                // A CONTESTED name that HAS already been requested is invisible
+                // here: `recoverUsernames` resolves a name through the DPNS unique
+                // index, and for a contested label that index is not awarded until
+                // the vote concludes — so `currentUsername` stays null even though
+                // the identity's own contender document is on chain. Re-registering
+                // on that basis pays the 0.2 DASH prefunded specialized balance a
+                // SECOND time.
+                //
+                // Field evidence (testnet 12000000, emulator, 2026-09-10): identity
+                // 7oct2Gqw… funded 0.25, registered `test-contested-1000` (explorer
+                // shows the name and exactly 20,000,000,000 credits gone to the vote
+                // poll beyond gas), then this block re-registered it and the FFI
+                // rejected the duplicate — "Insufficient identity balance
+                // 4680452100 required 20000100000". Each later trigger burned another
+                // preorder document's gas (blocks 570460, 570461) for a name the
+                // identity already owns.
+                //
+                // So ASK FIRST, with the single targeted query the candidate set
+                // already implies (see [ownContestedCandidates], which reads this
+                // same USERNAME pref). Fails CLOSED: `getVoteContenders` collapses a
+                // failed read into "no contenders", which is indistinguishable from
+                // "never requested", so use the throwing variant and treat an
+                // unreadable vote state as already-requested. Deferring costs one
+                // more worker trigger; a duplicate costs 0.2 DASH irrecoverably.
+                val alreadyContending = if (contestedReregistrationCheckApplies(requestedLabel)) {
+                    try {
+                        isOwnIdentityAContender(
+                            platformRepo.getVoteContendersOrThrow(requestedLabel!!).map.keys,
+                            blockchainIdentity.uniqueIdentifier
+                        )
+                    } catch (e: Exception) {
+                        log.warn(
+                            "contested re-registration guard: could not read the vote state for '{}' — " +
+                                "treating it as ALREADY requested and skipping re-registration (fail closed; " +
+                                "a later trigger re-drives this)",
+                            requestedLabel,
+                            e
+                        )
+                        true
+                    }
+                } else {
+                    false
+                }
+
+                if (cutoverCommitted && !requestedLabel.isNullOrEmpty() && alreadyContending) {
+                    log.info(
+                        "'{}' is a contested name this identity already contends for — skipping DPNS " +
+                            "re-registration; the contested-name walk below recovers the voting state",
+                        requestedLabel
+                    )
+                } else if (cutoverCommitted && !requestedLabel.isNullOrEmpty()) {
                     log.info("identity has no on-chain name yet — registering DPNS name '{}' via the SDK", requestedLabel)
                     identityRepository.updateIdentityCreationState(blockchainIdentityData, IdentityCreationState.PREORDER_REGISTERING)
                     identityRepository.updateIdentityCreationState(blockchainIdentityData, IdentityCreationState.USERNAME_REGISTERING)
@@ -889,3 +942,33 @@ internal fun contestedNameListsCanMatch(
     targetedScan: Boolean,
     ownCandidateNames: Set<String>
 ): Boolean = !targetedScan || ownCandidateNames.any { Names.isUsernameContestable(it) }
+
+/**
+ * Is the re-registration guard in [RestoreIdentityWorker] worth a vote-state query
+ * for [requestedLabel]?
+ *
+ * Only a CONTESTABLE label can be sitting in a vote poll invisible to
+ * `recoverUsernames`. A non-contestable name resolves through the ordinary DPNS
+ * unique index the moment it lands, so for those `currentUsername == null` really
+ * does mean "never registered" and the historic behaviour is exactly right — no
+ * query, no behaviour change.
+ *
+ * Blank/absent label means there is nothing to re-register at all.
+ */
+internal fun contestedReregistrationCheckApplies(requestedLabel: String?): Boolean =
+    !requestedLabel.isNullOrBlank() && Names.isUsernameContestable(requestedLabel)
+
+/**
+ * Is [ownIdentityId] one of the [contenderIds] for a contested name?
+ *
+ * True means this identity's own contender document is already on chain for that
+ * name — the vote is under way, the 0.2 DASH prefunded specialized balance has
+ * already been paid, and re-registering would pay it again. Mirrors the identity
+ * match the contested-name walk itself uses (`uniqueIdentifier == identifier`).
+ *
+ * Pure — host-testable.
+ */
+internal fun isOwnIdentityAContender(
+    contenderIds: Collection<Identifier>,
+    ownIdentityId: Identifier
+): Boolean = contenderIds.any { it == ownIdentityId }

--- a/wallet/test/de/schildbach/wallet/service/platform/sdk/SdkDashPayWritesTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/platform/sdk/SdkDashPayWritesTest.kt
@@ -214,10 +214,12 @@ class SdkDashPayWritesTest {
      * MO-972: the reason must not ASSERT an expiry nobody measured. Field log
      * (2026-09-10, testnet 12000007, HONOR PTP-N49): biometric authentication
      * at 11:49:16, this failure at 11:49:17 — one second — reported as
-     * "Keystore auth window expired". On that OEM the auth-bound Keystore gate
-     * is defective, the same defect family as the false-locked master alias;
-     * the window was not the problem and the label sent diagnosis the wrong
-     * way.
+     * "Keystore auth window expired". There was no window to expire: this app
+     * runs KeySecurityPolicy.DEVICE_BOUND, which has no auth gate. What that
+     * OEM actually denies is the UNLOCKED_DEVICE_REQUIRED gate, which Android
+     * reports with the identical exception — the same defect family as the
+     * false-locked master alias. The label sent diagnosis the wrong way for
+     * weeks.
      */
     @Test
     fun classify_userNotAuthenticated_doesNotClaimTheWindowExpired() {
@@ -242,14 +244,54 @@ class SdkDashPayWritesTest {
         )
     }
 
+    /**
+     * MO-972, the other half: dashpay/platform#4643 classifies the
+     * unlocked-device denial SDK-side, so the message that reaches us names
+     * the alias and the KeyguardManager state instead of saying "User not
+     * authenticated". Without an arm of its own this shape falls through to
+     * the generic handling and the failure gets LESS legible than before the
+     * SDK fix.
+     */
+    @Test
+    fun classify_keystoreDeviceLockedDenial_isNotBroadcastAndNamesTheGate() {
+        // Verbatim shape of KeystoreDeviceLockedException's message, as it
+        // arrives wrapped by the FFI.
+        val liveShape = DashSdkError.PlatformWallet.Generic(
+            5000,
+            "SDK error: Protocol error: Generic Error: Keystore denied 'decrypt' on " +
+                "lock-bound alias 'org.dashfoundation.wallet.keys.devicebound' as " +
+                "device-locked; KeyguardManager at throw time: isDeviceLocked=false " +
+                "isKeyguardLocked=false (FALSE-LOCKED: device reports unlocked but " +
+                "Keystore denied — Keystore2 lock-state misreporting; retryable " +
+                "immediately)"
+        )
+
+        val result = classifyBroadcastFailure(liveShape)
+
+        assertTrue("must be NotBroadcast, got $result", result is SdkWriteResult.NotBroadcast)
+        val reason = (result as SdkWriteResult.NotBroadcast).reason
+        assertTrue(
+            "must say the device was considered locked, got: $reason",
+            reason.contains("considers the device locked")
+        )
+        assertFalse(
+            "must not blame an auth window this policy does not have, got: $reason",
+            reason.contains("auth window expired")
+        )
+        assertTrue(
+            "must carry the alias so the log says WHICH key, got: $reason",
+            reason.contains("keys.devicebound")
+        )
+        assertSame(liveShape, result.cause)
+    }
+
     @Test
     fun classify_keystoreAuthWindowExpiry_isNotBroadcast() {
-        // The live S22 failure: the SDK's AUTH_GATED Keystore threw
-        // UserNotAuthenticatedException while decrypting the identity key to
-        // SIGN the state transition — signing runs during transition
-        // construction, strictly before broadcast, so nothing was submitted
-        // and the dashj fallback is safe. Message-matched until platform
-        // PR #4060 (DEVICE_BOUND keys) gives this a typed error.
+        // Pre-#4643 AAR lines (denial still unclassified), plus the genuinely
+        // auth-gated paths that survive on an install predating the
+        // DEVICE_BOUND switch. Signing runs during transition construction,
+        // strictly before broadcast, so nothing was submitted and the dashj
+        // fallback is safe.
         val liveShapes = listOf<Throwable>(
             DashSdkError.PlatformWallet.Generic(
                 5000,

--- a/wallet/test/de/schildbach/wallet/service/platform/sdk/SdkTxStoreWalkerTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/platform/sdk/SdkTxStoreWalkerTest.kt
@@ -804,6 +804,118 @@ class SdkTxStoreWalkerTest {
         assertEquals(Triple(1, -49_999_774L, 636L), storedShape(ids.drain))
     }
 
+    // ── Incomplete-TXO-mirror guard: no born-wrong durable stamps ─────
+    //
+    // Replica of the 2026-08-19 device investigation: the store had DROPPED
+    // change-output rows (platform ecc6740ed4 — owned output role losing
+    // index collisions in the same-txid record fold), so the walker summed
+    // an incomplete funded set and durably persisted a born-wrong net
+    // (5e4d7282: −0.98771 stamped when the true net was −0.00000227). The
+    // guard must catch the gap — a payload output paying a wallet-tracked
+    // address with no txos row — skip the correction, write nothing, and
+    // heal normally once the mirror rows land.
+
+    @Test
+    fun reattribution_incompleteMirror_defersCorrectionAndPersistsNothing() = runBlocking {
+        insertAccount(bip44Account, 0)
+        insertCoreAddress("bip44_g0", bip44Account)
+        insertCoreAddress("bip44_g1", bip44Account)
+        insertCoreAddress("chg_g", bip44Account)
+
+        val funding = txid(61)
+        insertTx(funding, direction = 0, netAmount = 100_000_000, payload = ByteArray(0), firstSeen = 1_700_000_001)
+        insertTxo(funding, 0, 100_000_000, "bip44_g0")
+
+        // An internal sweep stored misattributed as INCOMING +0.6. Its real
+        // outputs: 0.6 back to bip44_g1 (mirrored) and 0.39999774 change to
+        // chg_g — whose txos row the store dropped.
+        val sweep = txid(62)
+        insertTx(sweep, direction = 0, netAmount = 60_000_000, payload = byteArrayOf(6), firstSeen = 1_700_000_002)
+        exec("UPDATE txos SET spendingTxid = ?, isSpent = 1 WHERE txid = ?", sweep, funding)
+        insertTxo(sweep, 0, 60_000_000, "bip44_g1")
+        // The change row for vout 1 is deliberately absent — the dropped row.
+
+        val incompleteFacts: (ByteArray) -> TxPayloadFacts? = { payload ->
+            if (payload.firstOrNull()?.toInt() == 6) {
+                TxPayloadFacts(
+                    outputsTotalDuffs = 99_999_774,
+                    outputCount = 2,
+                    inputCount = 1,
+                    outputAddresses = listOf("bip44_g1", "chg_g")
+                )
+            } else {
+                null
+            }
+        }
+
+        queryLog.clear()
+        val byHex = HashMap<String, L1TxUiRecord>()
+        walker(payloadFacts = incompleteFacts).walkAll { page -> page.forEach { byHex[it.txidHex] = it } }
+
+        // Deferred: the stored shape is served untouched and NOTHING is
+        // written. Before the guard this pass computed net = 0.6 − 1.0 =
+        // −0.4 from the incomplete mirror and stamped it durably — the
+        // born-wrong value that then fought every later correct upsert.
+        val served = requireNotNull(byHex[displayHexOf(sweep)])
+        assertEquals(L1TxUiDirection.INCOMING, served.direction)
+        assertEquals(60_000_000L, served.netAmountDuffs)
+        assertEquals(Triple(0, 60_000_000L, null), storedShape(sweep))
+        assertTrue(queryLog.none { it.startsWith("UPDATE transactions") })
+
+        // The mirror heals (the upstream fold fix, or the rows simply land
+        // late): the exact same record now corrects to INTERNAL/−fee and
+        // persists durably — deferral, not suppression.
+        insertTxo(sweep, 1, 39_999_774, "chg_g")
+        val byHex2 = HashMap<String, L1TxUiRecord>()
+        walker(payloadFacts = incompleteFacts).walkAll { page -> page.forEach { byHex2[it.txidHex] = it } }
+        val healed = requireNotNull(byHex2[displayHexOf(sweep)])
+        assertEquals(L1TxUiDirection.INTERNAL, healed.direction)
+        assertEquals(-226L, healed.netAmountDuffs)
+        assertEquals(226L, healed.feeDuffs)
+        assertEquals(Triple(2, -226L, 226L), storedShape(sweep))
+    }
+
+    @Test
+    fun reattribution_externalSend_unknownOutputAddress_stillPersistsDurably() = runBlocking {
+        insertAccount(bip44Account, 0)
+        insertCoreAddress("bip44_h0", bip44Account)
+        insertCoreAddress("chg_h", bip44Account)
+
+        val receive = txid(63)
+        insertTx(receive, direction = 0, netAmount = 50_000_000, payload = ByteArray(0), firstSeen = 1_700_000_001)
+        insertTxo(receive, 0, 50_000_000, "bip44_h0")
+
+        // A genuine external payment stored INCOMING +change. The payment
+        // output's address is UNKNOWN to the wallet, so its absence from
+        // the mirror is the ordinary send shape, not a dropped row — the
+        // guard must not block the durable correction.
+        val send = txid(64)
+        insertTx(send, direction = 0, netAmount = 29_999_774, payload = byteArrayOf(7), firstSeen = 1_700_000_002)
+        exec("UPDATE txos SET spendingTxid = ?, isSpent = 1 WHERE txid = ?", send, receive)
+        insertTxo(send, 1, 29_999_774, "chg_h")
+
+        val sendFacts: (ByteArray) -> TxPayloadFacts? = { payload ->
+            if (payload.firstOrNull()?.toInt() == 7) {
+                TxPayloadFacts(
+                    outputsTotalDuffs = 49_999_774,
+                    outputCount = 2,
+                    inputCount = 1,
+                    outputAddresses = listOf("yTheirExternalAddress", "chg_h")
+                )
+            } else {
+                null
+            }
+        }
+
+        val byHex = HashMap<String, L1TxUiRecord>()
+        walker(payloadFacts = sendFacts).walkAll { page -> page.forEach { byHex[it.txidHex] = it } }
+        val corrected = requireNotNull(byHex[displayHexOf(send)])
+        assertEquals(L1TxUiDirection.OUTGOING, corrected.direction)
+        assertEquals(-20_000_226L, corrected.netAmountDuffs)
+        assertEquals(226L, corrected.feeDuffs)
+        assertEquals(Triple(1, -20_000_226L, 226L), storedShape(send))
+    }
+
     // ── pending_inputs reservations: the "lingering receive" fix ──────
     //
     // The SDK only writes `txos.isSpent`/`spendingTxid` at CONFIRMATION,
@@ -996,6 +1108,27 @@ class SdkTxStoreWalkerTest {
         assertEquals(-1_000L, contactPay.netAmountDuffs)
     }
 
+    @Test
+    fun firstUnmirroredKnownOutput_flagsOnlyTrackedAddressGaps() {
+        val payload = TxPayloadFacts(
+            outputsTotalDuffs = 1_000,
+            outputCount = 3,
+            inputCount = 1,
+            outputAddresses = listOf("external", "ours", null)
+        )
+        val known = setOf("ours")
+        // A tracked address with no mirror row → its vout.
+        assertEquals(1, firstUnmirroredKnownOutput(payload, known, setOf(0)))
+        // Its mirror row present → complete.
+        assertNull(firstUnmirroredKnownOutput(payload, known, setOf(1)))
+        // Unknown and address-less outputs never count as gaps.
+        assertNull(firstUnmirroredKnownOutput(payload, setOf("elsewhere"), emptySet()))
+        // A facts source without addresses, or no tracked addresses at all,
+        // keeps the guard inert (pre-guard behavior).
+        assertNull(firstUnmirroredKnownOutput(payload.copy(outputAddresses = emptyList()), known, emptySet()))
+        assertNull(firstUnmirroredKnownOutput(payload, emptySet(), emptySet()))
+    }
+
     // ── dashjPayloadFacts against the REAL device payloads ────────────
 
     /** The S22 drain `5538f908…` exactly as pulled from `dash-sdk.db`: 4 inputs, one 0.69998912 output. */
@@ -1023,6 +1156,10 @@ class SdkTxStoreWalkerTest {
         assertEquals(69_998_912L, facts.outputsTotalDuffs)
         assertEquals(1, facts.outputCount)
         assertEquals(4, facts.inputCount)
+        // The mirror-completeness guard needs the destination addresses:
+        // the single P2PKH output must resolve to a base58 address.
+        assertEquals(1, facts.outputAddresses.size)
+        assertTrue(facts.outputAddresses[0] != null)
         // Garbage never parses to facts.
         assertNull(dashjPayloadFacts(ByteArray(0)))
         assertNull(dashjPayloadFacts(byteArrayOf(1, 2, 3)))

--- a/wallet/test/de/schildbach/wallet/service/platform/work/ContestedReregistrationGuardTest.kt
+++ b/wallet/test/de/schildbach/wallet/service/platform/work/ContestedReregistrationGuardTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Dash Core Group.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package de.schildbach.wallet.service.platform.work
+
+import org.dashj.platform.dpp.identifier.Identifier
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-logic tests for the contested RE-REGISTRATION guard in
+ * [RestoreIdentityWorker] — [contestedReregistrationCheckApplies] /
+ * [isOwnIdentityAContender].
+ *
+ * Pins the live defect (testnet 12000000, emulator, 2026-09-10). Identity
+ * `7oct2Gqw…` was funded 0.25 DASH and successfully registered the contested name
+ * `test-contested-1000`; the explorer shows the name plus exactly 20,000,000,000
+ * credits (0.20 DASH) gone to the vote poll's prefunded specialized balance beyond
+ * gas. `recoverUsernames` still reported "none", because a contested label is not
+ * awarded in the DPNS unique index until the vote concludes — so the worker
+ * re-registered and the FFI rejected the duplicate with
+ * "Insufficient identity balance 4680452100 required 20000100000".
+ *
+ * The correctness bar is two-sided:
+ * - a name this identity ALREADY contends for must be detected, so the duplicate
+ *   0.2 DASH prefund is never paid;
+ * - a name it does NOT contend for (and any non-contestable name) must still be
+ *   registered exactly as before — the guard must not strand a genuine create.
+ */
+class ContestedReregistrationGuardTest {
+
+    private fun id(seed: Byte) = Identifier.from(ByteArray(32) { seed })
+
+    private val ownId = id(1)
+    private val otherId = id(2)
+
+    // ---- contestedReregistrationCheckApplies -------------------------------
+
+    @Test
+    fun `a contestable label is worth the vote-state query`() {
+        // 19 chars, only [a-zA-Z01-] — the live failing name.
+        assertTrue(contestedReregistrationCheckApplies("test-contested-1000"))
+    }
+
+    @Test
+    fun `a non-contestable label is not queried at all`() {
+        // Carries a 9, so it can never be in a vote poll; historic path unchanged.
+        assertFalse(contestedReregistrationCheckApplies("test-contested-09"))
+    }
+
+    @Test
+    fun `an over-long label is not contestable so it is not queried`() {
+        // 20 chars — one past the 3..19 contestable window.
+        assertFalse(contestedReregistrationCheckApplies("test-cointested-1000"))
+    }
+
+    @Test
+    fun `a missing or blank label is never queried`() {
+        assertFalse(contestedReregistrationCheckApplies(null))
+        assertFalse(contestedReregistrationCheckApplies(""))
+        assertFalse(contestedReregistrationCheckApplies("   "))
+    }
+
+    // ---- isOwnIdentityAContender -------------------------------------------
+
+    @Test
+    fun `our own contender document is detected so the duplicate is skipped`() {
+        assertTrue(isOwnIdentityAContender(listOf(otherId, ownId), ownId))
+    }
+
+    @Test
+    fun `a vote poll we are not in still registers`() {
+        // Someone else contends for the name; this identity never requested it.
+        assertFalse(isOwnIdentityAContender(listOf(otherId), ownId))
+    }
+
+    @Test
+    fun `an empty contender set still registers`() {
+        // The genuine fresh-create case: nothing on chain yet.
+        assertFalse(isOwnIdentityAContender(emptyList(), ownId))
+    }
+
+    @Test
+    fun `the sole contender being us is detected`() {
+        // The live case: uncontested-so-far vote poll with only our document.
+        assertTrue(isOwnIdentityAContender(listOf(ownId), ownId))
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, include story number -->
<!--- Remove sections that don't apply to this PR -->

> **Stacked on #1564** (`fix/contested-username-restore-identity`). Review that one first; this PR's diff is the single commit on top.

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? What is the new feature? -->

**MO-972.** DashPay username creation fails outright on a HONOR PTP-N49 (MagicOS, Android 16). Signing dies pre-broadcast with `Protocol error: Generic Error: User not authenticated`, one second after a successful biometric, reproducibly — and we reported it as *"Keystore auth window expired"*.

There is no window to expire. This app has run `KeySecurityPolicy.DEVICE_BOUND` since `7e7d53485`, and that alias carries no authentication gate. Android puts **two independent gates** on a Keystore key and reports both failures with the identical `UserNotAuthenticatedException`:

| gate | what it means | on our alias? |
|---|---|---|
| `setUserAuthenticationRequired` | authenticated within ~30 s | **no** — that is the point of DEVICE_BOUND |
| `setUnlockedDeviceRequired` | device unlocked right now | **yes** — the SDK stamps it on every alias |

The second one is what fails, on OEM builds whose lock-state tracking is defective (Google confirmed the same on Fairphone 5/6, [Issue Tracker 506989112]; [AOSP][aosp] ties this to *how* the device was unlocked). Our own comment in `DashSdkServiceImpl` asserted that DEVICE_BOUND keys "never throw UserNotAuthenticatedException" — that claim is what made the real cause invisible for weeks, so it is corrected here rather than merely softened.

[Issue Tracker 506989112]: https://issuetracker.google.com/issues/506989112
[aosp]: https://source.android.com/docs/security/features/keystore/features

## Related PR's and Dependencies
<!--- Put links to other PR's here for dash-wallet, dashj, dpp, dapi-client, dashpay, etc -->

- **dashpay/platform#4643** — the SDK-side fix. Classifies the lock-gate denial into `KeystoreDeviceLockedException` and degrades an affected device onto a never-lock-bound alias. **This PR depends on it**: the typed message no longer contains "User not authenticated", so without the new classifier arm the failure would fall through to the generic handling and become *less* legible than before the SDK fix.
- **#1564** — the branch this is stacked on.
- No `dashSdkVersion` bump here. Verified locally against an AAR built from platform `integration/v42int11` + the #4643 stack; the pin is left for the team's own AAR bump.

## What changed

- `SdkDashPayWrites.classifyBroadcastFailure` gains an arm for the typed device-locked denial — reports that Keystore considers the device locked, and carries the alias into the log.
- The existing `"User not authenticated"` arm stays, for AAR lines older than #4643 and for the genuinely auth-gated paths that survive on an install predating the DEVICE_BOUND switch (blobs still under the legacy auth-gated alias, reached through the SDK's migration fallback). Its wording no longer implies a timeout on a policy that has none.
- `DashSdkServiceImpl`: the false "never throw UserNotAuthenticatedException" claim corrected, plus its stale reference to platform #4060 (that PR proposed the policy but was closed unmerged; it landed as #4183).

**Not done here:** wiring a `BiometricGate` into `WalletManagerStore`. It cannot affect this bug — under DEVICE_BOUND the gate is unreachable — and its only beneficiaries are legacy auth-gated blobs, which the SDK can recover by silently re-deriving from the seed rather than prompting the user. It would also need new foreground-Activity plumbing the app does not have today. Happy to do it separately if wanted.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

```bash
./gradlew :wallet:testProdDebugUnitTest --tests '*SdkDashPayWritesTest*'
```

**`SdkDashPayWritesTest` 30/30 green**, including a new case pinning the typed device-locked shape end to end: NotBroadcast, names the gate, carries the alias, and does not blame a window. Two existing test docs corrected — they blamed the auth gate.

Run against a locally published AAR (`0.1.0-v42int11-mo972-SNAPSHOT`) built from platform `integration/v42int11` plus the #4643 stack, since the currently pinned `0.1.0-v42int5` does not contain `startWalletSubsystems` and the base branch will not compile against it.

**Pre-existing failures elsewhere in the module, not from this change:** `SendCoinsTaskRunner{BIP70,SdkRouting,SelfSpendGrace}` and `GetUsernameVotingResultOperationTest` — a leaked bitcoinj network context, and date-dependent assertions that have aged out. Re-running each class with these three files reverted reproduces the identical failure sets.

- [ ] QA (Mobile Team) — **needs the HONOR PTP-N49.** Emulators cannot reproduce this defect class: AOSP classifies every denial as genuinely locked, so the defective-OEM branch is unreachable. Expected result: username creation succeeds, or fails with a message naming the alias and the KeyguardManager state — never "auth window expired" again.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code and added comments where necessary
- [x] I have added or updated relevant unit/integration/functional/e2e tests
